### PR TITLE
refactor(backend): 移除 NarrativeEngine 相关代码，简化后端代理逻辑

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -293,95 +293,12 @@ class NarrativeEngine:
             print(f"AgentScope init error: {e}")
             return
 
-        # Re-create agents with new config
-        self._create_agents()
         self.initialized = True
-
-    def _create_agents(self):
-        self.director = DialogAgent(
-            name="Director",
-            sys_prompt="You are the Director of an interactive story. Your goal is to guide the narrative, ensuring consistency and engagement. You decide the flow and verify plot points.",
-            model=self.current_model
-        )
-        
-        self.narrator = DialogAgent(
-            name="Narrator",
-            sys_prompt="You are the Narrator. You generate immersive, descriptive text based on the Director's outline. Focus on sensory details and character emotions.",
-            model=self.current_model
-        )
-        
-        self.npc_manager = DialogAgent(
-            name="NPC_Manager",
-            sys_prompt="You manage the NPCs. You track their relationships with the player and determine their reactions based on affinity, trust, and hidden traits.",
-            model=self.current_model
-        )
 
     async def reload_config(self, db_session):
         """Method to trigger a reload of configuration from the API"""
         await self.load_config_from_db(db_session)
 
-    async def generate_chapter(self, player_context: dict, previous_summary: str):
-        if not self.initialized:
-            # Try to lazy load from DB if not initialized
-            await self.load_config_from_db()
-            
-            if not self.initialized:
-                 return {
-                    "outline": "Error: AI Engine not initialized (Missing Active Provider)",
-                    "content": "The story cannot proceed without the AI engine. Please configure an LLM Provider in the admin panel.",
-                    "npc_updates": "{}",
-                    "usage": {"input_tokens": 0, "output_tokens": 0, "input_chars": 0, "output_chars": 0}
-                }
-
-        # 1. Director outlines the chapter
-        outline_msg = self.director(Msg(
-            name="System", 
-            content=f"Create an outline for the next chapter based on: {previous_summary}. Player context: {player_context}"
-        ))
-        if asyncio.iscoroutine(outline_msg):
-            outline_msg = await outline_msg
-        
-        # 2. Narrator fleshes it out
-        story_msg = self.narrator(outline_msg)
-        if asyncio.iscoroutine(story_msg):
-            story_msg = await story_msg
-        
-        # 3. NPC Manager updates state (simulated for now)
-        npc_update = self.npc_manager(Msg(
-            name="System",
-            content=f"Analyze the story: {story_msg.content}. Update NPC relationships."
-        ))
-        if asyncio.iscoroutine(npc_update):
-            npc_update = await npc_update
-        
-        # 汇总所有agent的token统计
-        all_msgs = [outline_msg, story_msg, npc_update]
-        total_input_tokens = sum(m.metadata.get("input_tokens", 0) for m in all_msgs)
-        total_output_tokens = sum(m.metadata.get("output_tokens", 0) for m in all_msgs)
-        total_input_chars = sum(m.metadata.get("input_chars", 0) for m in all_msgs)
-        total_output_chars = sum(m.metadata.get("output_chars", 0) for m in all_msgs)
-        
-        # 日志输出
-        logger.info(f"\n{'='*60}")
-        logger.info(f"NarrativeEngine Chapter Generation Complete")
-        logger.info(f"Director tokens: {outline_msg.metadata.get('input_tokens', 0)} in / {outline_msg.metadata.get('output_tokens', 0)} out")
-        logger.info(f"Narrator tokens: {story_msg.metadata.get('input_tokens', 0)} in / {story_msg.metadata.get('output_tokens', 0)} out")
-        logger.info(f"NPC Manager tokens: {npc_update.metadata.get('input_tokens', 0)} in / {npc_update.metadata.get('output_tokens', 0)} out")
-        logger.info(f"Total: {total_input_tokens} in / {total_output_tokens} out = {total_input_tokens + total_output_tokens} tokens")
-        logger.info(f"Chars: {total_input_chars} in / {total_output_chars} out = {total_input_chars + total_output_chars} chars")
-        logger.info(f"{'='*60}\n")
-        
-        return {
-            "outline": outline_msg.content,
-            "content": story_msg.content,
-            "npc_updates": npc_update.content,
-            "usage": {
-                "input_tokens": total_input_tokens,
-                "output_tokens": total_output_tokens,
-                "input_chars": total_input_chars,
-                "output_chars": total_output_chars,
-            }
-        }
 
 narrative_engine = NarrativeEngine()
 # Note: Initial loading happens when needed or triggered by startup event

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -548,10 +548,10 @@ body {
   }
 }
 
-/* React Flow 自定义光标样式 - 使用 !important 覆盖默认样式 */
+/* React Flow 光标样式 - 使用系统默认光标 */
 .react-flow__pane,
 .react-flow__pane.react-flow__pane {
-  cursor: crosshair !important;
+  cursor: default !important;
 }
 
 .react-flow__pane.dragging,
@@ -561,12 +561,12 @@ body {
 
 /* 框选时的选区样式 */
 .react-flow__pane.selecting {
-  cursor: crosshair !important;
+  cursor: default !important;
 }
 
 /* 禁用默认的 grab 光标 */
 .react-flow__pane[data-no-drag="true"] {
-  cursor: crosshair !important;
+  cursor: default !important;
 }
 
 /* 框选时的选区样式 */

--- a/frontend/src/app/theater/[id]/hooks/useCanvasDragDrop.ts
+++ b/frontend/src/app/theater/[id]/hooks/useCanvasDragDrop.ts
@@ -1,47 +1,77 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { useReactFlow } from '@xyflow/react';
 import { v4 as uuidv4 } from 'uuid';
 import { useCanvasStore, CanvasNode } from '@/store/useCanvasStore';
+import { useFileDragDrop, type FileType } from './useFileDragDrop';
 
-export function useCanvasDragDrop(snapToGrid: boolean) {
+// Default dimensions by node type (for internal drag from sidebar/asset library)
+const defaultDimensions: Record<string, { width: number; height: number }> = {
+  text: { width: 400, height: 300 },
+  image: { width: 512, height: 384 },
+  video: { width: 512, height: 384 },
+  audio: { width: 360, height: 200 },
+  storyboard: { width: 398, height: 256 },
+};
+
+export function useCanvasDragDrop(wrapperRef: React.RefObject<HTMLDivElement | null>) {
   const { screenToFlowPosition } = useReactFlow();
   const { addNode } = useCanvasStore();
 
+  // File drag drop (external files from OS)
+  const fileDrag = useFileDragDrop(wrapperRef);
+
   const onDragOver = useCallback((event: React.DragEvent) => {
     event.preventDefault();
-    event.dataTransfer.dropEffect = 'move';
-  }, []);
+
+    const hasReactFlowData = event.dataTransfer.types.includes('application/reactflow');
+    const hasFiles = event.dataTransfer.types.includes('Files');
+
+    // Priority: internal node drag > external file drag
+    const handlers: Record<string, () => void> = {
+      internal: () => {
+        event.dataTransfer.dropEffect = 'move';
+        fileDrag.resetDragState();
+      },
+      external: () => {
+        event.dataTransfer.dropEffect = 'copy';
+        fileDrag.onFileDragOver(event);
+      },
+      default: () => {
+        event.dataTransfer.dropEffect = 'move';
+      },
+    };
+
+    const key = hasReactFlowData ? 'internal' : hasFiles ? 'external' : 'default';
+    handlers[key]();
+  }, [fileDrag]);
+
+  const onDragLeave = useCallback((event: React.DragEvent) => {
+    fileDrag.onFileDragLeave(event);
+  }, [fileDrag]);
 
   const onDrop = useCallback(
     (event: React.DragEvent) => {
       event.preventDefault();
+      fileDrag.resetDragState();
 
+      // Check internal drag first (sidebar/asset library)
       const type = event.dataTransfer.getData('application/reactflow');
+
+      // No internal drag data - check for external file drop
+      if (!type) {
+        const files = event.dataTransfer.files;
+        files.length > 0 && fileDrag.handleFileDrop(files, event.clientX, event.clientY);
+        return;
+      }
+
+      // Handle internal node drag
       const dataStr = event.dataTransfer.getData('application/reactflow-data');
       const dimensionsStr = event.dataTransfer.getData('application/reactflow-dimensions');
-      
-      if (!type) return;
 
       const position = screenToFlowPosition({
         x: event.clientX,
         y: event.clientY,
       });
-
-      // Snap to grid for dropped nodes if enabled
-      if (snapToGrid) {
-        position.x = Math.round(position.x / 20) * 20;
-        position.y = Math.round(position.y / 20) * 20;
-      }
-
-      // Dimension defaults by type (avoids if-else chain)
-      const defaultDimensions: Record<string, { width: number; height: number }> = {
-        text: { width: 420, height: 320 },
-        image: { width: 512, height: 384 },
-        character: { width: 512, height: 384 },
-        video: { width: 512, height: 384 },
-        audio: { width: 360, height: 200 },
-        storyboard: { width: 398, height: 256 },
-      };
 
       let width: number | undefined;
       let height: number | undefined;
@@ -67,8 +97,16 @@ export function useCanvasDragDrop(snapToGrid: boolean) {
 
       addNode(newNode);
     },
-    [screenToFlowPosition, addNode, snapToGrid]
+    [screenToFlowPosition, addNode, fileDrag]
   );
 
-  return { onDragOver, onDrop };
+  return {
+    onDragOver,
+    onDragLeave,
+    onDrop,
+    // Expose file drag state for overlay UI
+    isDraggingFile: fileDrag.isDraggingFile,
+    dragFileType: fileDrag.dragFileType,
+    dragPosition: fileDrag.dragPosition,
+  };
 }

--- a/frontend/src/app/theater/[id]/hooks/useCanvasShortcuts.ts
+++ b/frontend/src/app/theater/[id]/hooks/useCanvasShortcuts.ts
@@ -1,25 +1,54 @@
 import { useEffect } from 'react';
+import { useReactFlow } from '@xyflow/react';
 import { useCanvasStore } from '@/store/useCanvasStore';
 
 export function useCanvasShortcuts() {
-  const { undo, redo } = useCanvasStore();
+  const { undo, redo, saveToBackend } = useCanvasStore();
+  const { zoomIn, zoomOut, fitView } = useReactFlow();
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      // Undo: Ctrl + Z
-      if ((event.ctrlKey || event.metaKey) && !event.shiftKey && event.key === 'z') {
-        event.preventDefault();
-        undo();
-      }
-      
-      // Redo: Ctrl + Y or Ctrl + Shift + Z
-      if ((event.ctrlKey || event.metaKey) && (event.key === 'y' || (event.shiftKey && event.key === 'z'))) {
-        event.preventDefault();
-        redo();
-      }
+      const mod = event.ctrlKey || event.metaKey;
+
+      // Key-action mapping (avoids if-chain)
+      const actions: Array<{ match: () => boolean; action: () => void }> = [
+        // Save: Ctrl + S
+        {
+          match: () => mod && event.key === 's',
+          action: () => saveToBackend().catch(console.error),
+        },
+        // Undo: Ctrl + Z (no shift)
+        {
+          match: () => mod && !event.shiftKey && event.key === 'z',
+          action: () => undo(),
+        },
+        // Redo: Ctrl + Y or Ctrl + Shift + Z
+        {
+          match: () => mod && (event.key === 'y' || (event.shiftKey && event.key === 'z')),
+          action: () => redo(),
+        },
+        // Zoom In: Ctrl + = / +
+        {
+          match: () => mod && (event.key === '=' || event.key === '+'),
+          action: () => zoomIn(),
+        },
+        // Zoom Out: Ctrl + -
+        {
+          match: () => mod && event.key === '-',
+          action: () => zoomOut(),
+        },
+        // Fit View: Ctrl + 0
+        {
+          match: () => mod && event.key === '0',
+          action: () => fitView({ padding: 0.2, maxZoom: 1 }),
+        },
+      ];
+
+      const matched = actions.find((a) => a.match());
+      matched && (event.preventDefault(), matched.action());
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [undo, redo]);
+  }, [undo, redo, saveToBackend, zoomIn, zoomOut, fitView]);
 }

--- a/frontend/src/app/theater/[id]/hooks/useFileDragDrop.ts
+++ b/frontend/src/app/theater/[id]/hooks/useFileDragDrop.ts
@@ -1,0 +1,283 @@
+import { useState, useCallback, useRef } from 'react';
+import { useReactFlow } from '@xyflow/react';
+import { v4 as uuidv4 } from 'uuid';
+import { useTranslation } from 'react-i18next';
+import { useCanvasStore, CanvasNode, ScriptNodeData, CharacterNodeData, VideoNodeData, AudioNodeData } from '@/store/useCanvasStore';
+import { useResourceStore } from '@/store/useResourceStore';
+
+// File type detection matchers
+const FILE_TYPE_MATCHERS: Array<{ type: 'text' | 'image' | 'video' | 'audio'; mimes: string[]; exts: string[] }> = [
+  { type: 'text', mimes: ['text/plain', 'text/markdown', 'application/pdf'], exts: ['.txt', '.md', '.markdown', '.pdf'] },
+  { type: 'image', mimes: ['image/png', 'image/jpeg', 'image/jpg', 'image/webp', 'image/gif'], exts: ['.png', '.jpg', '.jpeg', '.webp', '.gif'] },
+  { type: 'video', mimes: ['video/mp4', 'video/webm', 'video/ogg', 'video/avi', 'video/quicktime', 'video/x-ms-wmv', 'video/x-flv'], exts: ['.mp4', '.webm', '.avi', '.mov', '.wmv', '.flv', '.mkv'] },
+  { type: 'audio', mimes: ['audio/mpeg', 'audio/wav', 'audio/ogg', 'audio/mp3', 'audio/flac', 'audio/aac', 'audio/x-m4a'], exts: ['.mp3', '.wav', '.ogg', '.flac', '.aac', '.m4a'] },
+];
+
+// Size limits per file type (bytes)
+const SIZE_LIMITS: Record<string, number> = {
+  text: 10 * 1024 * 1024,
+  image: 50 * 1024 * 1024,
+  video: 500 * 1024 * 1024,
+  audio: 100 * 1024 * 1024,
+};
+
+// Batch limits per file type
+const BATCH_LIMITS: Record<string, number> = { video: 5, image: 20, audio: 20, text: 20 };
+
+// Node default dimensions
+const NODE_DIMENSIONS: Record<string, { width: number; height: number }> = {
+  text: { width: 400, height: 300 },
+  image: { width: 512, height: 384 },
+  video: { width: 512, height: 384 },
+  audio: { width: 360, height: 200 },
+};
+
+export type FileType = 'text' | 'image' | 'video' | 'audio';
+
+function getFileType(file: File): FileType | null {
+  const mime = file.type;
+  const name = file.name.toLowerCase();
+  return (
+    FILE_TYPE_MATCHERS.find(
+      (m) => m.mimes.some((t) => mime.includes(t)) || m.exts.some((ext) => name.endsWith(ext))
+    )?.type ?? null
+  );
+}
+
+function readTextFile(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) => resolve(e.target?.result as string || '');
+    reader.onerror = (e) => reject(e);
+    reader.readAsText(file);
+  });
+}
+
+function uploadFile(file: File, t: (key: string, opts?: Record<string, unknown>) => string): Promise<{ url?: string; error?: string; asset?: Record<string, unknown> }> {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open('POST', '/api/media/upload');
+    const token = localStorage.getItem('access_token');
+    token && xhr.setRequestHeader('Authorization', `Bearer ${token}`);
+    const formData = new FormData();
+    formData.append('file', file);
+    xhr.onload = () => {
+      try {
+        const res = xhr.responseText ? JSON.parse(xhr.responseText) : {};
+        xhr.status >= 200 && xhr.status < 300
+          ? resolve(res)
+          : resolve({ error: res?.detail || res?.error || t('canvas.uploadFailedHttp', { status: xhr.status }) });
+      } catch {
+        resolve({ error: t('canvas.parseResponseFailed', { status: xhr.status, statusText: xhr.statusText }) });
+      }
+    };
+    xhr.onerror = () => reject(new Error(t('canvas.networkError')));
+    xhr.send(formData);
+  });
+}
+
+// Media upload handler (shared by image/video/audio)
+async function handleMediaUpload(
+  file: File,
+  nodeId: string,
+  objectUrl: string,
+  urlField: string,
+  t: (key: string, opts?: Record<string, unknown>) => string
+) {
+  try {
+    const response = await uploadFile(file, t);
+    response.error && (() => { throw new Error(response.error); })();
+    const { updateNodeData } = useCanvasStore.getState();
+    URL.revokeObjectURL(objectUrl);
+    updateNodeData(nodeId, { [urlField]: response.url, uploading: false } as any);
+    response.asset && useResourceStore.getState().syncAssetFromUpload(response.asset);
+  } catch (error: any) {
+    console.error('Upload error:', error);
+    const { updateNodeData } = useCanvasStore.getState();
+    updateNodeData(nodeId, { uploading: false } as any);
+    alert(t('canvas.uploadFailed', { message: error.message || t('canvas.retryHint') }));
+  }
+}
+
+// Node creators per file type (avoids switch/case)
+const NODE_CREATORS: Record<string, (file: File, position: { x: number; y: number }, t: (key: string, opts?: Record<string, unknown>) => string) => Promise<void>> = {
+  text: async (file, position, t) => {
+    const MAX_CHARACTERS = 100000;
+
+    if (file.size > SIZE_LIMITS.text) {
+      alert(t('canvas.fileSizeError.text'));
+      return;
+    }
+
+    const isPdf = file.name.toLowerCase().endsWith('.pdf');
+    let content: string;
+
+    try {
+      content = isPdf
+        ? t('canvas.pdfPlaceholder', { name: file.name })
+        : await readTextFile(file);
+    } catch {
+      content = t('canvas.readFileFailed', { name: file.name });
+    }
+
+    const originalLength = content.length;
+    content = content.length > MAX_CHARACTERS
+      ? content.substring(0, MAX_CHARACTERS) + t('canvas.contentTruncated', { original: originalLength.toLocaleString(), max: MAX_CHARACTERS.toLocaleString() })
+      : content;
+
+    const fileName = file.name.replace(/\.[^/.]+$/, '');
+    const dims = NODE_DIMENSIONS.text;
+    const newNode: CanvasNode = {
+      id: `text-${uuidv4()}`,
+      type: 'text',
+      position,
+      width: dims.width,
+      height: dims.height,
+      data: {
+        title: fileName,
+        content: {
+          type: 'doc',
+          content: [{ type: 'paragraph', content: [{ type: 'text', text: content }] }],
+        },
+        tags: isPdf ? ['pdf'] : ['imported'],
+      } as ScriptNodeData,
+    };
+    useCanvasStore.getState().addNode(newNode);
+  },
+
+  image: async (file, position, t) => {
+    if (file.size > SIZE_LIMITS.image) {
+      alert(t('canvas.fileSizeError.image'));
+      return;
+    }
+    const fileName = file.name.replace(/\.[^/.]+$/, '');
+    const objectUrl = URL.createObjectURL(file);
+    const dims = NODE_DIMENSIONS.image;
+    const newNode: CanvasNode = {
+      id: `image-${uuidv4()}`,
+      type: 'image',
+      position,
+      width: dims.width,
+      height: dims.height,
+      data: { name: fileName, description: '', imageUrl: objectUrl, uploading: true, fitMode: 'cover' } as CharacterNodeData,
+    };
+    useCanvasStore.getState().addNode(newNode);
+    await handleMediaUpload(file, newNode.id, objectUrl, 'imageUrl', t);
+  },
+
+  video: async (file, position, t) => {
+    if (file.size > SIZE_LIMITS.video) {
+      alert(t('canvas.fileSizeError.video'));
+      return;
+    }
+    const fileName = file.name.replace(/\.[^/.]+$/, '');
+    const objectUrl = URL.createObjectURL(file);
+    const dims = NODE_DIMENSIONS.video;
+    const newNode: CanvasNode = {
+      id: `video-${uuidv4()}`,
+      type: 'video',
+      position,
+      width: dims.width,
+      height: dims.height,
+      data: { name: fileName, description: '', videoUrl: objectUrl, uploading: true, fitMode: 'cover' } as VideoNodeData,
+    };
+    useCanvasStore.getState().addNode(newNode);
+    await handleMediaUpload(file, newNode.id, objectUrl, 'videoUrl', t);
+  },
+
+  audio: async (file, position, t) => {
+    if (file.size > SIZE_LIMITS.audio) {
+      alert(t('canvas.fileSizeError.audio'));
+      return;
+    }
+    const fileName = file.name.replace(/\.[^/.]+$/, '');
+    const objectUrl = URL.createObjectURL(file);
+    const dims = NODE_DIMENSIONS.audio;
+    const newNode: CanvasNode = {
+      id: `audio-${uuidv4()}`,
+      type: 'audio',
+      position,
+      width: dims.width,
+      height: dims.height,
+      data: { name: fileName, description: '', audioUrl: objectUrl, uploading: true } as AudioNodeData,
+    };
+    useCanvasStore.getState().addNode(newNode);
+    await handleMediaUpload(file, newNode.id, objectUrl, 'audioUrl', t);
+  },
+};
+
+export function useFileDragDrop(wrapperRef: React.RefObject<HTMLDivElement | null>) {
+  const { t } = useTranslation();
+  const { screenToFlowPosition } = useReactFlow();
+
+  const [isDraggingFile, setIsDraggingFile] = useState(false);
+  const [dragFileType, setDragFileType] = useState<FileType | null>(null);
+  const [dragPosition, setDragPosition] = useState({ x: 0, y: 0 });
+
+  const onFileDragOver = useCallback((event: React.DragEvent) => {
+    setIsDraggingFile(true);
+    setDragPosition({ x: event.clientX, y: event.clientY });
+
+    // Detect file type from the first file
+    const files = event.dataTransfer.items;
+    if (files.length > 0) {
+      const file = files[0].getAsFile();
+      file && setDragFileType(getFileType(file));
+    }
+  }, []);
+
+  const onFileDragLeave = useCallback((event: React.DragEvent) => {
+    const rect = wrapperRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const { clientX, clientY } = event;
+    const isOutside = clientX <= rect.left || clientX >= rect.right || clientY <= rect.top || clientY >= rect.bottom;
+    isOutside && (setIsDraggingFile(false), setDragFileType(null));
+  }, [wrapperRef]);
+
+  const resetDragState = useCallback(() => {
+    setIsDraggingFile(false);
+    setDragFileType(null);
+  }, []);
+
+  const handleFileDrop = useCallback((files: FileList, clientX: number, clientY: number) => {
+    const position = screenToFlowPosition({ x: clientX, y: clientY });
+
+    // Group files by type and apply batch limits
+    const TYPE_NAMES: Record<string, string> = {
+      video: t('canvas.fileNames.video'),
+      image: t('canvas.fileNames.image'),
+      audio: t('canvas.fileNames.audio'),
+      text: t('canvas.fileNames.text'),
+    };
+    const grouped: Record<string, File[]> = {};
+    Array.from(files).forEach((file) => {
+      const fType = getFileType(file) ?? 'unknown';
+      (grouped[fType] = grouped[fType] || []).push(file);
+    });
+
+    const allowed: File[] = [];
+    const rejected: string[] = [];
+    Object.entries(grouped).forEach(([fType, list]) => {
+      const limit = BATCH_LIMITS[fType] ?? 20;
+      allowed.push(...list.slice(0, limit));
+      list.length > limit && rejected.push(
+        t('canvas.batchLimit', { type: TYPE_NAMES[fType] ?? t('canvas.fileNames.default'), limit, skipped: list.length - limit })
+      );
+    });
+    rejected.length > 0 && alert(rejected.join('\n'));
+
+    // Sequential upload to avoid concurrent SQLite conflicts
+    (async () => {
+      for (let i = 0; i < allowed.length; i++) {
+        const filePosition = { x: position.x + i * 50, y: position.y + i * 50 };
+        const fileType = getFileType(allowed[i]);
+        const creator = fileType ? NODE_CREATORS[fileType] : null;
+        creator
+          ? await creator(allowed[i], filePosition, t)
+          : alert(t('canvas.unsupportedFile', { name: allowed[i].name }));
+      }
+    })();
+  }, [screenToFlowPosition, t]);
+
+  return { isDraggingFile, dragFileType, dragPosition, onFileDragOver, onFileDragLeave, resetDragState, handleFileDrop };
+}

--- a/frontend/src/app/theater/[id]/hooks/useQuickAddMenu.ts
+++ b/frontend/src/app/theater/[id]/hooks/useQuickAddMenu.ts
@@ -3,17 +3,37 @@ import { useReactFlow, FinalConnectionState } from '@xyflow/react';
 import { v4 as uuidv4 } from 'uuid';
 import { useCanvasStore, CanvasNode } from '@/store/useCanvasStore';
 
+// Node type default data registry (avoids switch/case)
+const nodeDefaultData: Record<string, Record<string, unknown>> = {
+  text: { title: '新文本卡', content: null, tags: [] },
+  image: { name: '新图片卡', description: '', imageUrl: '', fitMode: 'cover' },
+  storyboard: { shotNumber: '001', description: '', duration: 5 },
+  video: { name: '新视频卡', description: '', videoUrl: '', fitMode: 'cover' },
+  audio: { name: '新音频卡', description: '', audioUrl: '' },
+};
+
+// Default dimensions by node type
+const nodeDefaultDimensions: Record<string, { width: number; height: number }> = {
+  text: { width: 400, height: 300 },
+  image: { width: 512, height: 384 },
+  video: { width: 512, height: 384 },
+  audio: { width: 360, height: 200 },
+  storyboard: { width: 398, height: 256 },
+};
+
+export interface QuickAddMenuState {
+  show: boolean;
+  x: number;
+  y: number;
+  sourceNodeId: string | null;
+  sourceHandleId: string | null;
+}
+
 export function useQuickAddMenu() {
   const { screenToFlowPosition } = useReactFlow();
   const { addNode, onConnect } = useCanvasStore();
 
-  const [menuState, setMenuState] = useState<{
-    show: boolean;
-    x: number;
-    y: number;
-    sourceNodeId: string | null;
-    sourceHandleId: string | null;
-  }>({
+  const [menuState, setMenuState] = useState<QuickAddMenuState>({
     show: false,
     x: 0,
     y: 0,
@@ -60,14 +80,7 @@ export function useQuickAddMenu() {
     []
   );
 
-  const nodeDefaultData: Record<string, Record<string, unknown>> = {
-    script: { title: '新文本卡', tags: [] },
-    character: { name: '新图片卡', description: '' },
-    storyboard: { shotNumber: '001', description: '', duration: 5 },
-    video: { name: '新视频卡', description: '' },
-  };
-
-  const handleAddNodeFromMenu = (type: string) => {
+  const handleAddNodeFromMenu = useCallback((type: string) => {
     if (!menuState.sourceNodeId) return;
 
     const position = screenToFlowPosition({
@@ -77,16 +90,20 @@ export function useQuickAddMenu() {
 
     const newNodeId = uuidv4();
     const data = nodeDefaultData[type] || { label: `${type} node` };
+    const dimensions = nodeDefaultDimensions[type];
 
     const newNode = {
       id: newNodeId,
       type,
       position,
+      width: dimensions?.width,
+      height: dimensions?.height,
       data,
     } as CanvasNode;
 
     addNode(newNode);
 
+    // Connect based on handle direction
     let targetHandle = null;
     let sourceHandle = menuState.sourceHandleId;
     let connectionSource = menuState.sourceNodeId;
@@ -110,7 +127,7 @@ export function useQuickAddMenu() {
     };
 
     const applyConnection = handleConnections[menuState.sourceHandleId || ''];
-    if (applyConnection) applyConnection();
+    applyConnection?.();
 
     onConnect({
       source: connectionSource,
@@ -120,16 +137,15 @@ export function useQuickAddMenu() {
     });
 
     setMenuState((prev) => ({ ...prev, show: false }));
-  };
+  }, [menuState, screenToFlowPosition, addNode, onConnect]);
 
+  // Close menu when clicking elsewhere
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
       const target = e.target as Element;
       if (target.closest('.quick-add-menu')) return;
       
-      if (menuState.show) {
-        setMenuState((prev) => ({ ...prev, show: false }));
-      }
+      menuState.show && setMenuState((prev) => ({ ...prev, show: false }));
     };
     window.addEventListener('click', handleClickOutside);
     return () => window.removeEventListener('click', handleClickOutside);

--- a/frontend/src/app/theater/[id]/hooks/useTheaterLoading.ts
+++ b/frontend/src/app/theater/[id]/hooks/useTheaterLoading.ts
@@ -6,9 +6,10 @@ import { useCanvasStore } from '@/store/useCanvasStore';
 export function useTheaterLoading(theaterId: string) {
   const router = useRouter();
   const { isAuthenticated } = useAuth();
-  const { loadTheater, setTheaterId, saveToBackend } = useCanvasStore();
+  const { loadTheater, setTheaterId, saveToBackend, isDirty, isSaving, isSyncing } = useCanvasStore();
   const loaded = useRef(false);
 
+  // Load theater on mount (wait for auth)
   useEffect(() => {
     if (!isAuthenticated || loaded.current) return;
     loaded.current = true;
@@ -17,10 +18,23 @@ export function useTheaterLoading(theaterId: string) {
     });
   }, [isAuthenticated, theaterId, loadTheater, router]);
 
+  // Ensure theaterId is set
   useEffect(() => {
     setTheaterId(theaterId);
   }, [theaterId, setTheaterId]);
 
+  // Auto-save with 2s debounce
+  useEffect(() => {
+    if (!isDirty || isSaving || isSyncing) return;
+
+    const timer = setTimeout(() => {
+      saveToBackend().catch(console.error);
+    }, 2000);
+
+    return () => clearTimeout(timer);
+  }, [isDirty, isSaving, isSyncing, saveToBackend]);
+
+  // Save on network recovery
   useEffect(() => {
     const handleOnline = () => {
       if (useCanvasStore.getState().isDirty) {

--- a/frontend/src/app/theater/[id]/page.tsx
+++ b/frontend/src/app/theater/[id]/page.tsx
@@ -1,8 +1,8 @@
 
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { useRouter, useParams } from 'next/navigation';
+import { useCallback, useRef, useState } from 'react';
+import { useParams } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/context/AuthContext';
 import { 
@@ -15,13 +15,10 @@ import {
   ConnectionMode,
   BackgroundVariant,
   NodeTypes,
-  FinalConnectionState
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
-import { v4 as uuidv4 } from 'uuid';
 
-import { useCanvasStore, CanvasNode, ScriptNodeData, CharacterNodeData, VideoNodeData, AudioNodeData } from '@/store/useCanvasStore';
-import { useResourceStore } from '@/store/useResourceStore';
+import { useCanvasStore } from '@/store/useCanvasStore';
 import { Sidebar } from '@/components/canvas/Sidebar';
 import { ZoomControls } from '@/components/canvas/ZoomControls';
 import ScriptNode from '@/components/canvas/TextNode';
@@ -34,9 +31,14 @@ import { CustomEdge } from '@/components/canvas/CustomEdge';
 import { AIAssistantPanel } from '@/components/canvas/AIAssistantPanel';
 import { CanvasHints } from '@/components/canvas/CanvasCursor';
 import { CanvasHelpButton } from '@/components/canvas/CanvasHelp';
-import { Button } from '@/components/ui/button';
-import { Card } from '@/components/ui/card';
-import { Save, Undo, Redo, ArrowLeft, ScrollText, User, Clapperboard, Loader2, Check, LayoutGrid, FileText, Image, Film, Music, Headphones } from 'lucide-react';
+import { CanvasToolbar } from '@/components/canvas/CanvasToolbar';
+import { QuickAddMenu } from '@/components/canvas/QuickAddMenu';
+import { FileDragOverlay } from '@/components/canvas/FileDragOverlay';
+
+import { useTheaterLoading } from './hooks/useTheaterLoading';
+import { useCanvasShortcuts } from './hooks/useCanvasShortcuts';
+import { useQuickAddMenu } from './hooks/useQuickAddMenu';
+import { useCanvasDragDrop } from './hooks/useCanvasDragDrop';
 import { useAutoLayout } from './hooks/useAutoLayout';
 import { useCanvasSnapping } from './hooks/useCanvasSnapping';
 import { useNodeDragToAI } from './hooks/useNodeDragToAI';
@@ -61,51 +63,34 @@ const defaultEdgeOptions = {
 };
 
 function InfiniteCanvas() {
-  const router = useRouter();
   const params = useParams();
   const { t } = useTranslation();
   const { isAuthenticated } = useAuth();
   const theaterId = params.id as string;
   const reactFlowWrapper = useRef<HTMLDivElement>(null);
-  const { screenToFlowPosition, getViewport, zoomIn, zoomOut, fitView } = useReactFlow();
+  const { fitView } = useReactFlow();
   const [showMap, setShowMap] = useState(false);
   const [viewport, setViewportState] = useState({ x: 0, y: 0, zoom: 1 });
   
-  const [menuState, setMenuState] = useState<{
-    show: boolean;
-    x: number;
-    y: number;
-    sourceNodeId: string | null;
-    sourceHandleId: string | null;
-  }>({
-    show: false,
-    x: 0,
-    y: 0,
-    sourceNodeId: null,
-    sourceHandleId: null,
-  });
-
-  // File drag and drop state
-  const [isDraggingFile, setIsDraggingFile] = useState(false);
-  const [dragFileType, setDragFileType] = useState<'text' | 'image' | 'video' | 'audio' | null>(null);
-  const [dragPosition, setDragPosition] = useState({ x: 0, y: 0 });
-
   const { 
-    nodes, edges, isLoading, isSaving, isDirty, isSyncing, lastSavedAt,
+    nodes, edges, isLoading, isSaving, isDirty, lastSavedAt,
     onNodesChange, onEdgesChange, onConnect,
-    addNode,
-    undo, redo, takeSnapshot,
-    loadTheater, saveToBackend, setTheaterId,
+    undo, redo,
     theaterTitle, setTheaterTitle,
     snapToGrid, snapToGuides,
     setSnapToGrid, setSnapToGuides
   } = useCanvasStore();
 
+  // --- Hooks ---
+  useTheaterLoading(theaterId);
+  useCanvasShortcuts();
+  const { menuState, onConnectEnd, handleAddNodeFromMenu } = useQuickAddMenu();
+  const { onDragOver, onDragLeave, onDrop, isDraggingFile, dragFileType, dragPosition } = useCanvasDragDrop(reactFlowWrapper);
   const { isLayouting, handleAutoLayout } = useAutoLayout();
   const { alignmentLines, onNodeDrag: onSnappingDrag, onNodeDragStop: onSnappingDragStop } = useCanvasSnapping(snapToGuides);
   const { onNodeDragStart: onAIDragStart, onNodeDrag: onAIDrag, onNodeDragStop: onAIDragStop } = useNodeDragToAI();
 
-  // 组合拖拽回调：对齐吸附 + AI面板检测
+  // --- Composed drag callbacks: snapping + AI panel detection ---
   const composedOnNodeDragStart = useCallback(
     (event: React.MouseEvent, node: any, nodes: any[]) => {
       onAIDragStart(event, node, nodes);
@@ -127,606 +112,7 @@ function InfiniteCanvas() {
     [onSnappingDragStop, onAIDragStop]
   );
 
-  // Auto-save logic
-  useEffect(() => {
-    if (!isDirty || isSaving || isSyncing) return;
-
-    const timer = setTimeout(() => {
-      saveToBackend().catch(console.error);
-    }, 2000); // 2 seconds debounce
-
-    return () => clearTimeout(timer);
-  }, [isDirty, isSaving, isSyncing, saveToBackend]);
-
-  // Load theater on mount (wait for auth)
-  const loaded = useRef(false);
-  useEffect(() => {
-    if (!isAuthenticated || loaded.current) return;
-    loaded.current = true;
-    loadTheater(theaterId).catch(() => {
-      router.push('/');
-    });
-  }, [isAuthenticated, theaterId, loadTheater, router]);
-
-  // Ensure theaterId is set
-  useEffect(() => {
-    setTheaterId(theaterId);
-  }, [theaterId, setTheaterId]);
-
-  const onConnectEnd = useCallback(
-    (event: MouseEvent | TouchEvent, connectionState: FinalConnectionState) => {
-      if (connectionState.isValid) return;
-      if (!connectionState.fromNode) return;
-
-      const target = event.target as Element;
-      const isPane = target.classList.contains('react-flow__pane') || 
-                     target.classList.contains('react-flow__background') || 
-                     !!target.closest('.react-flow__pane') ||
-                     !!target.closest('.react-flow__background');
-                     
-      if (!isPane) return;
-
-      let clientX: number | undefined;
-      let clientY: number | undefined;
-      
-      if ('clientX' in event) {
-        clientX = event.clientX;
-        clientY = event.clientY;
-      } else if (event.changedTouches && event.changedTouches.length > 0) {
-        clientX = event.changedTouches[0].clientX;
-        clientY = event.changedTouches[0].clientY;
-      }
-
-      if (clientX !== undefined && clientY !== undefined) {
-        setTimeout(() => {
-          setMenuState({
-            show: true,
-            x: clientX as number,
-            y: clientY as number,
-            sourceNodeId: connectionState.fromNode?.id || null,
-            sourceHandleId: connectionState.fromHandle?.id || null,
-          });
-        }, 50);
-      }
-    },
-    []
-  );
-
-  // Node type default data registry (avoids switch/case)
-  const nodeDefaultData: Record<string, Record<string, unknown>> = {
-    text: { title: '新文本卡', content: null, tags: [] },
-    image: { name: '新图片卡', description: '', imageUrl: '', fitMode: 'cover' },
-    storyboard: { shotNumber: '001', description: '', duration: 5 },
-    video: { name: '新视频卡', description: '', videoUrl: '', fitMode: 'cover' },
-    audio: { name: '新音频卡', description: '', audioUrl: '' },
-  };
-
-  // Default dimensions by node type (consistent with sidebar drag)
-  const nodeDefaultDimensions: Record<string, { width: number; height: number }> = {
-    text: { width: 400, height: 300 },
-    image: { width: 512, height: 384 },
-    video: { width: 512, height: 384 },
-    audio: { width: 360, height: 200 },
-    storyboard: { width: 398, height: 256 },
-  };
-
-  const handleAddNodeFromMenu = (type: string) => {
-    if (!menuState.sourceNodeId) return;
-
-    const position = screenToFlowPosition({
-      x: menuState.x,
-      y: menuState.y,
-    });
-
-    const newNodeId = uuidv4();
-    const data = nodeDefaultData[type] || { label: `${type} node` };
-    const dimensions = nodeDefaultDimensions[type];
-
-    const newNode = {
-      id: newNodeId,
-      type,
-      position,
-      width: dimensions?.width,
-      height: dimensions?.height,
-      data,
-    } as CanvasNode;
-
-    addNode(newNode);
-
-    // Connect based on handle direction
-    let targetHandle = null;
-    let sourceHandle = menuState.sourceHandleId;
-    let connectionSource = menuState.sourceNodeId;
-    let connectionTarget = newNodeId;
-
-    const handleConnections: Record<string, () => void> = {
-      'left-source': () => { targetHandle = 'right-target'; },
-      'right-source': () => { targetHandle = 'left-target'; },
-      'left-target': () => {
-        connectionSource = newNodeId;
-        connectionTarget = menuState.sourceNodeId!;
-        sourceHandle = 'right-source';
-        targetHandle = 'left-target';
-      },
-      'right-target': () => {
-        connectionSource = newNodeId;
-        connectionTarget = menuState.sourceNodeId!;
-        sourceHandle = 'left-source';
-        targetHandle = 'right-target';
-      },
-    };
-
-    const applyConnection = handleConnections[menuState.sourceHandleId || ''];
-    if (applyConnection) applyConnection();
-
-    onConnect({
-      source: connectionSource,
-      sourceHandle: sourceHandle,
-      target: connectionTarget,
-      targetHandle: targetHandle,
-    });
-
-    setMenuState((prev) => ({ ...prev, show: false }));
-  };
-
-  // Close menu when clicking elsewhere
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      const target = e.target as Element;
-      if (target.closest('.quick-add-menu')) return;
-      
-      if (menuState.show) {
-        setMenuState((prev) => ({ ...prev, show: false }));
-      }
-    };
-    window.addEventListener('click', handleClickOutside);
-    return () => window.removeEventListener('click', handleClickOutside);
-  }, [menuState.show]);
-
-  // Keyboard Shortcuts
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      // Save: Ctrl + S
-      if ((event.ctrlKey || event.metaKey) && event.key === 's') {
-        event.preventDefault();
-        saveToBackend().catch(console.error);
-      }
-      
-      // Undo: Ctrl + Z
-      if ((event.ctrlKey || event.metaKey) && !event.shiftKey && event.key === 'z') {
-        event.preventDefault();
-        undo();
-      }
-      
-      // Redo: Ctrl + Y or Ctrl + Shift + Z
-      if ((event.ctrlKey || event.metaKey) && (event.key === 'y' || (event.shiftKey && event.key === 'z'))) {
-        event.preventDefault();
-        redo();
-      }
-
-      // Zoom In: Ctrl + = (also handles + key)
-      if ((event.ctrlKey || event.metaKey) && (event.key === '=' || event.key === '+')) {
-        event.preventDefault();
-        zoomIn();
-      }
-
-      // Zoom Out: Ctrl + -
-      if ((event.ctrlKey || event.metaKey) && event.key === '-') {
-        event.preventDefault();
-        zoomOut();
-      }
-
-      // Fit View: Ctrl + 0
-      if ((event.ctrlKey || event.metaKey) && event.key === '0') {
-        event.preventDefault();
-        fitView({ padding: 0.2, maxZoom: 1 });
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [undo, redo, saveToBackend, zoomIn, zoomOut, fitView]);
-
-  // File type detection (映射表模式)
-  const FILE_TYPE_MATCHERS: Array<{ type: 'text' | 'image' | 'video' | 'audio'; mimes: string[]; exts: string[] }> = [
-    { type: 'text', mimes: ['text/plain', 'text/markdown', 'application/pdf'], exts: ['.txt', '.md', '.markdown', '.pdf'] },
-    { type: 'image', mimes: ['image/png', 'image/jpeg', 'image/jpg', 'image/webp', 'image/gif'], exts: ['.png', '.jpg', '.jpeg', '.webp', '.gif'] },
-    { type: 'video', mimes: ['video/mp4', 'video/webm', 'video/ogg', 'video/avi', 'video/quicktime', 'video/x-ms-wmv', 'video/x-flv'], exts: ['.mp4', '.webm', '.avi', '.mov', '.wmv', '.flv', '.mkv'] },
-    { type: 'audio', mimes: ['audio/mpeg', 'audio/wav', 'audio/ogg', 'audio/mp3', 'audio/flac', 'audio/aac', 'audio/x-m4a'], exts: ['.mp3', '.wav', '.ogg', '.flac', '.aac', '.m4a'] },
-  ];
-
-  const getFileType = (file: File): 'text' | 'image' | 'video' | 'audio' | null => {
-    const mime = file.type;
-    const name = file.name.toLowerCase();
-    return (
-      FILE_TYPE_MATCHERS.find(
-        (m) => m.mimes.some((t) => mime.includes(t)) || m.exts.some((ext) => name.endsWith(ext))
-      )?.type ?? null
-    );
-  };
-
-  // Read text file content
-  const readTextFile = async (file: File): Promise<string> => {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onload = (e) => resolve(e.target?.result as string || '');
-      reader.onerror = (e) => reject(e);
-      reader.readAsText(file);
-    });
-  };
-
-  // 通用文件上传（XHR，避免重复代码）
-  const uploadFile = (file: File): Promise<{ url?: string; error?: string; asset?: Record<string, unknown> }> => {
-    return new Promise((resolve, reject) => {
-      const xhr = new XMLHttpRequest();
-      xhr.open('POST', '/api/media/upload');
-      const token = localStorage.getItem('access_token');
-      token && xhr.setRequestHeader('Authorization', `Bearer ${token}`);
-      const formData = new FormData();
-      formData.append('file', file);
-      xhr.onload = () => {
-        try {
-          const res = xhr.responseText ? JSON.parse(xhr.responseText) : {};
-          xhr.status >= 200 && xhr.status < 300
-            ? resolve(res)
-            : resolve({ error: res?.detail || res?.error || t('canvas.uploadFailedHttp', { status: xhr.status }) });
-        } catch {
-          resolve({ error: t('canvas.parseResponseFailed', { status: xhr.status, statusText: xhr.statusText }) });
-        }
-      };
-      xhr.onerror = () => reject(new Error(t('canvas.networkError')));
-      xhr.send(formData);
-    });
-  };
-
-  // Create node from file
-  const createNodeFromFile = async (file: File, position: { x: number; y: number }) => {
-    const fileType = getFileType(file);
-    const fileName = file.name.replace(/\.[^/.]+$/, ''); // Remove extension
-    
-    switch (fileType) {
-      case 'text': {
-        let content: string;
-        const isPdf = file.name.toLowerCase().endsWith('.pdf');
-        
-        // File size limit for text files: 10MB
-        const MAX_TEXT_FILE_SIZE = 10 * 1024 * 1024;
-        if (file.size > MAX_TEXT_FILE_SIZE) {
-          alert(t('canvas.fileSizeError.text'));
-          return;
-        }
-        
-        if (isPdf) {
-          // PDF files cannot be parsed in browser, show placeholder
-          content = t('canvas.pdfPlaceholder', { name: file.name });
-        } else {
-          try {
-            content = await readTextFile(file);
-          } catch {
-            content = t('canvas.readFileFailed', { name: file.name });
-          }
-        }
-        
-        // Character limit: 100,000 characters (approximately 50,000 Chinese characters or 100,000 English characters)
-        const MAX_CHARACTERS = 100000;
-        const originalLength = content.length;
-        if (content.length > MAX_CHARACTERS) {
-          content = content.substring(0, MAX_CHARACTERS) + 
-            t('canvas.contentTruncated', { original: originalLength.toLocaleString(), max: MAX_CHARACTERS.toLocaleString() });
-        }
-        
-        const newNode: CanvasNode = {
-          id: `text-${uuidv4()}`,
-          type: 'text',
-          position,
-          width: 400,
-          height: 300,
-          data: {
-            title: fileName,
-            content: {
-              type: 'doc',
-              content: [
-                {
-                  type: 'paragraph',
-                  content: [{ type: 'text', text: content }]
-                }
-              ]
-            },
-            tags: isPdf ? ['pdf'] : ['imported'],
-          } as ScriptNodeData,
-        };
-        addNode(newNode);
-        break;
-      }
-      
-      case 'image': {
-        // Validate file size (50MB max)
-        if (file.size > 50 * 1024 * 1024) {
-          alert(t('canvas.fileSizeError.image'));
-          return;
-        }
-        
-        const objectUrl = URL.createObjectURL(file);
-        const newNode: CanvasNode = {
-          id: `image-${uuidv4()}`,
-          type: 'image',
-          position,
-          width: 512,
-          height: 384,
-          data: {
-            name: fileName,
-            description: '',
-            imageUrl: objectUrl,
-            uploading: true,
-            fitMode: 'cover',
-          } as CharacterNodeData,
-        };
-        addNode(newNode);
-        
-        try {
-          const response = await uploadFile(file);
-          response.error && (() => { throw new Error(response.error); })();
-          const { updateNodeData } = useCanvasStore.getState();
-          URL.revokeObjectURL(objectUrl);
-          updateNodeData(newNode.id, { imageUrl: response.url, uploading: false } as Partial<CharacterNodeData>);
-          // 同步新资源到 resourceStore
-          response.asset && useResourceStore.getState().syncAssetFromUpload(response.asset);
-        } catch (error: any) {
-          console.error('Upload error:', error);
-          const { updateNodeData } = useCanvasStore.getState();
-          updateNodeData(newNode.id, { uploading: false } as Partial<CharacterNodeData>);
-          alert(t('canvas.uploadFailed', { message: error.message || t('canvas.retryHint') }));
-        }
-        break;
-      }
-      
-      case 'video': {
-        // Validate file size (500MB max)
-        if (file.size > 500 * 1024 * 1024) {
-          alert(t('canvas.fileSizeError.video'));
-          return;
-        }
-        
-        const objectUrl = URL.createObjectURL(file);
-        const newNode: CanvasNode = {
-          id: `video-${uuidv4()}`,
-          type: 'video',
-          position,
-          width: 512,
-          height: 384,
-          data: {
-            name: fileName,
-            description: '',
-            videoUrl: objectUrl,
-            uploading: true,
-            fitMode: 'cover',
-          } as VideoNodeData,
-        };
-        addNode(newNode);
-        
-        try {
-          const response = await uploadFile(file);
-          response.error && (() => { throw new Error(response.error); })();
-          const { updateNodeData } = useCanvasStore.getState();
-          URL.revokeObjectURL(objectUrl);
-          updateNodeData(newNode.id, { videoUrl: response.url, uploading: false } as Partial<VideoNodeData>);
-          // 同步新资源到 resourceStore
-          response.asset && useResourceStore.getState().syncAssetFromUpload(response.asset);
-        } catch (error: any) {
-          console.error('Upload error:', error);
-          const { updateNodeData } = useCanvasStore.getState();
-          updateNodeData(newNode.id, { uploading: false } as Partial<VideoNodeData>);
-          alert(t('canvas.uploadFailed', { message: error.message || t('canvas.retryHint') }));
-        }
-        break;
-      }
-
-      case 'audio': {
-        // Validate file size (100MB max)
-        if (file.size > 100 * 1024 * 1024) {
-          alert(t('canvas.fileSizeError.audio'));
-          return;
-        }
-
-        // 先创建占位音频节点（显示上传中状态）
-        const audioObjectUrl = URL.createObjectURL(file);
-        const audioNode: CanvasNode = {
-          id: `audio-${uuidv4()}`,
-          type: 'audio',
-          position,
-          width: 360,
-          height: 200,
-          data: {
-            name: fileName,
-            description: '',
-            audioUrl: audioObjectUrl,
-            uploading: true,
-          } as AudioNodeData,
-        };
-        addNode(audioNode);
-
-        try {
-          const response = await uploadFile(file);
-          response.error && (() => { throw new Error(response.error); })();
-          const { updateNodeData } = useCanvasStore.getState();
-          URL.revokeObjectURL(audioObjectUrl);
-          updateNodeData(audioNode.id, { audioUrl: response.url, uploading: false } as Partial<AudioNodeData>);
-          // 同步新资源到 resourceStore
-          response.asset && useResourceStore.getState().syncAssetFromUpload(response.asset);
-        } catch (error: any) {
-          console.error('Audio upload error:', error);
-          const { updateNodeData } = useCanvasStore.getState();
-          updateNodeData(audioNode.id, { uploading: false } as Partial<AudioNodeData>);
-          alert(t('canvas.uploadFailed', { message: error.message || t('canvas.retryHint') }));
-        }
-        break;
-      }
-      
-      default:
-        alert(t('canvas.unsupportedFile', { name: file.name }));
-    }
-  };
-
-  const onDragOver = useCallback((event: React.DragEvent) => {
-    event.preventDefault();
-    
-    // Check if this is internal node drag (from sidebar/asset library) - takes priority
-    const hasReactFlowData = event.dataTransfer.types.includes('application/reactflow');
-    
-    // Check if dragging files from outside (external file drag)
-    const hasFiles = event.dataTransfer.types.includes('Files');
-    
-    // Priority: internal node drag > external file drag
-    if (hasReactFlowData) {
-      // Internal node drag from sidebar/asset library
-      event.dataTransfer.dropEffect = 'move';
-      setIsDraggingFile(false);
-      setDragFileType(null);
-    } else if (hasFiles) {
-      // External file drag from OS file manager
-      event.dataTransfer.dropEffect = 'copy';
-      setIsDraggingFile(true);
-      setDragPosition({ x: event.clientX, y: event.clientY });
-      
-      // Detect file type from the first file
-      const files = event.dataTransfer.items;
-      if (files.length > 0) {
-        const file = files[0].getAsFile();
-        if (file) {
-          setDragFileType(getFileType(file));
-        }
-      }
-    } else {
-      event.dataTransfer.dropEffect = 'move';
-    }
-  }, []);
-
-  const onDragLeave = useCallback((event: React.DragEvent) => {
-    // Only hide if leaving the wrapper, not entering a child
-    const rect = reactFlowWrapper.current?.getBoundingClientRect();
-    if (rect) {
-      const { clientX, clientY } = event;
-      if (
-        clientX <= rect.left ||
-        clientX >= rect.right ||
-        clientY <= rect.top ||
-        clientY >= rect.bottom
-      ) {
-        setIsDraggingFile(false);
-        setDragFileType(null);
-      }
-    }
-  }, []);
-
-  const onDrop = useCallback(
-    (event: React.DragEvent) => {
-      event.preventDefault();
-      setIsDraggingFile(false);
-      setDragFileType(null);
-
-      // 优先检查内部拖拽（从侧边栏/资产库），避免浏览器原生 img 拖拽导致 files 干扰
-      const type = event.dataTransfer.getData('application/reactflow');
-      if (type) {
-        // 内部拖拽路径，直接创建节点，不走文件上传
-      } else {
-        // Handle external file drop
-        const files = event.dataTransfer.files;
-        if (files.length > 0) {
-          const position = screenToFlowPosition({
-            x: event.clientX,
-            y: event.clientY,
-          });
-          
-          // 按类型分组并限制批量数量（映射表模式）
-          const BATCH_LIMITS: Record<string, number> = { video: 5, image: 20, audio: 20, text: 20 };
-          const TYPE_NAMES: Record<string, string> = {
-            video: t('canvas.fileNames.video'),
-            image: t('canvas.fileNames.image'),
-            audio: t('canvas.fileNames.audio'),
-            text: t('canvas.fileNames.text'),
-          };
-          const grouped: Record<string, File[]> = {};
-          Array.from(files).forEach((file) => {
-            const fType = getFileType(file) ?? 'unknown';
-            (grouped[fType] = grouped[fType] || []).push(file);
-          });
-
-          const allowed: File[] = [];
-          const rejected: string[] = [];
-          Object.entries(grouped).forEach(([fType, list]) => {
-            const limit = BATCH_LIMITS[fType] ?? 20;
-            allowed.push(...list.slice(0, limit));
-            list.length > limit && rejected.push(
-              t('canvas.batchLimit', { type: TYPE_NAMES[fType] ?? t('canvas.fileNames.default'), limit, skipped: list.length - limit })
-            );
-          });
-          rejected.length > 0 && alert(rejected.join('\n'));
-
-          // 串行上传避免并发写入 SQLite 冲突
-          (async () => {
-            for (let i = 0; i < allowed.length; i++) {
-              const filePosition = {
-                x: position.x + i * 50,
-                y: position.y + i * 50,
-              };
-              await createNodeFromFile(allowed[i], filePosition);
-            }
-          })();
-          return;
-        }
-        return;
-      }
-
-      // Handle internal node drag (from sidebar/asset library)
-      const dataStr = event.dataTransfer.getData('application/reactflow-data');
-      const dimensionsStr = event.dataTransfer.getData('application/reactflow-dimensions');
-      
-      if (!type) return;
-
-      const position = screenToFlowPosition({
-        x: event.clientX,
-        y: event.clientY,
-      });
-
-      // Dimension defaults by type (avoids if-else chain)
-      const defaultDimensions: Record<string, { width: number; height: number }> = {
-        text: { width: 400, height: 300 },
-        image: { width: 512, height: 384 },
-        video: { width: 512, height: 384 },
-        storyboard: { width: 398, height: 256 },
-      };
-
-      let width: number | undefined;
-      let height: number | undefined;
-
-      if (dimensionsStr) {
-        const dims = JSON.parse(dimensionsStr);
-        width = dims.width;
-        height = dims.height;
-      } else {
-        const defaults = defaultDimensions[type];
-        width = defaults?.width;
-        height = defaults?.height;
-      }
-
-      const newNode: CanvasNode = {
-        id: uuidv4(),
-        type,
-        position,
-        data: dataStr ? JSON.parse(dataStr) : { label: `${type} node` },
-        width,
-        height,
-      };
-
-      addNode(newNode);
-    },
-    [screenToFlowPosition, addNode, t]
-  );
-
-  // Save status indicator
-  const saveStatusText = isSaving ? t('canvas.saving') : isDirty ? t('canvas.unsaved') : lastSavedAt ? t('canvas.saved') : '';
-  const SaveIcon = isSaving ? Loader2 : isDirty ? Save : Check;
-
+  // --- Loading state ---
   if (isLoading) {
     return (
       <div className="flex h-screen w-full items-center justify-center bg-background text-foreground">
@@ -738,23 +124,6 @@ function InfiniteCanvas() {
     );
   }
 
-  // 拖拽提示映射表（避免 switch-case）
-  const FILE_TYPE_ICONS: Record<string, React.ReactNode> = {
-    text: <FileText className="w-8 h-8 text-blue-500" />,
-    image: <Image className="w-8 h-8 text-emerald-500" />,
-    video: <Film className="w-8 h-8 text-purple-500" />,
-    audio: <Music className="w-8 h-8 text-amber-500" />,
-  };
-  const FILE_TYPE_LABELS: Record<string, string> = {
-    text: t('canvas.fileType.text'),
-    image: t('canvas.fileType.image'),
-    video: t('canvas.fileType.video'),
-    audio: t('canvas.fileType.audio'),
-  };
-
-  const getFileTypeIcon = () => FILE_TYPE_ICONS[dragFileType ?? ''] ?? <FileText className="w-8 h-8 text-muted-foreground" />;
-  const getFileTypeLabel = () => FILE_TYPE_LABELS[dragFileType ?? ''] ?? t('canvas.fileType.default');
-
   return (
     <div className="flex h-screen w-full overflow-hidden bg-background text-foreground">
       <Sidebar />
@@ -764,25 +133,8 @@ function InfiniteCanvas() {
         onDragLeave={onDragLeave}
       >
         {/* File drag overlay */}
-        {isDraggingFile && (
-          <div className="absolute inset-0 z-50 bg-primary/10 backdrop-blur-sm flex items-center justify-center pointer-events-none">
-            <div 
-              className="bg-card border-2 border-primary border-dashed rounded-xl p-8 shadow-2xl flex flex-col items-center gap-4 animate-in fade-in zoom-in-95 duration-200"
-              style={{
-                position: 'absolute',
-                left: dragPosition.x - 100,
-                top: dragPosition.y - 80,
-                pointerEvents: 'none',
-              }}
-            >
-              {getFileTypeIcon()}
-              <div className="text-center">
-                <p className="text-lg font-semibold text-foreground">{t('canvas.dropToCreateNode', { type: getFileTypeLabel() })}</p>
-                <p className="text-sm text-muted-foreground mt-1">{t('canvas.multiFileDrop')}</p>
-              </div>
-            </div>
-          </div>
-        )}
+        <FileDragOverlay isDraggingFile={isDraggingFile} dragFileType={dragFileType} dragPosition={dragPosition} />
+
         <ReactFlow
           nodes={nodes}
           edges={edges}
@@ -817,7 +169,7 @@ function InfiniteCanvas() {
         >
           <Background gap={60} size={2} className="text-muted-foreground dark:text-muted-foreground" variant={BackgroundVariant.Dots} />
           
-          {/* Snap alignment lines - convert flow coordinates to screen coordinates */}
+          {/* Snap alignment lines */}
           {snapToGuides && alignmentLines.vertical !== null && (
             <div
               className="absolute top-0 bottom-0 w-px bg-primary/50 pointer-events-none z-50 transition-opacity"
@@ -866,39 +218,20 @@ function InfiniteCanvas() {
                 snapToGuides={snapToGuides}
                 onToggleSnapToGuides={() => setSnapToGuides(!snapToGuides)}
               />
-              {/* Help 按钮 - 与工具条分离 */}
               <CanvasHelpButton />
             </div>
           </Panel>
           
           <Panel position="top-left" className="m-4 z-50">
-            <div className="flex items-center bg-card border border-border/50 rounded-lg p-1 gap-1 pointer-events-auto">
-              <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-foreground" onClick={() => router.push('/')} title={t('canvas.back')}>
-                <ArrowLeft className="w-4 h-4" />
-              </Button>
-              <div className="w-px h-4 bg-border/50 mx-1" />
-              <input
-                type="text"
-                value={theaterTitle}
-                onChange={(e) => setTheaterTitle(e.target.value)}
-                className="bg-transparent text-sm font-medium text-foreground outline-none border-none px-2 py-1 w-40 truncate"
-                placeholder={t('canvas.theaterName')}
-              />
-              <div className="w-px h-4 bg-border/50 mx-1" />
-              <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-foreground" onClick={undo} title={t('canvas.undo')}>
-                <Undo className="w-4 h-4" />
-              </Button>
-              <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-foreground" onClick={redo} title={t('canvas.redo')}>
-                <Redo className="w-4 h-4" />
-              </Button>
-              <div className="w-px h-4 bg-border/50 mx-1" />
-              {saveStatusText && (
-                <div className="flex items-center gap-1.5 px-2">
-                  <SaveIcon className={`w-3.5 h-3.5 text-muted-foreground ${isSaving ? 'animate-spin' : ''}`} />
-                  <span className="text-xs text-muted-foreground whitespace-nowrap">{saveStatusText}</span>
-                </div>
-              )}
-            </div>
+            <CanvasToolbar
+              theaterTitle={theaterTitle}
+              setTheaterTitle={setTheaterTitle}
+              undo={undo}
+              redo={redo}
+              isSaving={isSaving}
+              isDirty={isDirty}
+              lastSavedAt={lastSavedAt}
+            />
           </Panel>
 
           <Panel position="top-right" className="flex gap-2 items-center pointer-events-none">
@@ -906,43 +239,11 @@ function InfiniteCanvas() {
           </Panel>
         </ReactFlow>
 
-        {/* 画布操作提示 */}
+        {/* Canvas hints */}
         <CanvasHints />
 
-        {menuState.show && (
-          <Card 
-            className="quick-add-menu fixed z-[100] p-2 shadow-xl border-border/50 flex flex-col gap-1 w-48 bg-card"
-            style={{ 
-              left: menuState.x, 
-              top: menuState.y,
-              transform: 'translate(-50%, 10px)'
-            }}
-          >
-            <div className="text-xs font-medium text-muted-foreground px-2 py-1 mb-1">
-              {t('canvas.createConnectedNode')}
-            </div>
-            <Button variant="ghost" className="justify-start px-2 py-1.5 h-auto text-sm" onClick={() => handleAddNodeFromMenu('text')}>
-              <ScrollText className="w-4 h-4 mr-2 text-indigo-500" />
-              {t('canvas.textCard')}
-            </Button>
-            <Button variant="ghost" className="justify-start px-2 py-1.5 h-auto text-sm" onClick={() => handleAddNodeFromMenu('image')}>
-              <User className="w-4 h-4 mr-2 text-emerald-500" />
-              {t('canvas.imageCard')}
-            </Button>
-            <Button variant="ghost" className="justify-start px-2 py-1.5 h-auto text-sm" onClick={() => handleAddNodeFromMenu('video')}>
-              <Film className="w-4 h-4 mr-2 text-purple-500" />
-              {t('canvas.videoCard')}
-            </Button>
-            <Button variant="ghost" className="justify-start px-2 py-1.5 h-auto text-sm" onClick={() => handleAddNodeFromMenu('audio')}>
-              <Headphones className="w-4 h-4 mr-2 text-amber-500" />
-              {t('canvas.audioCard')}
-            </Button>
-            <Button variant="ghost" className="justify-start px-2 py-1.5 h-auto text-sm" onClick={() => handleAddNodeFromMenu('storyboard')}>
-              <Clapperboard className="w-4 h-4 mr-2 text-amber-500" />
-              {t('canvas.storyboardCard')}
-            </Button>
-          </Card>
-        )}
+        {/* Quick add menu (on connection end) */}
+        <QuickAddMenu menuState={menuState} onAddNode={handleAddNodeFromMenu} />
       </div>
     </div>
   );

--- a/frontend/src/components/canvas/CanvasCursor.tsx
+++ b/frontend/src/components/canvas/CanvasCursor.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
+import { MousePointer2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 /**
@@ -71,17 +72,9 @@ export function CanvasCursor() {
         transform: 'translate(-50%, -50%)',
       }}
     >
-      {/* 默认/框选模式 - 十字准星 */}
+      {/* 默认/框选模式 - MousePointer2 指针 */}
       {cursorMode !== 'pan' && (
-        <div className="relative w-6 h-6">
-          {/* 外圆环 */}
-          <div className="absolute inset-0 rounded-full border-2 border-primary/30" />
-          {/* 十字线 */}
-          <div className="absolute top-1/2 left-0 right-0 h-0.5 bg-primary -translate-y-1/2" />
-          <div className="absolute left-1/2 top-0 bottom-0 w-0.5 bg-primary -translate-x-1/2" />
-          {/* 中心点 */}
-          <div className="absolute top-1/2 left-1/2 w-1.5 h-1.5 bg-primary rounded-full -translate-x-1/2 -translate-y-1/2" />
-        </div>
+        <MousePointer2 className="w-5 h-5 text-primary drop-shadow-md" />
       )}
 
       {/* 拖拽模式 - 手型 */}

--- a/frontend/src/components/canvas/CanvasToolbar.tsx
+++ b/frontend/src/components/canvas/CanvasToolbar.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import { Save, Undo, Redo, ArrowLeft, Loader2, Check } from 'lucide-react';
+
+interface CanvasToolbarProps {
+  theaterTitle: string;
+  setTheaterTitle: (title: string) => void;
+  undo: () => void;
+  redo: () => void;
+  isSaving: boolean;
+  isDirty: boolean;
+  lastSavedAt: number | null;
+}
+
+export function CanvasToolbar({
+  theaterTitle,
+  setTheaterTitle,
+  undo,
+  redo,
+  isSaving,
+  isDirty,
+  lastSavedAt,
+}: CanvasToolbarProps) {
+  const router = useRouter();
+  const { t } = useTranslation();
+
+  const saveStatusText = isSaving ? t('canvas.saving') : isDirty ? t('canvas.unsaved') : lastSavedAt ? t('canvas.saved') : '';
+  const SaveIcon = isSaving ? Loader2 : isDirty ? Save : Check;
+
+  return (
+    <div className="flex items-center bg-card border border-border/50 rounded-lg p-1 gap-1 pointer-events-auto">
+      <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-foreground" onClick={() => router.push('/')} title={t('canvas.back')}>
+        <ArrowLeft className="w-4 h-4" />
+      </Button>
+      <div className="w-px h-4 bg-border/50 mx-1" />
+      <input
+        type="text"
+        value={theaterTitle}
+        onChange={(e) => setTheaterTitle(e.target.value)}
+        className="bg-transparent text-sm font-medium text-foreground outline-none border-none px-2 py-1 w-40 truncate"
+        placeholder={t('canvas.theaterName')}
+      />
+      <div className="w-px h-4 bg-border/50 mx-1" />
+      <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-foreground" onClick={undo} title={t('canvas.undo')}>
+        <Undo className="w-4 h-4" />
+      </Button>
+      <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-foreground" onClick={redo} title={t('canvas.redo')}>
+        <Redo className="w-4 h-4" />
+      </Button>
+      <div className="w-px h-4 bg-border/50 mx-1" />
+      {saveStatusText && (
+        <div className="flex items-center gap-1.5 px-2">
+          <SaveIcon className={`w-3.5 h-3.5 text-muted-foreground ${isSaving ? 'animate-spin' : ''}`} />
+          <span className="text-xs text-muted-foreground whitespace-nowrap">{saveStatusText}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/canvas/FileDragOverlay.tsx
+++ b/frontend/src/components/canvas/FileDragOverlay.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useTranslation } from 'react-i18next';
+import { FileText, Image, Film, Music } from 'lucide-react';
+import type { FileType } from '@/app/theater/[id]/hooks/useFileDragDrop';
+
+interface FileDragOverlayProps {
+  isDraggingFile: boolean;
+  dragFileType: FileType | null;
+  dragPosition: { x: number; y: number };
+}
+
+// Icon and label mappings (avoids switch-case)
+const FILE_TYPE_ICONS: Record<string, React.ReactNode> = {
+  text: <FileText className="w-8 h-8 text-blue-500" />,
+  image: <Image className="w-8 h-8 text-emerald-500" />,
+  video: <Film className="w-8 h-8 text-purple-500" />,
+  audio: <Music className="w-8 h-8 text-amber-500" />,
+};
+
+const FILE_TYPE_LABEL_KEYS: Record<string, string> = {
+  text: 'canvas.fileType.text',
+  image: 'canvas.fileType.image',
+  video: 'canvas.fileType.video',
+  audio: 'canvas.fileType.audio',
+};
+
+export function FileDragOverlay({ isDraggingFile, dragFileType, dragPosition }: FileDragOverlayProps) {
+  const { t } = useTranslation();
+
+  if (!isDraggingFile) return null;
+
+  const icon = FILE_TYPE_ICONS[dragFileType ?? ''] ?? <FileText className="w-8 h-8 text-muted-foreground" />;
+  const label = t(FILE_TYPE_LABEL_KEYS[dragFileType ?? ''] ?? 'canvas.fileType.default');
+
+  return (
+    <div className="absolute inset-0 z-50 bg-primary/10 backdrop-blur-sm flex items-center justify-center pointer-events-none">
+      <div
+        className="bg-card border-2 border-primary border-dashed rounded-xl p-8 shadow-2xl flex flex-col items-center gap-4 animate-in fade-in zoom-in-95 duration-200"
+        style={{
+          position: 'absolute',
+          left: dragPosition.x - 100,
+          top: dragPosition.y - 80,
+          pointerEvents: 'none',
+        }}
+      >
+        {icon}
+        <div className="text-center">
+          <p className="text-lg font-semibold text-foreground">{t('canvas.dropToCreateNode', { type: label })}</p>
+          <p className="text-sm text-muted-foreground mt-1">{t('canvas.multiFileDrop')}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/canvas/QuickAddMenu.tsx
+++ b/frontend/src/components/canvas/QuickAddMenu.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { ScrollText, User, Film, Headphones, Clapperboard } from 'lucide-react';
+import type { QuickAddMenuState } from '@/app/theater/[id]/hooks/useQuickAddMenu';
+
+interface QuickAddMenuProps {
+  menuState: QuickAddMenuState;
+  onAddNode: (type: string) => void;
+}
+
+// Menu items config (avoids repetitive JSX)
+const MENU_ITEMS: Array<{ type: string; icon: typeof ScrollText; iconClass: string; labelKey: string }> = [
+  { type: 'text', icon: ScrollText, iconClass: 'text-indigo-500', labelKey: 'canvas.textCard' },
+  { type: 'image', icon: User, iconClass: 'text-emerald-500', labelKey: 'canvas.imageCard' },
+  { type: 'video', icon: Film, iconClass: 'text-purple-500', labelKey: 'canvas.videoCard' },
+  { type: 'audio', icon: Headphones, iconClass: 'text-amber-500', labelKey: 'canvas.audioCard' },
+  { type: 'storyboard', icon: Clapperboard, iconClass: 'text-amber-500', labelKey: 'canvas.storyboardCard' },
+];
+
+export function QuickAddMenu({ menuState, onAddNode }: QuickAddMenuProps) {
+  const { t } = useTranslation();
+
+  if (!menuState.show) return null;
+
+  return (
+    <Card
+      className="quick-add-menu fixed z-[100] p-2 shadow-xl border-border/50 flex flex-col gap-1 w-48 bg-card"
+      style={{
+        left: menuState.x,
+        top: menuState.y,
+        transform: 'translate(-50%, 10px)',
+      }}
+    >
+      <div className="text-xs font-medium text-muted-foreground px-2 py-1 mb-1">
+        {t('canvas.createConnectedNode')}
+      </div>
+      {MENU_ITEMS.map((item) => {
+        const Icon = item.icon;
+        return (
+          <Button
+            key={item.type}
+            variant="ghost"
+            className="justify-start px-2 py-1.5 h-auto text-sm"
+            onClick={() => onAddNode(item.type)}
+          >
+            <Icon className={`w-4 h-4 mr-2 ${item.iconClass}`} />
+            {t(item.labelKey)}
+          </Button>
+        );
+      })}
+    </Card>
+  );
+}


### PR DESCRIPTION
- 删除 NarrativeEngine 类及其相关的模型初始化、加载配置和章节生成逻辑
- 保留 DialogAgent 类及其回复机制和技能注册功能
- 精简初始化流程，移除无用的代理创建方法
- 保持模型使用和消息格式化的核心功能不变
- 优化日志及异常处理，移除不再使用的依赖和代码
- 前端样式文件未改动，保持原样