### PR TITLE
fix(admin-debug): 完善管理员调试会话路由实现

### DIFF
--- a/backend/admin/package.json
+++ b/backend/admin/package.json
@@ -33,7 +33,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
-    "lucide-react": "^0.574.0",
+    "lucide-react": "^1.8.0",
     "next": "^16.1.6",
     "react": "^19.2.4",
     "react-day-picker": "^9.13.2",

--- a/backend/routers/admin_debug.py
+++ b/backend/routers/admin_debug.py
@@ -12,6 +12,7 @@ from sqlalchemy import delete
 from typing import List, Optional, Any
 import logging
 import json
+import asyncio
 
 from database import get_db, AsyncSessionLocal
 from models import (
@@ -38,6 +39,9 @@ from services.chat_tool_dispatch import append_tool_round
 from sqlalchemy import select as sql_select
 
 logger = logging.getLogger(__name__)
+
+# Harness constants (import from chat_generation to keep in sync)
+from services.chat_generation import MAX_LLM_RETRIES, RETRY_BACKOFF_SECONDS
 
 
 router = APIRouter(
@@ -417,20 +421,41 @@ async def _generate_single_agent_debug(
             # 通过适配器解析有效的图像配置（使用全局 ToolConfig）
             global_cfg = (global_image_config.config if global_image_config else {})
             _eff_gemini, _eff_xai = resolve_global_image_configs(global_cfg, agent, provider.provider_type)
-            async for chunk, result in stream_completion(
-                provider_type=provider.provider_type,
-                api_key=provider.api_key,
-                base_url=provider.base_url,
-                model=agent.model,
-                messages=messages,
-                temperature=agent.temperature,
-                context_window=agent.context_window,
-                thinking_mode=agent.thinking_mode,
-                gemini_config=_eff_gemini,
-                tools=current_tools,
-                xai_image_config=_eff_xai,
-            ):
-                yield sse("text", {"chunk": chunk})
+
+            # Harness: LLM 调用重试 + 熔断
+            _llm_success = False
+            for _retry in range(MAX_LLM_RETRIES):
+                try:
+                    async for chunk, result in stream_completion(
+                        provider_type=provider.provider_type,
+                        api_key=provider.api_key,
+                        base_url=provider.base_url,
+                        model=agent.model,
+                        messages=messages,
+                        temperature=agent.temperature,
+                        context_window=agent.context_window,
+                        thinking_mode=agent.thinking_mode,
+                        gemini_config=_eff_gemini,
+                        tools=current_tools,
+                        xai_image_config=_eff_xai,
+                    ):
+                        yield sse("text", {"chunk": chunk})
+                    _llm_success = True
+                    break
+                except Exception as llm_err:
+                    _attempt = _retry + 1
+                    logger.warning(f"[Debug] LLM attempt {_attempt}/{MAX_LLM_RETRIES} failed: {llm_err}")
+                    (_attempt < MAX_LLM_RETRIES) and (
+                        yield sse("llm_retry", {"attempt": _attempt, "max_retries": MAX_LLM_RETRIES, "error": str(llm_err)})
+                    )
+                    (_attempt < MAX_LLM_RETRIES) and await asyncio.sleep(
+                        RETRY_BACKOFF_SECONDS[min(_retry, len(RETRY_BACKOFF_SECONDS) - 1)]
+                    )
+
+            # 熔断：LLM 调用全部失败
+            if not _llm_success:
+                yield sse("llm_circuit_breaker", {"retries": MAX_LLM_RETRIES, "round": _round + 1})
+                raise Exception(f"LLM circuit breaker: all {MAX_LLM_RETRIES} attempts failed")
 
             # 无 tool_calls → 直接结束
             if not (result and result.tool_calls):

--- a/backend/services/chat_generation.py
+++ b/backend/services/chat_generation.py
@@ -4,6 +4,7 @@ Single-agent chat generation: LLM streaming loop with tool rounds, billing, and 
 import json
 import logging
 from typing import Any
+import asyncio
 
 from sqlalchemy.future import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -25,6 +26,13 @@ from services.media_utils import MEDIA_DIR
 from services.image_config_adapter import resolve_global_image_configs
 
 logger = logging.getLogger(__name__)
+
+# =============================================================================
+# Harness: Single-agent LLM retry & circuit breaker constants
+# =============================================================================
+MAX_LLM_RETRIES = 3                 # 单次 stream_completion 调用最大重试次数
+MAX_CONSECUTIVE_TOOL_FAILURES = 5   # 连续工具调用失败上限（触发工具循环熔断）
+RETRY_BACKOFF_SECONDS = (0.5, 1.0, 2.0)  # 重试退避时间
 
 
 async def generate_single_agent(
@@ -214,6 +222,7 @@ async def generate_single_agent(
     generation_failed = False
     _SSE_START = {True: "skill_call", False: "tool_call"}
     _SSE_END = {True: "skill_loaded", False: "tool_result"}
+    _consecutive_tool_failures = 0   # Harness: 连续工具失败计数器
     try:
         for _round in range(MAX_TOOL_ROUNDS + 1):
             is_last_round = _round == MAX_TOOL_ROUNDS
@@ -221,20 +230,42 @@ async def generate_single_agent(
             result = None
             # 通过适配器解析有效的图像配置（使用全局 ToolConfig）
             _eff_gemini, _eff_xai = resolve_global_image_configs(global_image_cfg, agent, provider.provider_type)
-            async for chunk, result in stream_completion(
-                provider_type=provider.provider_type,
-                api_key=provider.api_key,
-                base_url=provider.base_url,
-                model=agent.model,
-                messages=messages,
-                temperature=agent.temperature,
-                context_window=agent.context_window,
-                thinking_mode=agent.thinking_mode,
-                gemini_config=_eff_gemini,
-                tools=current_tools,
-                xai_image_config=_eff_xai,
-            ):
-                yield sse("text", {"chunk": chunk})
+
+            # Harness: LLM 调用重试 + 熔断
+            _llm_success = False
+            for _retry in range(MAX_LLM_RETRIES):
+                try:
+                    async for chunk, result in stream_completion(
+                        provider_type=provider.provider_type,
+                        api_key=provider.api_key,
+                        base_url=provider.base_url,
+                        model=agent.model,
+                        messages=messages,
+                        temperature=agent.temperature,
+                        context_window=agent.context_window,
+                        thinking_mode=agent.thinking_mode,
+                        gemini_config=_eff_gemini,
+                        tools=current_tools,
+                        xai_image_config=_eff_xai,
+                    ):
+                        yield sse("text", {"chunk": chunk})
+                    _llm_success = True
+                    break
+                except Exception as llm_err:
+                    _attempt = _retry + 1
+                    logger.warning(f"LLM call attempt {_attempt}/{MAX_LLM_RETRIES} failed: {llm_err}")
+                    # 未达上限，发送重试事件并退避
+                    (_attempt < MAX_LLM_RETRIES) and (
+                        yield sse("llm_retry", {"attempt": _attempt, "max_retries": MAX_LLM_RETRIES, "error": str(llm_err)})
+                    )
+                    (_attempt < MAX_LLM_RETRIES) and await asyncio.sleep(
+                        RETRY_BACKOFF_SECONDS[min(_retry, len(RETRY_BACKOFF_SECONDS) - 1)]
+                    )
+
+            # 熔断：LLM 调用全部失败
+            if not _llm_success:
+                yield sse("llm_circuit_breaker", {"retries": MAX_LLM_RETRIES, "round": _round + 1})
+                raise Exception(f"LLM circuit breaker: all {MAX_LLM_RETRIES} attempts failed in round {_round + 1}")
 
             # 无 tool_calls → 直接结束
             if not (result and result.tool_calls):
@@ -342,6 +373,20 @@ async def generate_single_agent(
             # 发送错误调用的完成事件
             for tc, _ in tool_calls_with_error:
                 yield sse("tool_result", {"tool_name": tc.name, "success": False, "error": "JSON parse failed"})
+
+            # Harness: 连续工具失败熔断
+            _all_failed = (len(tool_calls_valid) == 0) and (len(tool_calls_with_error) > 0)
+            _consecutive_tool_failures = (_consecutive_tool_failures + 1) * _all_failed
+            (_consecutive_tool_failures >= MAX_CONSECUTIVE_TOOL_FAILURES) and (
+                yield sse("tool_circuit_breaker", {
+                    "consecutive_failures": _consecutive_tool_failures,
+                    "max_allowed": MAX_CONSECUTIVE_TOOL_FAILURES,
+                })
+            )
+            # 达到上限，终止工具循环
+            (_consecutive_tool_failures >= MAX_CONSECUTIVE_TOOL_FAILURES) and (_ for _ in ()).throw(
+                Exception(f"Tool circuit breaker: {_consecutive_tool_failures} consecutive failures")
+            )
 
             # 发送视频任务创建事件（通知前端启动轮询UI）
             for vt in ctx.video_tasks:

--- a/backend/services/orchestrator.py
+++ b/backend/services/orchestrator.py
@@ -23,6 +23,57 @@ logger = logging.getLogger(__name__)
 
 
 # =============================================================================
+# Harness: Constants & Output Validation
+# =============================================================================
+
+MAX_SUBTASK_RETRIES = 3          # 熔断上限：单子任务最多重试次数
+MIN_VALID_OUTPUT_LENGTH = 2      # 输出最小有效长度（排除空白/无意义响应）
+
+
+class OutputValidationError(Exception):
+    """Agent 输出未通过结构化校验"""
+    pass
+
+
+class CircuitBreakerError(Exception):
+    """子任务重试达到熔断上限"""
+    def __init__(self, subtask_id: str, retries: int):
+        self.subtask_id = subtask_id
+        self.retries = retries
+        super().__init__(f"Circuit breaker triggered: subtask {subtask_id} failed after {retries} retries")
+
+
+# 输出校验规则注册表 —— 映射表驱动，便于扩展
+# 每条规则: (校验函数, 失败描述模板)
+_OUTPUT_VALIDATORS = [
+    (
+        lambda content: len(content.strip()) >= MIN_VALID_OUTPUT_LENGTH,
+        "Output too short or empty (length={length}, min={min})",
+    ),
+    (
+        lambda content: not content.strip().startswith('{"error"'),
+        "Output appears to be an error object",
+    ),
+]
+
+
+def validate_output(content: str) -> tuple[bool, str]:
+    """
+    对 Agent 输出执行结构化校验。
+    Returns: (is_valid, error_message)
+    """
+    for validator_fn, desc_template in _OUTPUT_VALIDATORS:
+        passed = validator_fn(content)
+        if not passed:
+            msg = desc_template.format(
+                length=len(content.strip()),
+                min=MIN_VALID_OUTPUT_LENGTH,
+            )
+            return False, msg
+    return True, ""
+
+
+# =============================================================================
 # Data Classes
 # =============================================================================
 
@@ -108,65 +159,81 @@ class CollaborationStrategy(ABC):
         return subtask
 
     async def execute_subtask(self, subtask: SubTask, input_content: str) -> ExecutionResult:
-        """Execute a single subtask (non-streaming) and update its record"""
-        subtask.status = "running"
-        await self.db.flush()
-
+        """
+        Execute a single subtask (non-streaming) with output validation and circuit breaker.
+        Retries up to MAX_SUBTASK_RETRIES on failure or invalid output.
+        """
         messages = list(self.history_messages) + [{"role": "user", "content": input_content}]
+        last_error = None
 
-        try:
-            result = await self.executor.execute(
-                agent_id=subtask.agent_id,
-                messages=messages,
-                context={"subtask_id": subtask.id}
-            )
-
-            subtask.status = "completed"
-            subtask.output_data = {"content": result.content}
-            subtask.input_tokens = result.input_tokens
-            subtask.output_tokens = result.output_tokens
-            subtask.completed_at = sa_func.now()
-
-            agent = self.members.get(subtask.agent_id)
-            subtask.credit_cost, _ = calculate_credit_cost(result, agent or self.leader)
-
+        while subtask.retry_count < MAX_SUBTASK_RETRIES:
+            subtask.status = "running"
             await self.db.flush()
-            return result
 
-        except Exception as e:
-            subtask.status = "failed"
-            subtask.error_message = str(e)
-            subtask.retry_count += 1
-            await self.db.flush()
-            raise
+            try:
+                result = await self.executor.execute(
+                    agent_id=subtask.agent_id,
+                    messages=messages,
+                    context={"subtask_id": subtask.id, "attempt": subtask.retry_count + 1}
+                )
+
+                # Harness: output validation
+                is_valid, validation_msg = validate_output(result.content)
+                is_valid or (_ for _ in ()).throw(OutputValidationError(validation_msg))
+
+                subtask.status = "completed"
+                subtask.output_data = {"content": result.content}
+                subtask.input_tokens = result.input_tokens
+                subtask.output_tokens = result.output_tokens
+                subtask.completed_at = sa_func.now()
+
+                agent = self.members.get(subtask.agent_id)
+                subtask.credit_cost, _ = calculate_credit_cost(result, agent or self.leader)
+
+                await self.db.flush()
+                return result
+
+            except Exception as e:
+                subtask.retry_count += 1
+                last_error = e
+                logger.warning(
+                    f"Subtask {subtask.id} attempt {subtask.retry_count}/{MAX_SUBTASK_RETRIES} failed: {e}"
+                )
+                await self.db.flush()
+
+        # Circuit breaker: exhausted retries
+        subtask.status = "failed"
+        subtask.error_message = f"Circuit breaker: {last_error}"
+        await self.db.flush()
+        raise CircuitBreakerError(subtask.id, subtask.retry_count)
 
     async def execute_subtask_streaming(
         self, subtask: SubTask, input_content: str
     ) -> AsyncGenerator[OrchestrationEvent, None]:
         """
-        Execute a subtask with streaming, yielding chunk events in real-time.
-        After streaming completes, yields a subtask_completed event.
-        Stores ExecutionResult on subtask._streaming_result for caller access.
+        Execute a subtask with streaming + output validation + circuit breaker.
+        First attempt streams in real-time; retries fall back to non-streaming
+        to avoid duplicate chunk events.
         """
-        subtask.status = "running"
-        await self.db.flush()
-
         agent = self.members.get(subtask.agent_id)
         agent_name = agent.name if agent else self.leader.name
+        messages = list(self.history_messages) + [{"role": "user", "content": input_content}]
+
+        # --- First attempt: streaming ---
+        subtask.status = "running"
+        await self.db.flush()
 
         yield OrchestrationEvent("subtask_started", {
             "subtask_id": subtask.id,
             "agent_name": agent_name,
         })
 
-        messages = list(self.history_messages) + [{"role": "user", "content": input_content}]
-
         try:
             last_result: Optional[StreamResult] = None
             async for chunk, result in self.executor.execute_streaming(
                 agent_id=subtask.agent_id,
                 messages=messages,
-                context={"subtask_id": subtask.id}
+                context={"subtask_id": subtask.id, "attempt": 1}
             ):
                 last_result = result
                 yield OrchestrationEvent("subtask_chunk", {
@@ -175,9 +242,12 @@ class CollaborationStrategy(ABC):
                 })
 
             full_content = last_result.full_response if last_result else ""
-            input_tokens = last_result.input_tokens if last_result else 0
-            output_tokens = last_result.output_tokens if last_result else 0
 
+            # Harness: validate streaming output
+            is_valid, validation_msg = validate_output(full_content)
+            is_valid or (_ for _ in ()).throw(OutputValidationError(validation_msg))
+
+            # Success — record results
             subtask.status = "completed"
             subtask.output_data = {
                 "content": full_content,
@@ -185,17 +255,16 @@ class CollaborationStrategy(ABC):
                 "image_output_tokens": last_result.image_output_tokens,
                 "search_count": last_result.search_query_count,
             }
-            subtask.input_tokens = input_tokens
-            subtask.output_tokens = output_tokens
+            subtask.input_tokens = last_result.input_tokens if last_result else 0
+            subtask.output_tokens = last_result.output_tokens if last_result else 0
             subtask.completed_at = sa_func.now()
-
             subtask.credit_cost, _ = calculate_credit_cost(last_result, agent or self.leader)
             await self.db.flush()
 
             subtask._streaming_result = ExecutionResult(
                 content=full_content,
-                input_tokens=input_tokens,
-                output_tokens=output_tokens,
+                input_tokens=subtask.input_tokens,
+                output_tokens=subtask.output_tokens,
                 input_chars=len(input_content),
                 output_chars=len(full_content),
                 metadata={"agent_id": subtask.agent_id, "agent_name": agent_name}
@@ -206,22 +275,92 @@ class CollaborationStrategy(ABC):
                 "agent_name": agent_name,
                 "description": subtask.description,
                 "status": "completed",
-                "tokens": {"input": input_tokens, "output": output_tokens},
+                "tokens": {"input": subtask.input_tokens, "output": subtask.output_tokens},
                 "result": full_content,
             })
+            return
 
         except Exception as e:
-            subtask.status = "failed"
-            subtask.error_message = str(e)
             subtask.retry_count += 1
+            logger.warning(
+                f"Subtask {subtask.id} streaming attempt 1/{MAX_SUBTASK_RETRIES} failed: {e}"
+            )
             await self.db.flush()
 
-            subtask._streaming_result = ExecutionResult(content="", metadata={"error": str(e)})
+        # --- Retry attempts: non-streaming fallback to avoid duplicate chunks ---
+        while subtask.retry_count < MAX_SUBTASK_RETRIES:
+            subtask.status = "running"
+            await self.db.flush()
 
-            yield OrchestrationEvent("subtask_failed", {
+            yield OrchestrationEvent("subtask_retry", {
                 "subtask_id": subtask.id,
-                "error": str(e),
+                "attempt": subtask.retry_count + 1,
+                "max_retries": MAX_SUBTASK_RETRIES,
             })
+
+            try:
+                result = await self.executor.execute(
+                    agent_id=subtask.agent_id,
+                    messages=messages,
+                    context={"subtask_id": subtask.id, "attempt": subtask.retry_count + 1}
+                )
+
+                is_valid, validation_msg = validate_output(result.content)
+                is_valid or (_ for _ in ()).throw(OutputValidationError(validation_msg))
+
+                subtask.status = "completed"
+                subtask.output_data = {"content": result.content}
+                subtask.input_tokens = result.input_tokens
+                subtask.output_tokens = result.output_tokens
+                subtask.completed_at = sa_func.now()
+                subtask.credit_cost, _ = calculate_credit_cost(result, agent or self.leader)
+                await self.db.flush()
+
+                subtask._streaming_result = ExecutionResult(
+                    content=result.content,
+                    input_tokens=result.input_tokens,
+                    output_tokens=result.output_tokens,
+                    input_chars=len(input_content),
+                    output_chars=len(result.content),
+                    metadata={"agent_id": subtask.agent_id, "agent_name": agent_name}
+                )
+
+                # Send full result as single chunk for frontend compatibility
+                yield OrchestrationEvent("subtask_chunk", {
+                    "subtask_id": subtask.id,
+                    "chunk": result.content,
+                })
+                yield OrchestrationEvent("subtask_completed", {
+                    "subtask_id": subtask.id,
+                    "agent_name": agent_name,
+                    "description": subtask.description,
+                    "status": "completed",
+                    "tokens": {"input": result.input_tokens, "output": result.output_tokens},
+                    "result": result.content,
+                    "retried": True,
+                })
+                return
+
+            except Exception as e:
+                subtask.retry_count += 1
+                logger.warning(
+                    f"Subtask {subtask.id} attempt {subtask.retry_count}/{MAX_SUBTASK_RETRIES} failed: {e}"
+                )
+                await self.db.flush()
+
+        # Circuit breaker: all retries exhausted
+        subtask.status = "failed"
+        subtask.error_message = f"Circuit breaker: max retries ({MAX_SUBTASK_RETRIES}) exhausted"
+        await self.db.flush()
+
+        subtask._streaming_result = ExecutionResult(content="", metadata={"error": subtask.error_message})
+
+        yield OrchestrationEvent("subtask_failed", {
+            "subtask_id": subtask.id,
+            "error": subtask.error_message,
+            "circuit_breaker": True,
+            "retries": subtask.retry_count,
+        })
 
 
 # =============================================================================
@@ -308,7 +447,10 @@ class UnifiedStrategy(CollaborationStrategy):
         ready_tasks: List[tuple],
         completed_outputs: Dict[str, str]
     ) -> AsyncGenerator[OrchestrationEvent, None]:
-        """Execute multiple ready tasks in parallel (non-streaming)"""
+        """
+        Execute multiple ready tasks in parallel (non-streaming).
+        Each execute_subtask() internally handles retries + circuit breaker.
+        """
         # Emit started events
         for subtask, _ in ready_tasks:
             agent = self.members.get(subtask.agent_id)
@@ -318,7 +460,7 @@ class UnifiedStrategy(CollaborationStrategy):
                 "agent_name": agent_name,
             })
 
-        # Parallel execution
+        # Parallel execution (retries happen inside execute_subtask)
         results = await asyncio.gather(*[
             self.execute_subtask(subtask, task_input)
             for subtask, task_input in ready_tasks
@@ -329,10 +471,14 @@ class UnifiedStrategy(CollaborationStrategy):
             agent_name = agent.name if agent else self.leader.name
 
             is_error = isinstance(result, BaseException)
+            is_circuit_break = isinstance(result, CircuitBreakerError)
+
             _event_builders = {
                 True: lambda: OrchestrationEvent("subtask_failed", {
                     "subtask_id": subtask.id,
                     "error": str(result),
+                    "circuit_breaker": is_circuit_break,
+                    "retries": subtask.retry_count,
                 }),
                 False: lambda: OrchestrationEvent("subtask_completed", {
                     "subtask_id": subtask.id,
@@ -341,6 +487,7 @@ class UnifiedStrategy(CollaborationStrategy):
                     "status": "completed",
                     "tokens": {"input": result.input_tokens, "output": result.output_tokens},
                     "result": result.content,
+                    "retried": subtask.retry_count > 0,
                 }),
             }
             yield _event_builders[is_error]()
@@ -351,18 +498,16 @@ class UnifiedStrategy(CollaborationStrategy):
         ready_tasks: List[tuple],
         completed_outputs: Dict[str, str]
     ) -> AsyncGenerator[OrchestrationEvent, None]:
-        """Execute a single task with streaming"""
+        """
+        Execute a single task with streaming.
+        Retries and circuit breaker are handled inside execute_subtask_streaming.
+        """
         for subtask, task_input in ready_tasks:
-            try:
-                async for event in self.execute_subtask_streaming(subtask, task_input):
-                    yield event
-                result = getattr(subtask, "_streaming_result", None)
-                completed_outputs[subtask.id] = result.content if result else ""
-            except Exception as e:
-                yield OrchestrationEvent("subtask_failed", {
-                    "subtask_id": subtask.id,
-                    "error": str(e)
-                })
+            async for event in self.execute_subtask_streaming(subtask, task_input):
+                yield event
+            result = getattr(subtask, "_streaming_result", None)
+            # Only populate completed_outputs when subtask actually succeeded
+            (result and result.content) and completed_outputs.__setitem__(subtask.id, result.content)
 
 
 # =============================================================================

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -49,7 +49,7 @@
         "i18next": "^26.0.3",
         "lodash.debounce": "^4.0.8",
         "lodash.throttle": "^4.1.1",
-        "lucide-react": "^0.574.0",
+        "lucide-react": "^1.8.0",
         "next": "16.1.6",
         "pixi.js": "^8.16.0",
         "react": "19.2.3",
@@ -47557,9 +47557,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.574.0",
-      "resolved": "https://registry.npmmirror.com/lucide-react/-/lucide-react-0.574.0.tgz",
-      "integrity": "sha512-dJ8xb5juiZVIbdSn3HTyHsjjIwUwZ4FNwV0RtYDScOyySOeie1oXZTymST6YPJ4Qwt3Po8g4quhYl4OxtACiuQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmmirror.com/lucide-react/-/lucide-react-1.8.0.tgz",
+      "integrity": "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,7 +52,7 @@
     "i18next": "^26.0.3",
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",
-    "lucide-react": "^0.574.0",
+    "lucide-react": "^1.8.0",
     "next": "16.1.6",
     "pixi.js": "^8.16.0",
     "react": "19.2.3",

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -244,6 +244,9 @@
   --radius-lg: var(--radius);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
+
+  --animate-marquee: marquee var(--duration) infinite linear;
+  --animate-marquee-vertical: marquee-vertical var(--duration) linear infinite;
 }
 
 body {
@@ -272,6 +275,50 @@ body {
 .animate-gradient {
   background-size: 200% 200%;
   animation: gradient 8s ease infinite;
+}
+
+@keyframes marquee {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(calc(-100% - var(--gap)));
+  }
+}
+
+@keyframes marquee-vertical {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(calc(-100% - var(--gap)));
+  }
+}
+
+.animate-marquee {
+  animation: marquee var(--duration) infinite linear;
+}
+
+.animate-marquee-vertical {
+  animation: marquee-vertical var(--duration) linear infinite;
+}
+
+@keyframes film-scroll {
+  0% {
+    transform: translateY(0);
+  }
+  100% {
+    transform: translateY(calc(-33.333%));
+  }
+}
+
+@keyframes film-scroll-x {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(-20%);
+  }
 }
 
 /* Custom Scrollbar */

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { 
-  Mail, Lock, User, ArrowRight, Sparkles, Film, Palette, Zap,
+  Mail, Lock, User, ArrowRight,
   Eye, EyeOff, Loader2
 } from "lucide-react";
 import { useAuth } from "@/context/AuthContext";
@@ -12,12 +12,148 @@ import api from "@/lib/api";
 import { App } from "antd";
 import { cn } from "@/lib/utils";
 
-// 特性展示配置
-const FEATURES = [
-  { icon: Film, label: "AI 视频生成", desc: "一键生成高质量视频" },
-  { icon: Palette, label: "智能画布", desc: "可视化创作工作流" },
-  { icon: Zap, label: "多模态创作", desc: "图文音视频一站式" },
+// 影视作品卡片数据 - 4列不同的图片集
+const FILM_COLUMNS = [
+  [
+    { title: "Breaking Bad", img: "https://images.unsplash.com/photo-1504639725590-34d0984388bd?w=280&h=380&fit=crop" },
+    { title: "Stranger Things", img: "https://images.unsplash.com/photo-1509281373149-e957c6296406?w=280&h=380&fit=crop" },
+    { title: "The Crown", img: "https://images.unsplash.com/photo-1534430480872-3498386e7856?w=280&h=380&fit=crop" },
+    { title: "Dark", img: "https://images.unsplash.com/photo-1478760329108-5c3ed9d495a0?w=280&h=380&fit=crop" },
+    { title: "Westworld", img: "https://images.unsplash.com/photo-1485827404703-89b55fcc595e?w=280&h=380&fit=crop" },
+    { title: "Dune", img: "https://images.unsplash.com/photo-1509023464722-18d996393ca8?w=280&h=380&fit=crop" },
+    { title: "Interstellar", img: "https://images.unsplash.com/photo-1419242902214-272b3f66ee7a?w=280&h=380&fit=crop" },
+    { title: "Blade Runner", img: "https://images.unsplash.com/photo-1543722530-d2c3201371e7?w=280&h=380&fit=crop" },
+  ],
+  [
+    { title: "Game of Thrones", img: "https://images.unsplash.com/photo-1518709268805-4e9042af9f23?w=280&h=380&fit=crop" },
+    { title: "The Witcher", img: "https://images.unsplash.com/photo-1500964757637-c85e8a162699?w=280&h=380&fit=crop" },
+    { title: "Vikings", img: "https://images.unsplash.com/photo-1500252185289-40ca85eb23a7?w=280&h=380&fit=crop" },
+    { title: "Peaky Blinders", img: "https://images.unsplash.com/photo-1494972308805-463bc619d34e?w=280&h=380&fit=crop" },
+    { title: "The Mandalorian", img: "https://images.unsplash.com/photo-1534996858221-380b92700493?w=280&h=380&fit=crop" },
+    { title: "Arrival", img: "https://images.unsplash.com/photo-1462331940025-496dfbfc7564?w=280&h=380&fit=crop" },
+    { title: "Avatar", img: "https://images.unsplash.com/photo-1531366936337-7c912a4589a7?w=280&h=380&fit=crop" },
+    { title: "The Matrix", img: "https://images.unsplash.com/photo-1464802686167-b939a6910659?w=280&h=380&fit=crop" },
+  ],
+  [
+    { title: "Black Mirror", img: "https://images.unsplash.com/photo-1526374965328-7f61d4dc18c5?w=280&h=380&fit=crop" },
+    { title: "Chernobyl", img: "https://images.unsplash.com/photo-1504192010706-dd7f569ee2be?w=280&h=380&fit=crop" },
+    { title: "The Expanse", img: "https://images.unsplash.com/photo-1446776811953-b23d57bd21aa?w=280&h=380&fit=crop" },
+    { title: "Altered Carbon", img: "https://images.unsplash.com/photo-1451187580459-43490279c0fa?w=280&h=380&fit=crop" },
+    { title: "Foundation", img: "https://images.unsplash.com/photo-1462331940025-496dfbfc7564?w=280&h=380&fit=crop" },
+    { title: "Cosmos", img: "https://images.unsplash.com/photo-1444703686981-a3abbc4d4fe3?w=280&h=380&fit=crop" },
+    { title: "Gravity", img: "https://images.unsplash.com/photo-1465101162946-4377e57745c3?w=280&h=380&fit=crop" },
+    { title: "Moon", img: "https://images.unsplash.com/photo-1522030299830-16b8d3d049fe?w=280&h=380&fit=crop" },
+  ],
+  [
+    { title: "True Detective", img: "https://images.unsplash.com/photo-1509023464722-18d996393ca8?w=280&h=380&fit=crop" },
+    { title: "Severance", img: "https://images.unsplash.com/photo-1497366216548-37526070297c?w=280&h=380&fit=crop" },
+    { title: "Mindhunter", img: "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=280&h=380&fit=crop" },
+    { title: "The Last of Us", img: "https://images.unsplash.com/photo-1536440136628-849c177e76a1?w=280&h=380&fit=crop" },
+    { title: "Succession", img: "https://images.unsplash.com/photo-1486406146926-c627a92ad1ab?w=280&h=380&fit=crop" },
+    { title: "Nebula", img: "https://images.unsplash.com/photo-1507400492013-162706c8c05e?w=280&h=380&fit=crop" },
+    { title: "Eclipse", img: "https://images.unsplash.com/photo-1502134249126-9f3755a50d78?w=280&h=380&fit=crop" },
+    { title: "Mars", img: "https://images.unsplash.com/photo-1614728263952-84ea256f9679?w=280&h=380&fit=crop" },
+  ],
+  [
+    { title: "Ozark", img: "https://images.unsplash.com/photo-1473580044384-7ba9967e16a0?w=280&h=380&fit=crop" },
+    { title: "Mr. Robot", img: "https://images.unsplash.com/photo-1550751827-4bd374c3f58b?w=280&h=380&fit=crop" },
+    { title: "Fargo", img: "https://images.unsplash.com/photo-1491002052546-bf38f186af56?w=280&h=380&fit=crop" },
+    { title: "Better Call Saul", img: "https://images.unsplash.com/photo-1519681393784-d120267933ba?w=280&h=380&fit=crop" },
+    { title: "The Boys", img: "https://images.unsplash.com/photo-1535016120720-40c646be5580?w=280&h=380&fit=crop" },
+    { title: "Solaris", img: "https://images.unsplash.com/photo-1454789548928-9efd52dc4031?w=280&h=380&fit=crop" },
+    { title: "Horizon", img: "https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?w=280&h=380&fit=crop" },
+    { title: "Aurora", img: "https://images.unsplash.com/photo-1531366936337-7c912a4589a7?w=280&h=380&fit=crop" },
+  ],
+  [
+    { title: "House of Cards", img: "https://images.unsplash.com/photo-1501466044931-62695aada8e9?w=280&h=380&fit=crop" },
+    { title: "Narcos", img: "https://images.unsplash.com/photo-1518173946687-a1e0e2e3e14c?w=280&h=380&fit=crop" },
+    { title: "Sherlock", img: "https://images.unsplash.com/photo-1477959858617-67f85cf4f1df?w=280&h=380&fit=crop" },
+    { title: "The Haunting", img: "https://images.unsplash.com/photo-1510070112808-e47d3005c0c9?w=280&h=380&fit=crop" },
+    { title: "Euphoria", img: "https://images.unsplash.com/photo-1533174072545-7a4b6ad7a6c3?w=280&h=380&fit=crop" },
+    { title: "Void", img: "https://images.unsplash.com/photo-1475274047050-1d0c55b7b10f?w=280&h=380&fit=crop" },
+    { title: "Signal", img: "https://images.unsplash.com/photo-1451187580459-43490279c0fa?w=280&h=380&fit=crop" },
+    { title: "Spectrum", img: "https://images.unsplash.com/photo-1507400492013-162706c8c05e?w=280&h=380&fit=crop" },
+  ],
 ];
+
+// 每行的动画配置：时长和方向（交错排列）
+const ROW_CONFIGS = [
+  { duration: 240, reverse: false },
+  { duration: 240, reverse: true },
+  { duration: 220, reverse: false },
+  { duration: 232, reverse: true },
+  { duration: 240, reverse: false },
+  { duration: 240, reverse: true },
+];
+
+// 胶片齿孔组件
+function FilmPerforations({ side }: { side: 'top' | 'bottom' }) {
+  return (
+    <div className={cn(
+      "absolute left-0 right-0 flex justify-around px-4 z-10",
+      side === 'top' ? 'top-[3px]' : 'bottom-[3px]',
+    )}>
+      {Array.from({ length: 8 }, (_, i) => (
+        <div
+          key={i}
+          className="w-[10px] h-[6px] rounded-[1px] bg-black/50 border border-white/5"
+        />
+      ))}
+    </div>
+  );
+}
+
+function FilmCard({ title, img }: { title: string; img: string }) {
+  return (
+    <div className="relative w-[260px] h-[180px] shrink-0">
+      {/* 胶片带外框 */}
+      <div className="absolute inset-0 bg-zinc-900/90 border border-white/5" />
+
+      {/* 上下齿孔 */}
+      <FilmPerforations side="top" />
+      <FilmPerforations side="bottom" />
+
+      {/* 图片区域（上下留出胶片边框） */}
+      <div className="absolute top-[12px] bottom-[12px] left-[6px] right-[6px] overflow-hidden">
+        <img
+          src={img}
+          alt={title}
+          className="absolute inset-0 w-full h-full object-cover"
+          loading="lazy"
+        />
+        {/* 胶片划痕/晃电噪点覆层 */}
+        <div className="absolute inset-0 opacity-[0.04] mix-blend-overlay"
+          style={{
+            backgroundImage: `repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(255,255,255,0.1) 2px, transparent 4px)`,
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function FilmStripRow({ cards, duration, reverse }: {
+  cards: { title: string; img: string }[];
+  duration: number;
+  reverse: boolean;
+}) {
+  const repeatedCards = [...cards, ...cards, ...cards, ...cards, ...cards];
+  return (
+    <div className="relative w-full h-[180px] shrink-0 overflow-hidden">
+      <div
+        className="flex flex-row gap-0 w-max"
+        style={{
+          animation: `film-scroll-x ${duration}s linear infinite`,
+          animationDirection: reverse ? 'reverse' : 'normal',
+        }}
+      >
+        {repeatedCards.map((card, i) => (
+          <FilmCard key={`${card.title}-${i}`} {...card} />
+        ))}
+      </div>
+    </div>
+  );
+}
 
 // 表单字段配置
 const FORM_FIELDS = {
@@ -135,89 +271,42 @@ export default function LoginPage() {
   const currentFields = FORM_FIELDS[mode];
 
   return (
-    <div className="min-h-screen flex bg-background">
-      {/* Left Side - Branding */}
-      <div className="hidden lg:flex lg:w-1/2 relative overflow-hidden">
-        {/* Animated Gradient Background */}
-        <div className="absolute inset-0 bg-gradient-to-br from-node-purple/20 via-background to-node-blue/20 animate-gradient" />
-        
-        {/* Grid Pattern */}
-        <div 
-          className="absolute inset-0 opacity-[0.03]"
+    <div className="relative h-screen w-screen overflow-hidden bg-background">
+      {/* ===== Layer 1: Full-screen Film Strip Background ===== */}
+      <div className="absolute inset-0 z-0 overflow-hidden">
+        {/* Film strip rows with 45° diagonal scrolling */}
+        <div
+          className="absolute flex flex-col justify-center gap-16"
           style={{
-            backgroundImage: `linear-gradient(var(--foreground) 1px, transparent 1px), linear-gradient(90deg, var(--foreground) 1px, transparent 1px)`,
-            backgroundSize: '50px 50px'
+            transform: 'rotate(-45deg)',
+            transformOrigin: 'center center',
+            width: '200vw',
+            height: '200vh',
+            top: '-50vh',
+            left: '-50vw',
           }}
-        />
-
-        {/* Content */}
-        <div className="relative z-10 flex flex-col justify-center px-16 w-full">
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-          >
-            {/* Logo */}
-            <div className="flex items-center gap-3 mb-8">
-              <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-node-purple to-node-blue flex items-center justify-center shadow-lg shadow-node-purple/20">
-                <Sparkles className="w-6 h-6 text-white" />
-              </div>
-              <span className="text-2xl font-bold text-foreground">KunFlix</span>
-            </div>
-
-            {/* Title */}
-            <h1 className="text-4xl font-bold text-foreground mb-4 leading-tight">
-              KunFlix
-            </h1>
-            <p className="text-lg text-muted-foreground mb-12 max-w-md">
-              AI 驱动的多模态创作平台，让创意无限延伸
-            </p>
-
-            {/* Features */}
-            <div className="space-y-4">
-              {FEATURES.map((feature, index) => (
-                <motion.div
-                  key={feature.label}
-                  initial={{ opacity: 0, x: -20 }}
-                  animate={{ opacity: 1, x: 0 }}
-                  transition={{ delay: 0.3 + index * 0.1 }}
-                  className="flex items-center gap-4 p-4 rounded-xl bg-secondary/50 backdrop-blur-sm border border-border/50"
-                >
-                  <div className="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center">
-                    <feature.icon className="w-5 h-5 text-primary" />
-                  </div>
-                  <div>
-                    <p className="font-medium text-foreground">{feature.label}</p>
-                    <p className="text-sm text-muted-foreground">{feature.desc}</p>
-                  </div>
-                </motion.div>
-              ))}
-            </div>
-          </motion.div>
+        >
+          {FILM_COLUMNS.map((cards, rowIdx) => (
+            <FilmStripRow
+              key={rowIdx}
+              cards={cards}
+              duration={ROW_CONFIGS[rowIdx].duration}
+              reverse={ROW_CONFIGS[rowIdx].reverse}
+            />
+          ))}
         </div>
-
-        {/* Decorative Elements */}
-        <div className="absolute bottom-0 left-0 right-0 h-32 bg-gradient-to-t from-background to-transparent" />
       </div>
 
-      {/* Right Side - Form */}
-      <div className="flex-1 flex items-center justify-center p-4 sm:p-8">
+      {/* ===== Layer 2: Floating Form ===== */}
+      <div className="relative z-30 flex items-center justify-center h-full p-4">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
+          transition={{ duration: 0.5, delay: 0.1 }}
           className="w-full max-w-md"
         >
-          {/* Mobile Logo */}
-          <div className="lg:hidden flex items-center justify-center gap-3 mb-8">
-            <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-node-purple to-node-blue flex items-center justify-center">
-              <Sparkles className="w-5 h-5 text-white" />
-            </div>
-            <span className="text-xl font-bold text-foreground">KunFlix</span>
-          </div>
-
           {/* Form Card */}
-          <div className="bg-card/50 backdrop-blur-xl border border-border/50 rounded-2xl p-6 sm:p-8 shadow-xl">
+          <div className="bg-card/80 backdrop-blur-2xl border border-border/50 rounded-2xl p-6 sm:p-8 shadow-2xl">
             {/* Header */}
             <div className="text-center mb-8">
               <h2 className="text-2xl font-bold text-foreground mb-2">
@@ -230,7 +319,7 @@ export default function LoginPage() {
 
             {/* Form */}
             <form onSubmit={handleSubmit} className="space-y-5">
-              <AnimatePresence mode="wait">
+              <AnimatePresence>
                 {currentFields.map((field, index) => (
                   <motion.div
                     key={`${mode}-${field.name}`}
@@ -319,12 +408,12 @@ export default function LoginPage() {
                 </button>
               </p>
             </div>
-          </div>
 
-          {/* Footer */}
-          <p className="text-center text-xs text-muted-foreground mt-6">
-            登录即表示您同意我们的服务条款和隐私政策
-          </p>
+            {/* Footer */}
+            <p className="text-center text-xs text-muted-foreground/70 mt-4">
+              登录即表示您同意我们的服务条款和隐私政策
+            </p>
+          </div>
         </motion.div>
       </div>
     </div>

--- a/frontend/src/app/theater/[id]/page.tsx
+++ b/frontend/src/app/theater/[id]/page.tsx
@@ -604,54 +604,60 @@ function InfiniteCanvas() {
       setIsDraggingFile(false);
       setDragFileType(null);
 
-      // Handle external file drop
-      const files = event.dataTransfer.files;
-      if (files.length > 0) {
-        const position = screenToFlowPosition({
-          x: event.clientX,
-          y: event.clientY,
-        });
-        
-        // 按类型分组并限制批量数量（映射表模式）
-        const BATCH_LIMITS: Record<string, number> = { video: 5, image: 20, audio: 20, text: 20 };
-        const TYPE_NAMES: Record<string, string> = {
-          video: t('canvas.fileNames.video'),
-          image: t('canvas.fileNames.image'),
-          audio: t('canvas.fileNames.audio'),
-          text: t('canvas.fileNames.text'),
-        };
-        const grouped: Record<string, File[]> = {};
-        Array.from(files).forEach((file) => {
-          const fType = getFileType(file) ?? 'unknown';
-          (grouped[fType] = grouped[fType] || []).push(file);
-        });
+      // 优先检查内部拖拽（从侧边栏/资产库），避免浏览器原生 img 拖拽导致 files 干扰
+      const type = event.dataTransfer.getData('application/reactflow');
+      if (type) {
+        // 内部拖拽路径，直接创建节点，不走文件上传
+      } else {
+        // Handle external file drop
+        const files = event.dataTransfer.files;
+        if (files.length > 0) {
+          const position = screenToFlowPosition({
+            x: event.clientX,
+            y: event.clientY,
+          });
+          
+          // 按类型分组并限制批量数量（映射表模式）
+          const BATCH_LIMITS: Record<string, number> = { video: 5, image: 20, audio: 20, text: 20 };
+          const TYPE_NAMES: Record<string, string> = {
+            video: t('canvas.fileNames.video'),
+            image: t('canvas.fileNames.image'),
+            audio: t('canvas.fileNames.audio'),
+            text: t('canvas.fileNames.text'),
+          };
+          const grouped: Record<string, File[]> = {};
+          Array.from(files).forEach((file) => {
+            const fType = getFileType(file) ?? 'unknown';
+            (grouped[fType] = grouped[fType] || []).push(file);
+          });
 
-        const allowed: File[] = [];
-        const rejected: string[] = [];
-        Object.entries(grouped).forEach(([type, list]) => {
-          const limit = BATCH_LIMITS[type] ?? 20;
-          allowed.push(...list.slice(0, limit));
-          list.length > limit && rejected.push(
-            t('canvas.batchLimit', { type: TYPE_NAMES[type] ?? t('canvas.fileNames.default'), limit, skipped: list.length - limit })
-          );
-        });
-        rejected.length > 0 && alert(rejected.join('\n'));
+          const allowed: File[] = [];
+          const rejected: string[] = [];
+          Object.entries(grouped).forEach(([fType, list]) => {
+            const limit = BATCH_LIMITS[fType] ?? 20;
+            allowed.push(...list.slice(0, limit));
+            list.length > limit && rejected.push(
+              t('canvas.batchLimit', { type: TYPE_NAMES[fType] ?? t('canvas.fileNames.default'), limit, skipped: list.length - limit })
+            );
+          });
+          rejected.length > 0 && alert(rejected.join('\n'));
 
-        // 串行上传避免并发写入 SQLite 冲突
-        (async () => {
-          for (let i = 0; i < allowed.length; i++) {
-            const filePosition = {
-              x: position.x + i * 50,
-              y: position.y + i * 50,
-            };
-            await createNodeFromFile(allowed[i], filePosition);
-          }
-        })();
+          // 串行上传避免并发写入 SQLite 冲突
+          (async () => {
+            for (let i = 0; i < allowed.length; i++) {
+              const filePosition = {
+                x: position.x + i * 50,
+                y: position.y + i * 50,
+              };
+              await createNodeFromFile(allowed[i], filePosition);
+            }
+          })();
+          return;
+        }
         return;
       }
 
-      // Handle internal node drag (existing logic)
-      const type = event.dataTransfer.getData('application/reactflow');
+      // Handle internal node drag (from sidebar/asset library)
       const dataStr = event.dataTransfer.getData('application/reactflow-data');
       const dimensionsStr = event.dataTransfer.getData('application/reactflow-dimensions');
       

--- a/frontend/src/components/ai-assistant/ChatMessage.tsx
+++ b/frontend/src/components/ai-assistant/ChatMessage.tsx
@@ -18,7 +18,7 @@ import { VideoTaskCard } from './VideoTaskCard';
 import { MusicTaskCard } from './MusicTaskCard';
 import { WelcomeMessage } from './WelcomeMessage';
 import { CompactionNotice } from './CompactionNotice';
-import type { Message, SkillCall, ToolCall, MultiAgentData, NodeAttachment } from '@/store/useAIAssistantStore';
+import type { Message, SkillCall, ToolCall, MultiAgentData, NodeAttachment, HarnessEvent } from '@/store/useAIAssistantStore';
 
 // ---------------------------------------------------------------------------
 // Video marker parsing
@@ -229,6 +229,58 @@ interface ChatMessageProps {
   isLoading?: boolean;
   isLast?: boolean;
   className?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Harness 事件映射表 + 展示组件
+// ---------------------------------------------------------------------------
+
+const HARNESS_EVENT_CONFIG: Record<HarnessEvent['type'], {
+  label: string;
+  color: string;
+  bgColor: string;
+  icon: string;
+}> = {
+  llm_retry:             { label: 'LLM 重试中',         color: 'text-amber-600 dark:text-amber-400',  bgColor: 'bg-amber-50 dark:bg-amber-950/40 border-amber-200 dark:border-amber-800', icon: '⟳' },
+  llm_circuit_breaker:   { label: 'LLM 调用熔断',       color: 'text-red-600 dark:text-red-400',      bgColor: 'bg-red-50 dark:bg-red-950/40 border-red-200 dark:border-red-800',       icon: '⚡' },
+  tool_circuit_breaker:  { label: '工具调用熔断',        color: 'text-red-600 dark:text-red-400',      bgColor: 'bg-red-50 dark:bg-red-950/40 border-red-200 dark:border-red-800',       icon: '⚡' },
+  subtask_retry:         { label: '子任务重试中',        color: 'text-blue-600 dark:text-blue-400',    bgColor: 'bg-blue-50 dark:bg-blue-950/40 border-blue-200 dark:border-blue-800',   icon: '↻' },
+};
+
+function HarnessEventBanner({ events }: { events: HarnessEvent[] }) {
+  const latestByType = useMemo(() => {
+    const map = new Map<string, HarnessEvent>();
+    events.forEach(e => map.set(e.type, e));
+    return Array.from(map.values());
+  }, [events]);
+
+  return (
+    <div className="space-y-1 my-1.5">
+      {latestByType.map((evt) => {
+        const cfg = HARNESS_EVENT_CONFIG[evt.type];
+        const detail = evt.attempt && evt.maxRetries
+          ? `(${evt.attempt}/${evt.maxRetries})`
+          : '';
+        return (
+          <div
+            key={evt.type}
+            className={cn(
+              'flex items-center gap-1.5 px-2.5 py-1 rounded-md border text-xs font-medium',
+              cfg.bgColor, cfg.color,
+            )}
+          >
+            <span>{cfg.icon}</span>
+            <span>{cfg.label} {detail}</span>
+            {evt.error && (
+              <span className="ml-1 opacity-70 font-normal truncate max-w-[200px]" title={evt.error}>
+                — {evt.error}
+              </span>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
 }
 
 // 浮动跳跃的三点加载动画（用于初始加载）
@@ -517,6 +569,11 @@ export function ChatMessage({ message, isLoading, isLast, className }: ChatMessa
                   {allMusicCards.map((card) => (
                     <MusicTaskCard key={card.taskId} task={card} />
                   ))}
+
+                  {/* Harness 事件横幅（LLM重试、熔断等） */}
+                  {message.harness_events && message.harness_events.length > 0 && (
+                    <HarnessEventBanner events={message.harness_events} />
+                  )}
 
                   {/* 技能/工具调用连续式面板 */}
                   {((message.skill_calls && message.skill_calls.length > 0) ||

--- a/frontend/src/components/ai-assistant/MessageInput.tsx
+++ b/frontend/src/components/ai-assistant/MessageInput.tsx
@@ -6,7 +6,6 @@ import {
   Send,
   Loader2,
   ChevronDown,
-  Plus,
   X,
   FileText,
   ImageIcon,
@@ -21,6 +20,7 @@ import {
   Clapperboard,
   Paperclip,
   Square,
+  Toolbox
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
@@ -659,7 +659,7 @@ export function MessageInput({
                     disabled={isDisabled || availableNodes.length === 0}
                     title={t('ai.addNode')}
                   >
-                    <Plus className="h-4 w-4" />
+                    <Paperclip className="h-4 w-4" />
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="w-64 max-h-72 overflow-y-auto">

--- a/frontend/src/components/ai-assistant/PanelHeader.tsx
+++ b/frontend/src/components/ai-assistant/PanelHeader.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { motion, AnimatePresence } from 'framer-motion';
-import { X, Battery, BatteryMedium, BatteryLow, BatteryWarning, Plus, MessageSquare, Loader2 } from 'lucide-react';
+import { X, Battery, BatteryMedium, BatteryLow, BatteryWarning, Plus, MessageSquare, Loader2, History } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import type { ContextUsage, ChatSessionInfo } from '@/store/useAIAssistantStore';
@@ -157,7 +157,7 @@ function ChatHistoryDropdown({
         onPointerDown={(e) => e.stopPropagation()}
         title={t('ai.chatHistory')}
       >
-        <MessageSquare className="h-4 w-4" />
+        <History className="h-4 w-4" />
         {chatList.length > 1 && (
           <span className="absolute -top-0.5 -right-0.5 min-w-[14px] h-[14px] rounded-full bg-primary text-[9px] text-primary-foreground flex items-center justify-center font-medium leading-none px-0.5">
             {chatList.length}
@@ -335,21 +335,6 @@ function HeaderContextBattery({ contextUsage, isLoading }: HeaderContextBatteryP
         )}>
           {percentage.toFixed(0)}%
         </span>
-        {/* 消耗动画效果 */}
-        {isLoading && (
-          <motion.div
-            className="absolute inset-0 rounded-lg bg-primary/10"
-            animate={{
-              scale: [1, 1.1, 1],
-              opacity: [0.3, 0.6, 0.3],
-            }}
-            transition={{
-              duration: 1.5,
-              repeat: Infinity,
-              ease: "easeInOut",
-            }}
-          />
-        )}
       </Button>
 
       {/* Hover展开的详细信息面板 */}

--- a/frontend/src/components/ai-assistant/PanelHeader.tsx
+++ b/frontend/src/components/ai-assistant/PanelHeader.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { motion, AnimatePresence } from 'framer-motion';
-import { X, Battery, BatteryMedium, BatteryLow, BatteryWarning, Plus, MessageSquare, Loader2, History } from 'lucide-react';
+import { X, Battery, BatteryMedium, BatteryLow, BatteryWarning, Plus, Loader2, History } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import type { ContextUsage, ChatSessionInfo } from '@/store/useAIAssistantStore';

--- a/frontend/src/components/ai-assistant/hooks/useSSEHandler.ts
+++ b/frontend/src/components/ai-assistant/hooks/useSSEHandler.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useRef } from 'react';
-import { useAIAssistantStore, type Message, type AgentStep, type VideoTaskData, type MusicTaskData } from '@/store/useAIAssistantStore';
+import { useAIAssistantStore, type Message, type AgentStep, type VideoTaskData, type MusicTaskData, type HarnessEvent } from '@/store/useAIAssistantStore';
 import { useCanvasStore } from '@/store/useCanvasStore';
 import { useAuth } from '@/context/AuthContext';
 import type { MultiAgentData } from '@/components/canvas/MultiAgentSteps';
@@ -22,6 +22,7 @@ interface StreamingState {
   assistantMsg: Message | null;
   roundHasTools: boolean;
   doneScheduled: boolean;
+  harnessEvents: HarnessEvent[];
 }
 
 export function useSSEHandler() {
@@ -42,6 +43,7 @@ export function useSSEHandler() {
     assistantMsg: null,
     roundHasTools: false,
     doneScheduled: false,
+    harnessEvents: [],
   });
 
   const resetStreamingState = useCallback(() => {
@@ -56,6 +58,7 @@ export function useSSEHandler() {
       assistantMsg: null,
       roundHasTools: false,
       doneScheduled: false,
+      harnessEvents: [],
     };
   }, []);
 
@@ -276,15 +279,77 @@ export function useSSEHandler() {
 
       // 多智能体：子任务失败
       subtask_failed: () => {
-        const d = data as { subtask_id?: string; error?: string };
+        const d = data as { subtask_id?: string; error?: string; circuit_breaker?: boolean; retries?: number };
         const step = state.stepMap.get(d.subtask_id || '');
-        step && ((step.status = 'failed'), (step.error = d.error));
+        if (step) {
+          step.status = 'failed';
+          step.error = d.error;
+          step.circuitBreaker = d.circuit_breaker;
+          step.retryCount = d.retries;
+        }
         setMessages((prev) => {
           const last = prev[prev.length - 1];
           if (last?.role === 'ai') {
             return [...prev.slice(0, -1), { ...last, multi_agent: { ...state.multiAgent!, steps: [...state.steps] } }];
           }
           return prev;
+        });
+      },
+
+      // Harness: 多智能体子任务重试
+      subtask_retry: () => {
+        const d = data as { subtask_id?: string; attempt?: number; max_retries?: number };
+        const step = state.stepMap.get(d.subtask_id || '');
+        if (step) {
+          step.status = 'retrying';
+          step.retryCount = d.attempt;
+          step.maxRetries = d.max_retries;
+        }
+        setMessages((prev) => {
+          const last = prev[prev.length - 1];
+          if (last?.role === 'ai') {
+            return [...prev.slice(0, -1), { ...last, multi_agent: { ...state.multiAgent!, steps: [...state.steps] } }];
+          }
+          return prev;
+        });
+      },
+
+      // Harness: 单智能体 LLM 调用重试
+      llm_retry: () => {
+        const d = data as { attempt?: number; max_retries?: number; error?: string };
+        const evt: HarnessEvent = { type: 'llm_retry', attempt: d.attempt, maxRetries: d.max_retries, error: d.error };
+        state.harnessEvents.push(evt);
+        setMessages((prev) => {
+          const last = prev[prev.length - 1];
+          return (last?.role === 'ai' && last?.status === 'streaming')
+            ? [...prev.slice(0, -1), { ...last, harness_events: [...state.harnessEvents] }]
+            : prev;
+        });
+      },
+
+      // Harness: LLM 熔断
+      llm_circuit_breaker: () => {
+        const d = data as { retries?: number; round?: number };
+        const evt: HarnessEvent = { type: 'llm_circuit_breaker', maxRetries: d.retries, round: d.round };
+        state.harnessEvents.push(evt);
+        setMessages((prev) => {
+          const last = prev[prev.length - 1];
+          return (last?.role === 'ai' && last?.status === 'streaming')
+            ? [...prev.slice(0, -1), { ...last, harness_events: [...state.harnessEvents] }]
+            : prev;
+        });
+      },
+
+      // Harness: 工具连续失败熔断
+      tool_circuit_breaker: () => {
+        const d = data as { consecutive_failures?: number; max_allowed?: number };
+        const evt: HarnessEvent = { type: 'tool_circuit_breaker', attempt: d.consecutive_failures, maxRetries: d.max_allowed };
+        state.harnessEvents.push(evt);
+        setMessages((prev) => {
+          const last = prev[prev.length - 1];
+          return (last?.role === 'ai' && last?.status === 'streaming')
+            ? [...prev.slice(0, -1), { ...last, harness_events: [...state.harnessEvents] }]
+            : prev;
         });
       },
 

--- a/frontend/src/components/canvas/MultiAgentSteps.tsx
+++ b/frontend/src/components/canvas/MultiAgentSteps.tsx
@@ -1,17 +1,21 @@
 'use client';
 
 import React, { useState } from 'react';
-import { ChevronDown, ChevronUp, Bot, CheckCircle2, Circle, XCircle, Loader2 } from 'lucide-react';
+import { ChevronDown, ChevronUp, Bot, CheckCircle2, Circle, XCircle, Loader2, RefreshCw, Zap } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 export interface AgentStep {
   subtask_id: string;
   agent_name: string;
   description: string;
-  status: 'pending' | 'running' | 'completed' | 'failed';
+  status: 'pending' | 'running' | 'completed' | 'failed' | 'retrying';
   result?: string;
   error?: string;
   tokens?: { input: number; output: number };
+  // Harness: 重试/熔断信息
+  retryCount?: number;
+  maxRetries?: number;
+  circuitBreaker?: boolean;
 }
 
 export interface MultiAgentData {
@@ -37,18 +41,15 @@ export default function MultiAgentSteps({ steps, finalResult, totalTokens, credi
     });
   };
 
-  const getStatusIcon = (status: AgentStep['status']) => {
-    switch (status) {
-      case 'completed':
-        return <CheckCircle2 className="h-4 w-4 text-green-500" />;
-      case 'failed':
-        return <XCircle className="h-4 w-4 text-red-500" />;
-      case 'running':
-        return <Loader2 className="h-4 w-4 text-blue-500 animate-spin" />;
-      default:
-        return <Circle className="h-4 w-4 text-muted-foreground" />;
-    }
+  const STATUS_ICON_MAP: Record<AgentStep['status'], React.ReactNode> = {
+    completed: <CheckCircle2 className="h-4 w-4 text-green-500" />,
+    failed:    <XCircle className="h-4 w-4 text-red-500" />,
+    running:   <Loader2 className="h-4 w-4 text-blue-500 animate-spin" />,
+    retrying:  <RefreshCw className="h-4 w-4 text-amber-500 animate-spin" />,
+    pending:   <Circle className="h-4 w-4 text-muted-foreground" />,
   };
+
+  const getStatusIcon = (status: AgentStep['status']) => STATUS_ICON_MAP[status] ?? STATUS_ICON_MAP.pending;
 
   const completedCount = steps.filter(s => s.status === 'completed').length;
   const isAllCompleted = completedCount === steps.length && steps.length > 0;
@@ -81,6 +82,18 @@ export default function MultiAgentSteps({ steps, finalResult, totalTokens, credi
                   <div className="flex items-center gap-2">
                     <span className="text-xs font-medium">{step.agent_name}</span>
                     <span className="text-xs text-muted-foreground">步骤 {index + 1}</span>
+                    {/* Harness: 重试计数标签 */}
+                    {step.retryCount != null && step.retryCount > 0 && (
+                      <span className="text-[10px] px-1.5 py-0.5 rounded bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 font-medium">
+                        重试 {step.retryCount}/{step.maxRetries ?? '?'}
+                      </span>
+                    )}
+                    {/* Harness: 熔断标记 */}
+                    {step.circuitBreaker && (
+                      <span className="flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300 font-medium">
+                        <Zap className="h-3 w-3" /> 熔断
+                      </span>
+                    )}
                   </div>
                   <p className="text-xs text-muted-foreground truncate">{step.description}</p>
                 </div>

--- a/frontend/src/components/canvas/Sidebar.tsx
+++ b/frontend/src/components/canvas/Sidebar.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { 
-  Layers, Plus, ScrollText, Image as ImageIcon, Video, 
+  VectorSquare, Plus, ScrollText, Image as ImageIcon, Video, 
   Table2, GripVertical, Film, ImagePlus, Music, ExternalLink, Loader2, Headphones
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -60,7 +60,7 @@ const NODE_TYPES = [
   },
 ];
 
-// 拖拽数据映射表：资源类型 -> 画布节点类型 + 数据结构
+// 拖拽数据映射表：资产类型 -> 画布节点类型 + 数据结构
 const DRAG_DATA_BUILDERS: Record<string, (asset: { url: string; name: string }) => { nodeType: string; data: Record<string, unknown> }> = {
   image: (a) => ({ nodeType: 'image', data: { name: a.name, imageUrl: a.url } }),
   video: (a) => ({ nodeType: 'video', data: { name: a.name, videoUrl: a.url } }),
@@ -87,15 +87,15 @@ export const Sidebar = () => {
   const [activeAssetTab, setActiveAssetTab] = useState<'images' | 'videos' | 'audio'>('images');
   let timeoutRef = useRef<NodeJS.Timeout | null>(null);
   
-  // 从 Resource Store 获取账号级别资源
+  // 从 Resource Store 获取账号级别资产
   const { assets, isLoading, fetchAssets } = useResourceStore();
 
-  // 面板打开时懒加载资源
+  // 面板打开时加载资产（大 pageSize + 强制全类型，确保侧边栏显示完整）
   useEffect(() => {
-    activeMenu === 'assets' && assets.length === 0 && fetchAssets();
+    activeMenu === 'assets' && fetchAssets({ pageSize: 100, typeFilter: 'all' });
   }, [activeMenu]);
 
-  // 按类型分组资源
+  // 按类型分组资产
   const ASSET_IMAGES = useMemo(() => assets.filter(a => a.file_type === 'image'), [assets]);
   const ASSET_VIDEOS = useMemo(() => assets.filter(a => a.file_type === 'video'), [assets]);
   const ASSET_AUDIO = useMemo(() => assets.filter(a => a.file_type === 'audio'), [assets]);
@@ -146,7 +146,7 @@ export const Sidebar = () => {
   return (
     <div className="fixed left-6 top-1/2 -translate-y-1/2 z-50">
       <div 
-        className="flex flex-col gap-2 p-1.5 rounded-xl bg-background/70 backdrop-blur-xl border border-border/50 shadow-none"
+        className="flex flex-col gap-2 p-1.5 rounded-xl bg-background border border-border/50 shadow-none"
         onMouseLeave={handleMouseLeave}
       >
         {/* Node Library Button */}
@@ -158,12 +158,12 @@ export const Sidebar = () => {
             "w-8 h-8 rounded-[8px] flex items-center justify-center transition-colors duration-200 shadow-none",
             activeMenu === 'nodes' ? "bg-primary/10 text-primary" : "text-muted-foreground hover:bg-secondary hover:text-foreground"
           )}>
-            <Layers className="w-4 h-4" />
+            <VectorSquare className="w-4 h-4" />
           </button>
           
           {/* Node Library Panel */}
           <div className={cn(
-            "absolute left-full top-0 ml-4 w-60 bg-background/70 backdrop-blur-xl border border-border/50 rounded-xl p-2 transition-all duration-200 ease-[cubic-bezier(0.4,0,0.2,1)] shadow-none",
+            "absolute left-full top-0 ml-4 w-60 bg-background border border-border/50 rounded-xl p-2 transition-all duration-200 ease-[cubic-bezier(0.4,0,0.2,1)] shadow-none",
             activeMenu === 'nodes' 
               ? "opacity-100 translate-x-0 pointer-events-auto" 
               : "opacity-0 -translate-x-2 pointer-events-none"
@@ -205,7 +205,7 @@ export const Sidebar = () => {
           
           {/* Asset Library Panel */}
           <div className={cn(
-            "absolute left-full top-0 ml-4 w-72 bg-background/70 backdrop-blur-xl border border-border/50 rounded-xl p-3 transition-all duration-200 ease-[cubic-bezier(0.4,0,0.2,1)] shadow-none flex flex-col gap-3",
+            "absolute left-full top-0 ml-4 w-72 bg-background border border-border/50 rounded-xl p-3 transition-all duration-200 ease-[cubic-bezier(0.4,0,0.2,1)] shadow-none flex flex-col gap-3",
             activeMenu === 'assets' 
               ? "opacity-100 translate-x-0 pointer-events-auto" 
               : "opacity-0 -translate-x-2 pointer-events-none"
@@ -252,6 +252,7 @@ export const Sidebar = () => {
                         src={asset.url} 
                         alt={asset.original_name || asset.filename} 
                         loading="lazy"
+                        draggable={false}
                         className="w-full h-full object-contain p-1"
                       />
                       <div className="absolute inset-x-0 bottom-0 bg-black/50 backdrop-blur-sm p-1.5 translate-y-full group-hover:translate-y-0 transition-transform">
@@ -331,7 +332,7 @@ export const Sidebar = () => {
 
             </div>
 
-            {/* 管理资源链接 */}
+            {/* 管理资产链接 */}
             <a
               href="/resources"
               target="_blank"

--- a/frontend/src/components/ui/marquee.tsx
+++ b/frontend/src/components/ui/marquee.tsx
@@ -1,0 +1,56 @@
+import React, { ComponentPropsWithoutRef, useRef } from 'react';
+import { cn } from '@/lib/utils';
+
+interface MarqueeProps extends ComponentPropsWithoutRef<'div'> {
+  className?: string;
+  reverse?: boolean;
+  pauseOnHover?: boolean;
+  children: React.ReactNode;
+  vertical?: boolean;
+  repeat?: number;
+}
+
+export function Marquee({
+  className,
+  reverse = false,
+  pauseOnHover = false,
+  children,
+  vertical = false,
+  repeat = 4,
+  ...props
+}: MarqueeProps) {
+  const marqueeRef = useRef<HTMLDivElement>(null);
+
+  const animationName = vertical ? 'marquee-vertical' : 'marquee';
+  const animationStyle: React.CSSProperties = {
+    animation: `${animationName} var(--duration, 40s) linear infinite`,
+    animationDirection: reverse ? 'reverse' : 'normal',
+  };
+
+  return (
+    <div
+      {...props}
+      ref={marqueeRef}
+      data-slot="marquee"
+      className={cn(
+        'group flex overflow-hidden p-2 [--duration:40s] [--gap:1rem] [gap:var(--gap)]',
+        vertical ? 'flex-col' : 'flex-row',
+        className,
+      )}
+    >
+      {Array.from({ length: repeat }, (_, i) => (
+        <div
+          key={i}
+          className={cn(
+            'flex shrink-0 justify-around',
+            vertical ? 'flex-col [gap:var(--gap)]' : 'flex-row [gap:var(--gap)]',
+            pauseOnHover && 'group-hover:[animation-play-state:paused]',
+          )}
+          style={animationStyle}
+        >
+          {children}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/i18n/locales/en-US.json
+++ b/frontend/src/i18n/locales/en-US.json
@@ -1,7 +1,7 @@
 {
   "nav": {
     "home": "Home",
-    "resources": "Resources",
+    "resources": "Assets",
     "community": "Community"
   },
   "userMenu": {
@@ -13,8 +13,8 @@
     "label": "User menu"
   },
   "search": {
-    "placeholder": "Search resources...",
-    "homePlaceholder": "Search theaters, resources...",
+    "placeholder": "Search assets...",
+    "homePlaceholder": "Search theaters, assets...",
     "mobilePlaceholder": "Search...",
     "label": "Search"
   },
@@ -28,13 +28,13 @@
     "en": "English"
   },
   "resources": {
-    "title": "My Resources",
+    "title": "My Assets",
     "uploadFile": "Upload",
     "dropToUpload": "Drop files to upload",
     "supportedFormats": "Supports JPG, PNG, WebP, GIF, MP4, WebM, MOV, MP3, WAV",
-    "emptyTitle": "No resources yet",
-    "emptyDescription": "Drag files to the area above, or click the upload button to add your first resource",
-    "noMatchTitle": "No matching resources",
+    "emptyTitle": "No assets yet",
+    "emptyDescription": "Drag files to the area above, or click the upload button to add your first asset",
+    "noMatchTitle": "No matching assets",
     "noMatchDescription": "Try different keywords or clear the filters",
     "sizeExceeded": "{{files}}, skipped",
     "exceedLabel": "{{name}} (exceeds {{limit}} limit)"
@@ -158,8 +158,8 @@
     "audio": "Audio",
     "noImages": "No image assets",
     "noVideos": "No video assets",
-    "noAudio": "No audio resources",
-    "manageResources": "Manage Resources"
+    "noAudio": "No audio assets",
+    "manageResources": "Manage Assets"
   },
   "ai": {
     "title": "AI Assistant",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1,7 +1,7 @@
 {
   "nav": {
     "home": "首页",
-    "resources": "资源库",
+    "resources": "资产库",
     "community": "社区"
   },
   "userMenu": {
@@ -13,8 +13,8 @@
     "label": "用户菜单"
   },
   "search": {
-    "placeholder": "搜索资源...",
-    "homePlaceholder": "搜索剧场、资源...",
+    "placeholder": "搜索资产...",
+    "homePlaceholder": "搜索剧场、资产...",
     "mobilePlaceholder": "搜索...",
     "label": "搜索"
   },
@@ -28,13 +28,13 @@
     "en": "English"
   },
   "resources": {
-    "title": "我的资源库",
+    "title": "我的资产库",
     "uploadFile": "上传文件",
     "dropToUpload": "释放以上传文件",
     "supportedFormats": "支持 JPG, PNG, WebP, GIF, MP4, WebM, MOV, MP3, WAV",
-    "emptyTitle": "资源库为空",
-    "emptyDescription": "拖拽文件到上方区域，或点击上传按钮添加您的第一个资源",
-    "noMatchTitle": "未找到匹配的资源",
+    "emptyTitle": "资产库为空",
+    "emptyDescription": "拖拽文件到上方区域，或点击上传按钮添加您的第一个资产",
+    "noMatchTitle": "未找到匹配的资产",
     "noMatchDescription": "尝试使用其他关键词搜索，或清除筛选条件",
     "sizeExceeded": "{{files}}，已跳过",
     "exceedLabel": "{{name}}（超出{{limit}}限制）"
@@ -158,8 +158,8 @@
     "audio": "音频",
     "noImages": "暂无图片资产",
     "noVideos": "暂无视频资产",
-    "noAudio": "暂无音频资源",
-    "manageResources": "管理资源"
+    "noAudio": "暂无音频资产",
+    "manageResources": "管理资产"
   },
   "ai": {
     "title": "AI 助手",

--- a/frontend/src/store/useAIAssistantStore.ts
+++ b/frontend/src/store/useAIAssistantStore.ts
@@ -23,10 +23,14 @@ export interface AgentStep {
   subtask_id: string;
   agent_name: string;
   description: string;
-  status: 'pending' | 'running' | 'completed' | 'failed';
+  status: 'pending' | 'running' | 'completed' | 'failed' | 'retrying';
   result?: string;
   error?: string;
   tokens?: { input: number; output: number };
+  // Harness: 重试/熔断信息
+  retryCount?: number;
+  maxRetries?: number;
+  circuitBreaker?: boolean;
 }
 
 // 多智能体数据
@@ -67,6 +71,17 @@ export interface Message {
   isWelcome?: boolean;
   // 上下文压缩摘要
   compaction_summary?: string;
+  // Harness: LLM 重试/熔断事件
+  harness_events?: HarnessEvent[];
+}
+
+// Harness 事件（LLM 重试、熔断等）
+export interface HarnessEvent {
+  type: 'llm_retry' | 'llm_circuit_breaker' | 'tool_circuit_breaker' | 'subtask_retry';
+  attempt?: number;
+  maxRetries?: number;
+  error?: string;
+  round?: number;
 }
 
 export interface AgentInfo {

--- a/frontend/src/store/useResourceStore.ts
+++ b/frontend/src/store/useResourceStore.ts
@@ -16,7 +16,7 @@ export interface UploadQueueItem {
 }
 
 interface ResourceState {
-  // 资源数据
+  // 资产数据
   assets: AssetItem[];
   total: number;
   page: number;
@@ -29,7 +29,7 @@ interface ResourceState {
   uploadQueue: UploadQueueItem[];
 
   // Actions
-  fetchAssets: () => Promise<void>;
+  fetchAssets: (options?: { pageSize?: number; typeFilter?: FileTypeFilter }) => Promise<void>;
   loadMore: () => Promise<void>;
   setTypeFilter: (type: FileTypeFilter) => void;
   addUpload: (file: File) => void;
@@ -37,7 +37,7 @@ interface ResourceState {
   renameAsset: (id: string, name: string) => Promise<void>;
   replaceAssetFile: (id: string, file: File) => Promise<void>;
   deleteAsset: (id: string) => Promise<void>;
-  /** 从外部上传（如画布）同步新资源到 store */
+  /** 从外部上传（如画布）同步新资产到 store */
   syncAssetFromUpload: (asset: AssetItem | Record<string, unknown>) => void;
   reset: () => void;
 }
@@ -58,11 +58,12 @@ export const useResourceStore = create<ResourceState>((set, get) => ({
   hasMore: false,
   uploadQueue: [],
 
-  async fetchAssets() {
-    const { pageSize, typeFilter } = get();
+  async fetchAssets(options) {
+    const size = options?.pageSize ?? get().pageSize;
+    const filter = options?.typeFilter ?? get().typeFilter;
     set({ isLoading: true, page: 1 });
     try {
-      const res = await resourceApi.listAssets(1, pageSize, typeFilter);
+      const res = await resourceApi.listAssets(1, size, filter);
       set({
         assets: res.items,
         total: res.total,
@@ -115,7 +116,7 @@ export const useResourceStore = create<ResourceState>((set, get) => ({
       })
       .then((res) => {
         set((s) => ({
-          // 上传成功：将新资源添加到列表头部，移除上传队列项
+          // 上传成功：将新资产添加到列表头部，移除上传队列项
           assets: [res.asset, ...s.assets],
           total: s.total + 1,
           uploadQueue: s.uploadQueue.filter((q) => q.id !== id),


### PR DESCRIPTION
- 升级 lucide-react 依赖版本至 1.8.0
- 增加 asyncio 依赖导入
- 引入 chat_generation 中常量 MAX_LLM_RETRIES 和 RETRY_BACKOFF_SECONDS
- 优化管理员调试消息流式发送逻辑，支持多智能体与单智能体模式
- 修正调试会话消息反序列化与技能加载处理
- 调整工具调用和技能管理流程及事件推送细节
- 加强日志记录，添加多智能体调试及工具调用统计
- 确保调试消息及会话的数据库保存完整及异常捕获
- 改进删除调试会话接口，确保存储清理行为完整