### PR TITLE
feat(canvas): 增加音频节点支持并扩展分镜节点功能

### DIFF
--- a/backend/services/tool_manager/providers/canvas.py
+++ b/backend/services/tool_manager/providers/canvas.py
@@ -74,21 +74,31 @@ NODE_TYPE_INFO = {
         },
         "example": {"name": "开场动画", "description": "城市夜景转场", "videoUrl": "/media/xxx.mp4", "fitMode": "cover"}
     },
+    "audio": {
+        "description": "音频节点：用于背景音乐、音效、配音等音频内容。支持MP3/WAV/OGG格式。",
+        "fields": {
+            "name": "音频名称，字符串类型",
+            "description": "音频描述，字符串类型，包含风格、用途等信息",
+            "audioUrl": "音频URL地址，字符串类型，支持mp3/wav/ogg格式",
+            "lyrics": "歌词文本，字符串类型，可选"
+        },
+        "example": {"name": "背景音乐", "description": "城市夜景氛围音乐", "audioUrl": "/media/xxx.mp3"}
+    },
     "storyboard": {
-        "description": "分镜节点：用于分镜脚本、镜头设计等多维表格内容。支持自定义表格数据。",
+        "description": "分镜节点：用于分镜脚本、镜头设计等多维表格内容。支持自定义表格数据，支持在单元格内引用图片、视频、音频。",
         "fields": {
             "shotNumber": "镜头号，字符串类型，如'1-1', '2-3'",
             "description": "镜头描述，字符串类型，描述画面内容",
             "duration": "时长，整数类型，单位为秒",
-            "tableData": "表格数据行，数组类型，每个元素是一个对象代表一行数据。例如：[{\"scene\": \"城市夜景\", \"type\": \"全景\", \"duration\": 5}]",
-            "tableColumns": "表格列定义，数组类型，每个元素包含key(字段名)、label(显示名)、type(可选，text/number)。例如：[{\"key\": \"scene\", \"label\": \"场景\"}, {\"key\": \"type\", \"label\": \"类型\"}]"
+            "tableData": "表格数据行，数组类型，每个元素是一个对象代表一行数据。媒体列的值应为媒体URL路径（如'/api/media/xxx.jpg'）。例如：[{\"scene\": \"城市夜景\", \"type\": \"全景\", \"duration\": 5, \"ref_image\": \"/api/media/abc.jpg\"}]",
+            "tableColumns": "表格列定义，数组类型，每个元素包含key(字段名)、label(显示名)、type(列类型)。type支持: text(文本)、number(数字)、image(图片缩略图)、video(视频缩略图)、audio(音频播放器)。媒体类型列的值应为/api/media/路径或完整URL。例如：[{\"key\": \"scene\", \"label\": \"场景\", \"type\": \"text\"}, {\"key\": \"ref_image\", \"label\": \"参考图\", \"type\": \"image\"}]"
         },
         "example": {
             "shotNumber": "1-1",
             "description": "全景：城市夜景",
             "duration": 5,
-            "tableColumns": [{"key": "scene", "label": "场景", "type": "text"}, {"key": "type", "label": "镜头类型", "type": "text"}, {"key": "duration", "label": "时长", "type": "number"}],
-            "tableData": [{"scene": "城市夜景", "type": "全景", "duration": 5}, {"scene": "主角特写", "type": "近景", "duration": 3}]
+            "tableColumns": [{"key": "scene", "label": "场景", "type": "text"}, {"key": "type", "label": "镜头类型", "type": "text"}, {"key": "duration", "label": "时长", "type": "number"}, {"key": "ref_image", "label": "参考图", "type": "image"}],
+            "tableData": [{"scene": "城市夜景", "type": "全景", "duration": 5, "ref_image": "/api/media/example1.jpg"}, {"scene": "主角特写", "type": "近景", "duration": 3, "ref_image": "/api/media/example2.jpg"}]
         }
     }
 }
@@ -98,6 +108,7 @@ NODE_TYPE_SCHEMA = {
     "text":       {"title": str, "content": str, "tags": list},
     "image":      {"name": str, "description": str, "imageUrl": str, "fitMode": str},
     "video":      {"name": str, "description": str, "videoUrl": str, "fitMode": str},
+    "audio":      {"name": str, "description": str, "audioUrl": str, "lyrics": str},
     "storyboard": {"shotNumber": str, "description": str, "duration": int, "pivotConfig": Any, "tableData": Any, "tableColumns": Any},
 }
 
@@ -134,23 +145,19 @@ def _build_node_type_description() -> str:
 def _build_canvas_tool_defs(target_node_types: list[str]) -> list[dict]:
     migrated_types = [_migrate_node_type(t) for t in target_node_types] if target_node_types else []
     type_enum = migrated_types or list(NODE_TYPE_SCHEMA.keys())
-    node_type_desc = _build_node_type_description()
 
     return [
         {
             "type": "function",
             "function": {
                 "name": "list_canvas_nodes",
-                "description": (
-                    "列出画布上的所有节点。可以按节点类型筛选。"
-                    "返回节点摘要，包含id、类型、位置和关键数据字段。"
-                ),
+                "description": "列出画布上的所有节点，返回节点摘要列表。",
                 "parameters": {
                     "type": "object",
                     "properties": {
                         "node_type": {
                             "type": "string",
-                            "description": "按节点类型筛选，留空则列出所有可访问的节点。",
+                            "description": "按节点类型筛选，留空则列出全部。",
                             "enum": type_enum,
                         },
                     },
@@ -162,13 +169,13 @@ def _build_canvas_tool_defs(target_node_types: list[str]) -> list[dict]:
             "type": "function",
             "function": {
                 "name": "get_canvas_node",
-                "description": "获取指定节点的完整详情。返回节点的所有数据字段。",
+                "description": "获取指定节点的完整详情。",
                 "parameters": {
                     "type": "object",
                     "properties": {
                         "node_id": {
                             "type": "string",
-                            "description": "要获取的节点UUID。",
+                            "description": "节点UUID。",
                         },
                     },
                     "required": ["node_id"],
@@ -179,30 +186,26 @@ def _build_canvas_tool_defs(target_node_types: list[str]) -> list[dict]:
             "type": "function",
             "function": {
                 "name": "create_canvas_node",
-                "description": (
-                    "在画布上创建新节点。指定节点类型和数据。"
-                    "位置可选，如未提供则自动放置在现有节点右侧。\n\n"
-                    f"{node_type_desc}"
-                ),
+                "description": "在画布上创建新节点。字段结构参见 Skill 文档中的节点类型说明。",
                 "parameters": {
                     "type": "object",
                     "properties": {
                         "node_type": {
                             "type": "string",
-                            "description": "要创建的节点类型。",
+                            "description": "节点类型。",
                             "enum": type_enum,
                         },
                         "data": {
                             "type": "object",
-                            "description": "节点数据，根据节点类型提供相应字段。参考上方节点类型说明。",
+                            "description": "节点数据，按节点类型提供对应字段。",
                         },
                         "position_x": {
                             "type": "number",
-                            "description": "画布X坐标，可选。",
+                            "description": "X坐标，可选，省略则自动放置。",
                         },
                         "position_y": {
                             "type": "number",
-                            "description": "画布Y坐标，可选。",
+                            "description": "Y坐标，可选。",
                         },
                     },
                     "required": ["node_type", "data"],
@@ -213,20 +216,17 @@ def _build_canvas_tool_defs(target_node_types: list[str]) -> list[dict]:
             "type": "function",
             "function": {
                 "name": "update_canvas_node",
-                "description": (
-                    "更新现有节点的数据。只需提供要修改的字段，会与现有数据合并。\n\n"
-                    f"{node_type_desc}"
-                ),
+                "description": "更新节点数据，只需提供要修改的字段（增量合并）。",
                 "parameters": {
                     "type": "object",
                     "properties": {
                         "node_id": {
                             "type": "string",
-                            "description": "要更新的节点UUID。",
+                            "description": "节点UUID。",
                         },
                         "data": {
                             "type": "object",
-                            "description": "要更新的字段，会与现有数据合并。参考上方节点类型说明。",
+                            "description": "要更新的字段。",
                         },
                     },
                     "required": ["node_id", "data"],
@@ -237,13 +237,13 @@ def _build_canvas_tool_defs(target_node_types: list[str]) -> list[dict]:
             "type": "function",
             "function": {
                 "name": "delete_canvas_node",
-                "description": "从画布上删除节点。同时会删除与该节点相连的所有连线。",
+                "description": "删除节点及其所有关联连线。",
                 "parameters": {
                     "type": "object",
                     "properties": {
                         "node_id": {
                             "type": "string",
-                            "description": "要删除的节点UUID。",
+                            "description": "节点UUID。",
                         },
                     },
                     "required": ["node_id"],
@@ -254,7 +254,7 @@ def _build_canvas_tool_defs(target_node_types: list[str]) -> list[dict]:
             "type": "function",
             "function": {
                 "name": "list_canvas_edges",
-                "description": "列出画布上所有节点间的连线。返回连线的源节点、目标节点、连接点位置等信息。",
+                "description": "列出画布上所有连线。",
                 "parameters": {
                     "type": "object",
                     "properties": {},
@@ -266,34 +266,30 @@ def _build_canvas_tool_defs(target_node_types: list[str]) -> list[dict]:
             "type": "function",
             "function": {
                 "name": "create_canvas_edge",
-                "description": (
-                    "在两个节点之间创建连线。用于建立节点间的关联关系，如剧本与分镜的关联、"
-                    "角色与场景的关联等。每个节点有左右两个连接点：left-source/right-source（输出）"
-                    "和 left-target/right-target（输入）。建议从左节点的右连接点连到右节点的左连接点。"
-                ),
+                "description": "在两个节点之间创建连线。标准方向：source_handle='right-source', target_handle='left-target'。",
                 "parameters": {
                     "type": "object",
                     "properties": {
                         "source_node_id": {
                             "type": "string",
-                            "description": "源节点UUID（连线的起点）。",
+                            "description": "源节点UUID。",
                         },
                         "target_node_id": {
                             "type": "string",
-                            "description": "目标节点UUID（连线的终点）。",
+                            "description": "目标节点UUID。",
                         },
                         "source_handle": {
                             "type": "string",
-                            "description": "源节点的连接点位置。",
+                            "description": "源节点连接点。默认 'right-source'。",
                             "enum": ["left-source", "right-source"],
                         },
                         "target_handle": {
                             "type": "string",
-                            "description": "目标节点的连接点位置。",
+                            "description": "目标节点连接点。默认 'left-target'。",
                             "enum": ["left-target", "right-target"],
                         },
                     },
-                    "required": ["source_node_id", "target_node_id", "source_handle", "target_handle"],
+                    "required": ["source_node_id", "target_node_id"],
                 },
             },
         },
@@ -301,7 +297,7 @@ def _build_canvas_tool_defs(target_node_types: list[str]) -> list[dict]:
             "type": "function",
             "function": {
                 "name": "delete_canvas_edge",
-                "description": "删除画布上两个节点之间的连线。",
+                "description": "删除两个节点之间的连线。",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -339,6 +335,7 @@ def _node_summary(node: TheaterNode) -> dict:
         "text": ["title", "tags"],
         "image": ["name"],
         "video": ["name"],
+        "audio": ["name"],
         "storyboard": ["shotNumber", "description"],
     }
     key_fields = key_fields_map.get(node.node_type, [])

--- a/backend/services/tool_manager/providers/image_edit.py
+++ b/backend/services/tool_manager/providers/image_edit.py
@@ -388,14 +388,14 @@ async def _maybe_create_edit_node(
         )
         db.add(new_node)
 
-        # 创建连线：源节点 → 新节点（左侧输出 → 右侧输入）
+        # 创建连线：源节点右侧输出 → 新节点左侧输入
         edge = TheaterEdge(
             id=generate_uuid(),
             theater_id=theater_id,
             source_node_id=source.id,
             target_node_id=new_node.id,
-            source_handle="left-source",
-            target_handle="right-target",
+            source_handle="right-source",
+            target_handle="left-target",
             edge_type="custom",
             animated=True,
             style={},

--- a/backend/skills/active_skills/canvas_tools/SKILL.md
+++ b/backend/skills/active_skills/canvas_tools/SKILL.md
@@ -2,186 +2,229 @@
 name: canvas_tools
 description: "Canvas node and edge CRUD operations. Provides tools to manage theater canvas nodes and connections between them."
 metadata:
-  builtin_skill_version: "1.1"
+  builtin_skill_version: "1.2"
 ---
 # Canvas Tools
 
 Use this skill when the user asks to view, create, update, or delete content on the theater canvas (nodes and edges).
 
-Loading this skill activates the following tools:
+Loading this skill activates 8 tools across two categories:
 
-## Node Management
-- `list_canvas_nodes` — List all nodes on the canvas
-- `get_canvas_node` — Get full details of a specific node
-- `create_canvas_node` — Create a new node
-- `update_canvas_node` — Update an existing node
-- `delete_canvas_node` — Delete a node
+## Quick Reference
 
-## Edge (Connection) Management
-- `list_canvas_edges` — List all connections between nodes
-- `create_canvas_edge` — Create a connection between two nodes
-- `delete_canvas_edge` — Remove a connection between nodes
+| Tool | Purpose |
+|------|---------|
+| `list_canvas_nodes` | List all nodes (optionally filter by type) |
+| `get_canvas_node` | Get full node details by ID |
+| `create_canvas_node` | Create a new node |
+| `update_canvas_node` | Update node data (incremental merge) |
+| `delete_canvas_node` | Delete a node and its edges |
+| `list_canvas_edges` | List all edges |
+| `create_canvas_edge` | Connect two nodes |
+| `delete_canvas_edge` | Remove a connection |
 
-## Node Types
+---
 
-The canvas supports these node types (available types depend on agent configuration):
+## Node Types & Field Reference
 
-### text
-Text nodes for scripts, copy, ads, and other written content. Supports rich text (Markdown).
+Available node types depend on agent configuration. Below are all supported types and their data fields.
 
-Fields:
-- `title` (string, required) — Node title
-- `content` (string, Markdown) — Body text. Supports headings (#/##/###), paragraphs, bold (**text**), italic (*text*), code blocks, etc. Required when creating; omit when updating if unchanged.
-- `tags` (array, optional) — Tags for categorization
+### text — 文本节点
+For scripts, copy, ads, and written content. Supports Markdown.
 
-### image
-Image nodes for character designs, scenes, posters, and visual content.
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `title` | string | yes | Node title |
+| `content` | string | on create | Markdown body. Supports `#/##/###` headings, `**bold**`, `*italic*`, code blocks, lists. **Omit when updating if unchanged** to save tokens. |
+| `tags` | string[] | no | Tags for categorization |
 
-Fields:
-- `name` (string) — Image name
-- `description` (string) — Image description (scene, character info, etc.)
-- `imageUrl` (string) — Image URL path (e.g. `/media/xxx.jpg`), supports JPEG/PNG/JPG
-- `fitMode` (string) — "cover" (fill) or "contain" (fit)
+### image — 图像节点
+For character designs, scenes, posters, and visual content.
 
-### video
-Video nodes for animations, short films, and motion content.
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | yes | Image name |
+| `description` | string | yes | Scene/character description |
+| `imageUrl` | string | no | Image URL (e.g. `/api/media/xxx.jpg`). Supports JPEG/PNG/WebP. |
+| `fitMode` | string | no | `"cover"` (fill) or `"contain"` (fit) |
 
-Fields:
-- `name` (string) — Video name
-- `description` (string) — Video description (scene, duration, etc.)
-- `videoUrl` (string) — Video URL path (e.g. `/media/xxx.mp4`), supports MP4
-- `fitMode` (string) — "cover" (fill) or "contain" (fit)
+### video — 视频节点
+For animations, short films, and motion content.
 
-### storyboard
-Storyboard nodes for shot breakdowns and multi-dimensional table content.
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | yes | Video name |
+| `description` | string | yes | Scene/duration description |
+| `videoUrl` | string | no | Video URL (e.g. `/api/media/xxx.mp4`). Supports MP4. |
+| `fitMode` | string | no | `"cover"` (fill) or `"contain"` (fit) |
 
-Fields:
-- `shotNumber` (string) — Shot number (e.g. "1-1", "2-3")
-- `description` (string) — Shot description
-- `duration` (integer) — Duration in seconds
-- `pivotConfig` (JSON) — Multi-dimensional table config with custom field types
+### audio — 音频节点
+For background music, sound effects, voiceover, and audio content.
 
-## Tool: list_canvas_nodes
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | yes | Audio name |
+| `description` | string | yes | Style/purpose description |
+| `audioUrl` | string | no | Audio URL (e.g. `/api/media/xxx.mp3`). Supports MP3/WAV/OGG. |
+| `lyrics` | string | no | Lyrics text |
 
-List all nodes on the canvas, optionally filtered by type.
+### storyboard — 分镜/多维表格节点
+For shot breakdowns and multi-dimensional table content. **Supports embedding media (images, videos, audio) in table cells.**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `shotNumber` | string | no | Shot number (e.g. `"1-1"`, `"2-3"`) |
+| `description` | string | no | Shot description |
+| `duration` | integer | no | Duration in seconds |
+| `tableColumns` | array | yes (for table) | Column definitions. Each item: `{key, label, type}`. |
+| `tableData` | array | yes (for table) | Row data. Each item is an object matching column keys. |
+
+**Column `type` options:**
+- `"text"` — plain text cell
+- `"number"` — numeric cell
+- `"image"` — renders image thumbnail from URL; click to preview full-size
+- `"video"` — renders video thumbnail with play icon; click to preview
+- `"audio"` — renders audio play button; click to play in full-screen player
+
+Media cell values should be `/api/media/xxx.ext` paths or full URLs.
+
+**Example — storyboard with media columns:**
+```json
+{
+  "tableColumns": [
+    {"key": "scene", "label": "场景", "type": "text"},
+    {"key": "duration", "label": "时长", "type": "number"},
+    {"key": "ref_image", "label": "参考图", "type": "image"},
+    {"key": "ref_video", "label": "参考视频", "type": "video"},
+    {"key": "bgm", "label": "背景音乐", "type": "audio"}
+  ],
+  "tableData": [
+    {
+      "scene": "城市夜景",
+      "duration": 5,
+      "ref_image": "/api/media/abc.jpg",
+      "ref_video": "/api/media/xyz.mp4",
+      "bgm": "/api/media/music.mp3"
+    }
+  ]
+}
+```
+
+---
+
+## Tool Usage Guide
+
+### list_canvas_nodes
+
+List all nodes. Returns summaries with `id`, `node_type`, `position`, and key fields (e.g. `title` for text, `name` for image/video/audio, `shotNumber` for storyboard).
+
+**Always call this first** to understand what exists before creating or modifying.
 
 Parameters:
-- `node_type` (string, optional) — Filter by node type (e.g. "text", "image", "video", "storyboard")
+- `node_type` (string, optional) — filter by type
 
-Returns a list of node summaries (id, type, position, key fields).
+### get_canvas_node
 
-## Tool: get_canvas_node
-
-Get full details of a specific node.
+Get complete node data. Use when you need full field details (e.g. content text, media URLs, table data).
 
 Parameters:
-- `node_id` (string, required) — ID of the node to retrieve
+- `node_id` (string, required) — node UUID from `list_canvas_nodes`
 
-Returns complete node data including all fields, position, and metadata.
+### create_canvas_node
 
-## Tool: create_canvas_node
-
-Create a new node on the canvas.
+Create a new node. Position is auto-calculated (placed to the right of existing nodes) if omitted.
 
 Parameters:
-- `node_type` (string, required) — Type of node to create
-- `data` (object, required) — Node data matching the type's field schema
-- `position_x` (number, optional) — X position. Auto-calculated if omitted.
-- `position_y` (number, optional) — Y position. Auto-calculated if omitted.
+- `node_type` (string, required)
+- `data` (object, required) — fields matching the node type schema above
+- `position_x` (number, optional)
+- `position_y` (number, optional)
 
-Example — create a text node:
+**Examples:**
 ```
 create_canvas_node(
   node_type="text",
-  data={
-    "title": "Chapter 1 Outline",
-    "content": "# Chapter 1\n\nThe story begins...\n\n## Scene 1\n\nThe protagonist appears.",
-    "tags": ["outline", "chapter1"]
-  }
+  data={"title": "第一章", "content": "# 开头\n\n故事开始...", "tags": ["大纲"]}
 )
-```
 
-Example — create an image node:
-```
 create_canvas_node(
   node_type="image",
-  data={
-    "name": "Hero Portrait",
-    "description": "Main character, age 18, cheerful personality",
-    "imageUrl": "/media/generated-image.jpg",
-    "fitMode": "cover"
-  }
+  data={"name": "主角立绘", "description": "18岁，性格开朗"}
+)
+
+create_canvas_node(
+  node_type="audio",
+  data={"name": "背景音乐", "description": "城市夜景氛围钢琴曲"}
 )
 ```
 
-## Tool: update_canvas_node
+### update_canvas_node
 
-Update an existing node's data.
+Incremental merge — only provide fields you want to change. Unmentioned fields remain unchanged.
 
 Parameters:
-- `node_id` (string, required) — ID of the node to update
-- `data` (object, required) — Fields to update (partial update supported)
+- `node_id` (string, required)
+- `data` (object, required) — partial fields to update
 
-Example:
+**Example:**
 ```
 update_canvas_node(
-  node_id="node-uuid-here",
-  data={"title": "Updated Title", "tags": ["revised"]}
+  node_id="uuid-here",
+  data={"title": "修改后的标题", "tags": ["已修订"]}
 )
 ```
 
-## Tool: delete_canvas_node
+### delete_canvas_node
 
-Delete a node from the canvas.
-
-Parameters:
-- `node_id` (string, required) — ID of the node to delete
-
-## Tool: list_canvas_edges
-
-List all connections (edges) between nodes on the canvas.
-
-Returns a list of edges with source node ID, target node ID, and connection point positions.
-
-## Tool: create_canvas_edge
-
-Create a connection (edge) between two nodes to establish their relationship.
+Delete a node and automatically remove all connected edges.
 
 Parameters:
-- `source_node_id` (string, required) — UUID of the source node (where the connection starts)
-- `target_node_id` (string, required) — UUID of the target node (where the connection ends)
-- `source_handle` (string, required) — Connection point on the source node: `"left-source"` or `"right-source"`
-- `target_handle` (string, required) — Connection point on the target node: `"left-target"` or `"right-target"`
+- `node_id` (string, required)
 
-Connection points guide:
-- Each node has 4 connection points: left-source, left-target, right-source, right-target
-- Source handles (left-source, right-source): Use for the starting node of the connection
-- Target handles (left-target, right-target): Use for the ending node of the connection
-- Recommended pattern: Connect from a node's `right-source` to another node's `left-target` for left-to-right flow
+### list_canvas_edges
 
-Example — connect a script node to a storyboard node:
+List all connections. Returns `id`, `source_node_id`, `target_node_id`, `source_handle`, `target_handle`.
+
+Use before creating edges to avoid duplicates.
+
+### create_canvas_edge
+
+Connect two nodes. Canvas flows left-to-right.
+
+Parameters:
+- `source_node_id` (string, required) — starting node
+- `target_node_id` (string, required) — ending node
+- `source_handle` (string, optional) — `"right-source"` (default, recommended) or `"left-source"`
+- `target_handle` (string, optional) — `"left-target"` (default, recommended) or `"right-target"`
+
+**Standard direction:** `right-source` → `left-target` (left-to-right flow). Always use this unless the user specifically requests a different layout.
+
+**Example:**
 ```
 create_canvas_edge(
-  source_node_id="script-node-uuid",
-  target_node_id="storyboard-node-uuid",
+  source_node_id="script-uuid",
+  target_node_id="storyboard-uuid",
   source_handle="right-source",
   target_handle="left-target"
 )
 ```
 
-## Tool: delete_canvas_edge
+### delete_canvas_edge
 
 Remove a connection between two nodes.
 
 Parameters:
-- `source_node_id` (string, required) — UUID of the source node
-- `target_node_id` (string, required) — UUID of the target node
+- `source_node_id` (string, required)
+- `target_node_id` (string, required)
 
-## Tips
+---
 
-- Always use `list_canvas_nodes` first to see what exists before creating or modifying.
-- When creating nodes, omit position to let the system auto-place them.
-- Only include fields you want to change in `update_canvas_node`.
-- Node types are restricted by agent configuration — you can only create/access allowed types.
-- Use `create_canvas_edge` to establish visual and logical relationships between nodes (e.g., script → storyboard → video).
-- Check existing edges with `list_canvas_edges` before creating new connections to avoid duplicates.
+## Best Practices
+
+1. **Always list before mutating** — call `list_canvas_nodes` to see current state before creating, updating, or deleting.
+2. **Omit position** — let the system auto-place nodes unless the user specifies coordinates.
+3. **Minimal updates** — only include changed fields in `update_canvas_node` to minimize payload.
+4. **Check edges first** — use `list_canvas_edges` before creating connections to avoid duplicates.
+5. **Standard edge direction** — always use `right-source` → `left-target` for consistent left-to-right flow.
+6. **Media references in storyboard** — when referencing existing canvas media in a storyboard table, use `get_canvas_node` to retrieve the media URL, then set it as the cell value for the corresponding `image`/`video`/`audio` column type.
+7. **Node types are restricted** — you can only create/access node types allowed by the agent configuration.

--- a/frontend/src/app/theater/[id]/page.tsx
+++ b/frontend/src/app/theater/[id]/page.tsx
@@ -29,6 +29,7 @@ import CharacterNode from '@/components/canvas/CharacterNode';
 import StoryboardNode from '@/components/canvas/StoryboardNode';
 import VideoNode from '@/components/canvas/VideoNode';
 import AudioNode from '@/components/canvas/AudioNode';
+import GhostNode from '@/components/canvas/GhostNode';
 import { CustomEdge } from '@/components/canvas/CustomEdge';
 import { AIAssistantPanel } from '@/components/canvas/AIAssistantPanel';
 import { CanvasHints } from '@/components/canvas/CanvasCursor';
@@ -46,6 +47,7 @@ const nodeTypes = {
   storyboard: StoryboardNode,
   video: VideoNode,
   audio: AudioNode,
+  ghost: GhostNode,
 } as unknown as NodeTypes;
 
 const edgeTypes = {

--- a/frontend/src/components/ai-assistant/hooks/useSSEHandler.ts
+++ b/frontend/src/components/ai-assistant/hooks/useSSEHandler.ts
@@ -150,6 +150,15 @@ export function useSSEHandler() {
         const args = (data as { arguments?: Record<string, unknown> })?.arguments;
         state.toolCalls.push({ tool_name: toolName, arguments: args, status: 'executing' });
         state.roundHasTools = true;
+
+        // Ghost node: show skeleton placeholder when agent creates a canvas node
+        const canvasStore = useCanvasStore.getState();
+        (toolName === 'create_canvas_node' && args) && canvasStore.addGhostNode(
+          (args.node_type as string) || 'text',
+          args.position_x as number | undefined,
+          args.position_y as number | undefined,
+        );
+
         setMessages((prev) => {
           const last = prev[prev.length - 1];
           if (last?.role === 'ai' && last?.status === 'streaming') {

--- a/frontend/src/components/canvas/GhostNode.tsx
+++ b/frontend/src/components/canvas/GhostNode.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { memo } from 'react';
+import { NodeProps, Node } from '@xyflow/react';
+import { FileText, Image, Film, Music, Clapperboard, Sparkles } from 'lucide-react';
+import { GhostNodeData } from '@/store/useCanvasStore';
+
+const TYPE_CONFIG: Record<string, { icon: typeof FileText; color: string; label: string }> = {
+  text: { icon: FileText, color: 'text-indigo-400', label: '文本卡' },
+  image: { icon: Image, color: 'text-emerald-400', label: '图片卡' },
+  video: { icon: Film, color: 'text-purple-400', label: '视频卡' },
+  audio: { icon: Music, color: 'text-amber-400', label: '音频卡' },
+  storyboard: { icon: Clapperboard, color: 'text-amber-400', label: '分镜卡' },
+};
+
+const DEFAULT_CONFIG = { icon: FileText, color: 'text-muted-foreground', label: '节点' };
+
+// Dimensions must match addGhostNode in useCanvasStore
+const GHOST_DIMENSIONS: Record<string, { width: number; height: number }> = {
+  text: { width: 400, height: 300 },
+  image: { width: 512, height: 384 },
+  video: { width: 512, height: 384 },
+  audio: { width: 360, height: 200 },
+  storyboard: { width: 398, height: 256 },
+};
+
+const GhostNode = memo(({ data }: NodeProps<Node<GhostNodeData>>) => {
+  const nodeType = data.targetNodeType || 'text';
+  const config = TYPE_CONFIG[nodeType] || DEFAULT_CONFIG;
+  const Icon = config.icon;
+  const dims = GHOST_DIMENSIONS[nodeType] || { width: 420, height: 300 };
+
+  return (
+    <div
+      className="rounded-xl border-2 border-dashed border-primary/30 bg-card/80 backdrop-blur-sm overflow-hidden relative"
+      style={{ width: dims.width, height: dims.height }}
+    >
+      {/* Shimmer overlay */}
+      <div
+        className="absolute inset-0 animate-ghost-shimmer"
+        style={{
+          background: 'linear-gradient(90deg, transparent 0%, hsl(var(--primary) / 0.08) 50%, transparent 100%)',
+          backgroundSize: '200% 100%',
+        }}
+      />
+
+      {/* Pulse ring */}
+      <div className="absolute inset-0 rounded-xl animate-ghost-pulse" />
+
+      {/* Content */}
+      <div className="relative z-10 flex flex-col items-center justify-center h-full gap-3">
+        <div className="relative">
+          <Icon className={`w-10 h-10 ${config.color} opacity-60`} />
+          <Sparkles className="w-4 h-4 text-primary absolute -top-1 -right-1 animate-pulse" />
+        </div>
+        <div className="text-center">
+          <p className="text-sm font-medium text-foreground/70">AI 正在创建</p>
+          <p className="text-xs text-muted-foreground mt-0.5">{config.label}</p>
+        </div>
+        {/* Loading dots */}
+        <div className="flex gap-1.5">
+          {[0, 150, 300].map((delay) => (
+            <span
+              key={delay}
+              className="w-1.5 h-1.5 rounded-full bg-primary/50 animate-ghost-dot"
+              style={{ animationDelay: `${delay}ms` }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+});
+
+GhostNode.displayName = 'GhostNode';
+
+export default GhostNode;

--- a/frontend/src/components/canvas/StoryboardNode.tsx
+++ b/frontend/src/components/canvas/StoryboardNode.tsx
@@ -2,16 +2,28 @@
 import { memo, useCallback, useMemo, useState } from 'react';
 import { Handle, Position, NodeProps, Node, useReactFlow, NodeResizer } from '@xyflow/react';
 import { Card, CardContent } from '@/components/ui/card';
-import { Clapperboard, Trash2, Copy } from 'lucide-react';
+import { Clapperboard, Trash2, Copy, Image, Film, Music, Play, X } from 'lucide-react';
 import { useCanvasStore, StoryboardNodeData, CanvasNode } from '@/store/useCanvasStore';
 import { NodeToolbar, ToolbarAction } from './NodeToolbar';
 import { v4 as uuidv4 } from 'uuid';
+
+/** Ensure media URL has /api/media/ prefix */
+const normalizeMediaUrl = (url: string | null | undefined): string | null => {
+  const u = url?.toString().trim();
+  return !u ? null
+    : (u.startsWith('http') || u.startsWith('/api/media/') || u.startsWith('data:') || u.startsWith('blob:'))
+      ? u : `/api/media/${u}`;
+};
+
+type ColType = 'text' | 'number' | 'image' | 'video' | 'audio';
+const MEDIA_TYPES = new Set<ColType>(['image', 'video', 'audio']);
 
 const StoryboardNode = ({ id, data, selected }: NodeProps<Node<StoryboardNodeData>>) => {
   const updateNodeData = useCanvasStore((state) => state.updateNodeData);
   const deleteNode = useCanvasStore((state) => state.deleteNode);
   const addNode = useCanvasStore((state) => state.addNode);
   const [isEditing, setIsEditing] = useState(false);
+  const [previewMedia, setPreviewMedia] = useState<{ type: ColType; url: string } | null>(null);
   const { getNode } = useReactFlow();
 
   const handleDelete = (e: React.MouseEvent) => {
@@ -40,16 +52,16 @@ const StoryboardNode = ({ id, data, selected }: NodeProps<Node<StoryboardNodeDat
     }
   };
 
-  // Extract table data
+  // Extract table data (preserve column type for media rendering)
   const tableInfo = useMemo(() => {
     const td = data.tableData;
     const tc = data.tableColumns;
     const hasTableData = Array.isArray(td) && td.length > 0;
     const hasTableCols = Array.isArray(tc) && tc.length > 0;
-    const columns: { key: string; label: string }[] = hasTableCols
-      ? tc.map((c: any) => ({ key: c.key, label: c.label || c.key }))
+    const columns: { key: string; label: string; type: ColType }[] = hasTableCols
+      ? tc.map((c: any) => ({ key: c.key, label: c.label || c.key, type: (c.type as ColType) || 'text' }))
       : hasTableData
-        ? Object.keys(td[0]).filter(k => k !== 'key').map(k => ({ key: k, label: k }))
+        ? Object.keys(td[0]).filter(k => k !== 'key').map(k => ({ key: k, label: k, type: 'text' as ColType }))
         : [];
     return { columns, rows: hasTableData ? td : [], total: hasTableData ? td.length : 0 };
   }, [data.tableData, data.tableColumns]);
@@ -127,8 +139,13 @@ const StoryboardNode = ({ id, data, selected }: NodeProps<Node<StoryboardNodeDat
                     <thead>
                       <tr className="bg-muted/60 border-b border-border sticky top-0 z-[1]">
                         {tableInfo.columns.map(col => (
-                          <th key={col.key} className="px-3 py-2 text-left font-medium text-muted-foreground max-w-[180px] bg-muted/60">
-                            {col.label}
+                          <th key={col.key} className={`px-3 py-2 text-left font-medium text-muted-foreground bg-muted/60 ${MEDIA_TYPES.has(col.type) ? 'w-[120px] min-w-[120px]' : 'max-w-[180px]'}`}>
+                            <span className="flex items-center gap-1">
+                              {col.type === 'image' && <Image className="w-3 h-3 shrink-0" />}
+                              {col.type === 'video' && <Film className="w-3 h-3 shrink-0" />}
+                              {col.type === 'audio' && <Music className="w-3 h-3 shrink-0" />}
+                              <span className="truncate">{col.label}</span>
+                            </span>
                           </th>
                         ))}
                       </tr>
@@ -136,17 +153,79 @@ const StoryboardNode = ({ id, data, selected }: NodeProps<Node<StoryboardNodeDat
                     <tbody>
                       {tableInfo.rows.map((row: any, i: number) => (
                         <tr key={i} className="border-b border-border/30 last:border-0 hover:bg-muted/20">
-                          {tableInfo.columns.map(col => (
-                            <td
-                              key={col.key}
-                              className={`px-3 py-1.5 max-w-[180px] text-foreground/80 ${isEditing ? 'cursor-text' : 'cursor-default select-none'}`}
-                              contentEditable={isEditing}
-                              suppressContentEditableWarning
-                              onBlur={(e) => handleCellBlur(i, col.key, e.currentTarget.textContent || '')}
-                            >
-                              {row[col.key] != null ? String(row[col.key]) : ''}
-                            </td>
-                          ))}
+                          {tableInfo.columns.map(col => {
+                            const isMedia = MEDIA_TYPES.has(col.type);
+                            const rawValue = row[col.key];
+                            const mediaUrl = isMedia ? normalizeMediaUrl(rawValue as string) : null;
+
+                            // --- Media cell: image ---
+                            return col.type === 'image' ? (
+                              <td key={col.key} className="px-2 py-1.5 w-[120px] min-w-[120px]">
+                                {mediaUrl ? (
+                                  <button
+                                    className="block w-32 h-32 rounded-md overflow-hidden border border-border/40 bg-muted/30 cursor-pointer hover:ring-2 hover:ring-primary/40 hover:shadow-md transition-all"
+                                    onClick={() => setPreviewMedia({ type: 'image', url: mediaUrl })}
+                                    onPointerDown={(e) => e.stopPropagation()}
+                                  >
+                                    <img src={mediaUrl} alt="" className="w-full h-full object-cover" loading="lazy" />
+                                  </button>
+                                ) : (
+                                  <div className="w-32 h-16 rounded-md border border-dashed border-border/40 bg-muted/20 flex items-center justify-center">
+                                    <Image className="w-5 h-5 text-muted-foreground/30" />
+                                  </div>
+                                )}
+                              </td>
+                            ) : col.type === 'video' ? (
+                              <td key={col.key} className="px-2 py-1.5 w-[120px] min-w-[120px]">
+                                {mediaUrl ? (
+                                  <button
+                                    className="relative block w-32 h-32 rounded-md overflow-hidden border border-border/40 bg-black cursor-pointer hover:ring-2 hover:ring-primary/40 hover:shadow-md transition-all group/vid"
+                                    onClick={() => setPreviewMedia({ type: 'video', url: mediaUrl })}
+                                    onPointerDown={(e) => e.stopPropagation()}
+                                  >
+                                    <video src={mediaUrl} className="w-full h-full object-cover" muted preload="metadata" />
+                                    <div className="absolute inset-0 flex items-center justify-center bg-black/30 group-hover/vid:bg-black/15 transition-colors">
+                                      <Play className="w-5 h-5 text-white/90 fill-white/90" />
+                                    </div>
+                                  </button>
+                                ) : (
+                                  <div className="w-32 h-32 rounded-md border border-dashed border-border/40 bg-muted/20 flex items-center justify-center">
+                                    <Film className="w-5 h-5 text-muted-foreground/30" />
+                                  </div>
+                                )}
+                              </td>
+                            ) : col.type === 'audio' ? (
+                              <td key={col.key} className="px-2 py-1.5 w-[120px] min-w-[120px]">
+                                {mediaUrl ? (
+                                  <button
+                                    className="flex items-center gap-2 w-32 h-32 rounded-md border border-border/40 bg-amber-500/5 cursor-pointer hover:ring-2 hover:ring-primary/40 hover:shadow-md transition-all px-2"
+                                    onClick={() => setPreviewMedia({ type: 'audio', url: mediaUrl })}
+                                    onPointerDown={(e) => e.stopPropagation()}
+                                  >
+                                    <div className="w-8 h-8 rounded-full bg-amber-500/15 flex items-center justify-center shrink-0">
+                                      <Play className="w-3.5 h-3.5 text-amber-500 fill-amber-500" />
+                                    </div>
+                                    <span className="text-[10px] text-muted-foreground leading-tight truncate">播放</span>
+                                  </button>
+                                ) : (
+                                  <div className="w-24 h-16 rounded-md border border-dashed border-border/40 bg-muted/20 flex items-center justify-center">
+                                    <Music className="w-5 h-5 text-muted-foreground/30" />
+                                  </div>
+                                )}
+                              </td>
+                            ) : (
+                              /* --- Text / Number cell --- */
+                              <td
+                                key={col.key}
+                                className={`px-3 py-1.5 max-w-[180px] text-foreground/80 ${isEditing ? 'cursor-text' : 'cursor-default select-none'}`}
+                                contentEditable={isEditing}
+                                suppressContentEditableWarning
+                                onBlur={(e) => handleCellBlur(i, col.key, e.currentTarget.textContent || '')}
+                              >
+                                {rawValue != null ? String(rawValue) : ''}
+                              </td>
+                            );
+                          })}
                         </tr>
                       ))}
                     </tbody>
@@ -160,6 +239,44 @@ const StoryboardNode = ({ id, data, selected }: NodeProps<Node<StoryboardNodeDat
               )}
           </CardContent>
         </Card>
+
+        {/* 媒体全屏预览弹窗 */}
+        {previewMedia && (
+          <div
+            className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/70 backdrop-blur-sm nodrag"
+            onClick={() => setPreviewMedia(null)}
+            onPointerDown={(e) => e.stopPropagation()}
+          >
+            <button
+              className="absolute top-4 right-4 p-2 rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors cursor-pointer z-10"
+              onClick={() => setPreviewMedia(null)}
+            >
+              <X className="w-5 h-5" />
+            </button>
+            <div className="max-w-[85vw] max-h-[85vh] flex items-center justify-center" onClick={(e) => e.stopPropagation()}>
+              {previewMedia.type === 'image' && (
+                <img src={previewMedia.url} alt="" className="max-w-full max-h-[85vh] rounded-lg shadow-2xl object-contain" />
+              )}
+              {previewMedia.type === 'video' && (
+                <video src={previewMedia.url} controls autoPlay className="max-w-full max-h-[85vh] rounded-lg shadow-2xl" />
+              )}
+              {previewMedia.type === 'audio' && (
+                <div className="flex flex-col items-center gap-6 p-10 rounded-2xl bg-card/95 shadow-2xl border border-border/30">
+                  <div className="w-20 h-20 rounded-full bg-amber-500/15 flex items-center justify-center">
+                    <Music className="w-10 h-10 text-amber-500" />
+                  </div>
+                  <audio
+                    src={previewMedia.url}
+                    controls
+                    autoPlay
+                    className="w-80 nodrag"
+                    onPointerDown={(e) => e.stopPropagation()}
+                  />
+                </div>
+              )}
+            </div>
+          </div>
+        )}
 
         {/* 工具条 */}
         <NodeToolbar

--- a/frontend/src/store/useCanvasStore.ts
+++ b/frontend/src/store/useCanvasStore.ts
@@ -48,7 +48,7 @@ export type StoryboardNodeData = {
   pivotConfig?: any; // From PivotConfig in types.ts
   pivotData?: any; // Cached or computed data
   tableData?: Record<string, unknown>[]; // Raw table rows provided by Agent
-  tableColumns?: { key: string; label: string; type?: string }[]; // Column definitions from Agent
+  tableColumns?: { key: string; label: string; type?: 'text' | 'number' | 'image' | 'video' | 'audio' }[]; // Column definitions from Agent
 };
 
 export type VideoNodeData = {
@@ -67,7 +67,12 @@ export type AudioNodeData = {
   lyrics?: string;
 };
 
-export type CanvasNode = Node<ScriptNodeData | CharacterNodeData | StoryboardNodeData | VideoNodeData | AudioNodeData>;
+export type GhostNodeData = {
+  targetNodeType: string;  // The node type being created (text/image/video/audio/storyboard)
+  label?: string;
+};
+
+export type CanvasNode = Node<ScriptNodeData | CharacterNodeData | StoryboardNodeData | VideoNodeData | AudioNodeData | GhostNodeData>;
 
 interface HistoryState {
   nodes: CanvasNode[];
@@ -122,6 +127,10 @@ interface CanvasState {
   snapToGuides: boolean;
   setSnapToGrid: (snap: boolean) => void;
   setSnapToGuides: (snap: boolean) => void;
+
+  // Ghost nodes (AI creating animation)
+  addGhostNode: (nodeType: string, positionX?: number, positionY?: number) => void;
+  removeGhostNodes: () => void;
 }
 
 const MAX_HISTORY = 50;
@@ -477,8 +486,10 @@ export const useCanvasStore = create<CanvasState>()(
           }
 
           if (nodesChanged || edgesChanged) {
+            // Remove ghost nodes when real nodes arrive from backend
+            const finalNodes = nodesChanged ? mergedNodes.filter((n) => n.type !== 'ghost') : undefined;
             set({
-              ...(nodesChanged ? { nodes: mergedNodes } : {}),
+              ...(nodesChanged ? { nodes: finalNodes! } : {}),
               ...(edgesChanged ? { edges: mergedEdges } : {}),
               // We intentionally do NOT overwrite viewport to preserve user zoom/scroll
             });
@@ -500,7 +511,7 @@ export const useCanvasStore = create<CanvasState>()(
           await theaterApi.updateTheater(theaterId, { title: theaterTitle });
 
           const detail = await theaterApi.saveCanvas(theaterId, {
-            nodes: nodes.map(nodeToApi),
+            nodes: nodes.filter((n) => n.type !== 'ghost').map(nodeToApi),
             edges: edges.map(edgeToApi),
             canvas_viewport: viewport as Record<string, number>,
           });
@@ -521,6 +532,50 @@ export const useCanvasStore = create<CanvasState>()(
 
       markDirty: () => {
         set({ isDirty: true });
+      },
+
+      // Ghost node default dimensions by target type
+      addGhostNode: (nodeType: string, positionX?: number, positionY?: number) => {
+        const GHOST_DIMENSIONS: Record<string, { width: number; height: number }> = {
+          text: { width: 400, height: 300 },
+          image: { width: 512, height: 384 },
+          video: { width: 512, height: 384 },
+          audio: { width: 360, height: 200 },
+          storyboard: { width: 398, height: 256 },
+        };
+        const dims = GHOST_DIMENSIONS[nodeType] || { width: 420, height: 300 };
+
+        // Estimate position: replicate backend _calculate_auto_position logic
+        // when agent doesn't provide explicit coordinates
+        let finalX = positionX;
+        let finalY = positionY;
+        const needsAutoPosition = finalX == null || finalY == null;
+        const { nodes } = get();
+        const realNodes = nodes.filter((n) => n.type !== 'ghost');
+        const AUTO_X_OFFSET = 460;
+        const maxX = realNodes.reduce((max, n) => Math.max(max, n.position.x), -Infinity);
+        const autoX = realNodes.length > 0 ? maxX + AUTO_X_OFFSET : 100;
+        finalX = finalX ?? autoX;
+        finalY = finalY ?? (needsAutoPosition ? 100 : 100);
+
+        const ghostId = `ghost-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        const ghostNode: CanvasNode = {
+          id: ghostId,
+          type: 'ghost',
+          position: { x: finalX, y: finalY },
+          width: dims.width,
+          height: dims.height,
+          selectable: false,
+          draggable: false,
+          data: { targetNodeType: nodeType } as GhostNodeData,
+        };
+        set({ nodes: [...nodes, ghostNode] });
+      },
+
+      removeGhostNodes: () => {
+        const { nodes } = get();
+        const filtered = nodes.filter((n) => n.type !== 'ghost');
+        (filtered.length !== nodes.length) && set({ nodes: filtered });
       },
     }),
     {

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -55,7 +55,26 @@ const config: Config = {
   			lg: 'var(--radius)',
   			md: 'calc(var(--radius) - 2px)',
   			sm: 'calc(var(--radius) - 4px)'
-  		}
+  		},
+  		keyframes: {
+  			'ghost-shimmer': {
+  				'0%': { backgroundPosition: '200% 0' },
+  				'100%': { backgroundPosition: '-200% 0' },
+  			},
+  			'ghost-pulse': {
+  				'0%, 100%': { boxShadow: 'inset 0 0 0 1px hsl(var(--primary) / 0.1)' },
+  				'50%': { boxShadow: 'inset 0 0 0 2px hsl(var(--primary) / 0.3)' },
+  			},
+  			'ghost-dot': {
+  				'0%, 80%, 100%': { opacity: '0.3', transform: 'scale(0.8)' },
+  				'40%': { opacity: '1', transform: 'scale(1.2)' },
+  			},
+  		},
+  		animation: {
+  			'ghost-shimmer': 'ghost-shimmer 2s ease-in-out infinite',
+  			'ghost-pulse': 'ghost-pulse 2s ease-in-out infinite',
+  			'ghost-dot': 'ghost-dot 1s ease-in-out infinite',
+  		},
   	}
   },
   plugins: [require("tailwindcss-animate")],


### PR DESCRIPTION
- 新增音频节点类型，支持背景音乐、音效、配音等，字段包含音频URL和歌词
- 分镜节点支持多媒体列，允许在表格单元格内引用图片、视频、音频资源
- 分镜节点表格列类型扩展，新增image/video/audio三种多媒体展示类型
- 精简新增工具函数，更新画布节点相关的功能定义文本描述
- 节点摘要和完整信息获取支持新的音频节点数据字段
- 修正部分节点描述字段及示例内容以配合新节点类型需求