### PR TITLE
feat(admin): 添加 admin_dashboard 路由支持

### DIFF
--- a/backend/admin/package-lock.json
+++ b/backend/admin/package-lock.json
@@ -27,6 +27,7 @@
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-toast": "^1.2.15",
         "@radix-ui/react-tooltip": "^1.2.8",
+        "@tanstack/react-virtual": "^3.13.23",
         "axios": "^1.13.5",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -4792,6 +4793,33 @@
       },
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.23",
+      "resolved": "https://registry.npmmirror.com/@tanstack/react-virtual/-/react-virtual-3.13.23.tgz",
+      "integrity": "sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.23"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.23",
+      "resolved": "https://registry.npmmirror.com/@tanstack/virtual-core/-/virtual-core-3.13.23.tgz",
+      "integrity": "sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/backend/admin/package.json
+++ b/backend/admin/package.json
@@ -28,6 +28,7 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-toast": "^1.2.15",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@tanstack/react-virtual": "^3.13.23",
     "axios": "^1.13.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/backend/admin/src/app/admin/page.tsx
+++ b/backend/admin/src/app/admin/page.tsx
@@ -1,108 +1,533 @@
 'use client';
 
-import React from 'react';
+import React, { useState, useRef } from 'react';
+import {
+  Users,
+  UserCheck,
+  BookOpen,
+  FileImage,
+  Video,
+  Coins,
+  TrendingUp,
+  AlertTriangle,
+  Loader2,
+  Crown,
+  Wrench,
+  Clock,
+  Music,
+  Film,
+  ImageIcon,
+} from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { User, BookOpen, FileImage, Bot } from 'lucide-react';
-import useSWR from 'swr';
-import api from '@/lib/axios';
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import { Badge } from '@/components/ui/badge';
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { Separator } from '@/components/ui/separator';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import {
+  useDashboardOverview,
+  useRegistrationTrend,
+  useTokenLeaderboard,
+  useSubscriptionAnalysis,
+  useContentStats,
+} from '@/hooks/useDashboard';
+import {
+  ResponsiveContainer,
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  BarChart,
+  Bar,
+  PieChart,
+  Pie,
+  Cell,
+} from 'recharts';
 
-const fetcher = (url: string) => api.get(url).then((res) => res.data);
+// ---------------------------------------------------------------------------
+// Constants & helpers
+// ---------------------------------------------------------------------------
 
-export default function AdminDashboard() {
-  const { data: stats, error, isLoading } = useSWR('/admin/stats', fetcher);
+const TOOLTIP_STYLE = {
+  backgroundColor: 'hsl(var(--card))',
+  borderColor: 'hsl(var(--border))',
+  color: 'hsl(var(--card-foreground))',
+};
 
-  if (error) return <div className="p-4">加载失败</div>;
-  if (isLoading) return <div className="p-4">加载中...</div>;
+const BUCKET_LABELS: Record<string, string> = {
+  today: '今日',
+  yesterday: '昨日',
+  this_week: '本周',
+  this_month: '本月',
+  older: '更早',
+};
 
-  const data = [
-    { name: '用户', count: stats.users },
-    { name: '故事', count: stats.stories },
-    { name: '资产', count: stats.assets },
-    { name: '供应商', count: stats.providers },
+const PIE_COLORS = [
+  'hsl(var(--chart-1, 220 70% 50%))',
+  'hsl(var(--chart-2, 160 60% 45%))',
+  'hsl(var(--chart-3, 30 80% 55%))',
+  'hsl(var(--chart-4, 280 65% 60%))',
+  'hsl(var(--chart-5, 340 75% 55%))',
+];
+
+const fmt = (n?: number | null) => (n ?? 0).toLocaleString();
+const pct = (n?: number | null) => `${(n ?? 0).toFixed(2)}%`;
+
+// ---------------------------------------------------------------------------
+// Period / Limit options
+// ---------------------------------------------------------------------------
+
+const PERIOD_OPTIONS: Array<{ key: string; label: string }> = [
+  { key: 'today', label: '今日' },
+  { key: 'yesterday', label: '昨日' },
+  { key: 'week', label: '本周' },
+  { key: 'month', label: '本月' },
+  { key: 'quarter', label: '近三月' },
+  { key: 'all', label: '全部' },
+];
+
+const PERIOD_TITLE: Record<string, string> = {
+  today: '注册趋势（今日）',
+  yesterday: '注册趋势（近 2 天）',
+  week: '注册趋势（本周）',
+  month: '注册趋势（近 30 天）',
+  quarter: '注册趋势（近 3 个月）',
+  all: '注册趋势（全部）',
+};
+
+const LIMIT_OPTIONS = [10, 50, 100] as const;
+
+// ---------------------------------------------------------------------------
+// Stat Card config
+// ---------------------------------------------------------------------------
+
+interface StatCardDef {
+  key: string;
+  label: string;
+  icon: React.ElementType;
+  color: string;
+  getValue: (o: NonNullable<ReturnType<typeof useDashboardOverview>['overview']>) => string;
+}
+
+const STAT_CARDS: StatCardDef[] = [
+  { key: 'users', label: '用户总数', icon: Users, color: 'text-blue-500', getValue: (o) => fmt(o.total_users) },
+  { key: 'active', label: '活跃用户', icon: UserCheck, color: 'text-green-500', getValue: (o) => fmt(o.active_users) },
+  { key: 'theaters', label: '故事总数', icon: BookOpen, color: 'text-violet-500', getValue: (o) => fmt(o.total_theaters) },
+  { key: 'assets', label: '生成资产', icon: FileImage, color: 'text-cyan-500', getValue: (o) => fmt(o.total_assets) },
+  { key: 'video', label: '视频任务', icon: Video, color: 'text-rose-500', getValue: (o) => fmt(o.total_video_tasks) },
+  { key: 'credits', label: '积分消耗', icon: Coins, color: 'text-amber-500', getValue: (o) => fmt(o.total_credits_consumed) },
+  { key: 'conversion', label: '付费转化率', icon: TrendingUp, color: 'text-emerald-500', getValue: (o) => pct(o.paid_conversion_rate) },
+  { key: 'error', label: 'API 错误率', icon: AlertTriangle, color: 'text-red-500', getValue: (o) => pct(o.api_error_rate) },
+];
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function LoadingSpinner() {
+  return (
+    <div className="flex items-center justify-center py-16">
+      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+    </div>
+  );
+}
+
+function StatCardGrid() {
+  const { overview, isLoading } = useDashboardOverview();
+
+  if (isLoading) return <LoadingSpinner />;
+
+  return (
+    <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+      {STAT_CARDS.map(({ key, label, icon: Icon, color, getValue }) => (
+        <Card key={key} className="relative overflow-hidden">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-1">
+            <CardTitle className="text-xs font-medium text-muted-foreground">{label}</CardTitle>
+            <Icon className={`h-4 w-4 ${color}`} />
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-bold tracking-tight">{overview ? getValue(overview) : '—'}</p>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Registration trend
+// ---------------------------------------------------------------------------
+
+function RegistrationTrendChart() {
+  const [period, setPeriod] = useState('month');
+  const { trend, isLoading } = useRegistrationTrend(period);
+
+  const buckets = trend?.buckets ?? {};
+  const daily = trend?.daily ?? [];
+
+  return (
+    <Card className="flex flex-col">
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="text-base">{PERIOD_TITLE[period] ?? '注册趋势'}</CardTitle>
+          <div className="flex gap-1">
+            {PERIOD_OPTIONS.map(({ key, label }) => (
+              <button
+                key={key}
+                onClick={() => setPeriod(key)}
+                className={`rounded-md px-2 py-0.5 text-xs transition-colors ${
+                  period === key
+                    ? 'bg-primary text-primary-foreground'
+                    : 'text-muted-foreground hover:bg-muted'
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2 pt-1">
+          {Object.entries(BUCKET_LABELS).map(([k, v]) => (
+            <Badge key={k} variant="secondary" className="text-xs font-normal">
+              {v}：{fmt(buckets[k])}
+            </Badge>
+          ))}
+        </div>
+      </CardHeader>
+      <CardContent className="flex-1 pt-0">
+        {isLoading ? <LoadingSpinner /> : (
+          <div className="h-[260px] w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              <AreaChart data={daily} margin={{ top: 8, right: 8, left: -16, bottom: 0 }}>
+                <defs>
+                  <linearGradient id="regGrad" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor="hsl(var(--primary))" stopOpacity={0.3} />
+                    <stop offset="100%" stopColor="hsl(var(--primary))" stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+                <XAxis
+                  dataKey="date"
+                  tick={{ fontSize: 11 }}
+                  tickFormatter={(v: string) => v.slice(5)}
+                  className="fill-muted-foreground"
+                />
+                <YAxis tick={{ fontSize: 11 }} className="fill-muted-foreground" allowDecimals={false} />
+                <Tooltip contentStyle={TOOLTIP_STYLE} labelFormatter={(l) => `日期：${l}`} />
+                <Area
+                  type="monotone"
+                  dataKey="count"
+                  name="注册数"
+                  stroke="hsl(var(--primary))"
+                  fill="url(#regGrad)"
+                  strokeWidth={2}
+                />
+              </AreaChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Token leaderboard (virtual scroll)
+// ---------------------------------------------------------------------------
+
+const RANK_COLORS: Record<number, string> = {
+  1: 'text-amber-500',
+  2: 'text-slate-400',
+  3: 'text-amber-700',
+};
+
+const ROW_HEIGHT = 52;
+
+function TokenLeaderboard() {
+  const [limit, setLimit] = useState<number>(10);
+  const { leaderboard, isLoading } = useTokenLeaderboard(limit);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const rowVirtualizer = useVirtualizer({
+    count: leaderboard.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => ROW_HEIGHT,
+    overscan: 8,
+  });
+
+  return (
+    <Card className="flex h-full flex-col">
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <Crown className="h-4 w-4 text-amber-500" />
+            <CardTitle className="text-base">Token 消耗排行榜</CardTitle>
+          </div>
+          <div className="flex gap-1">
+            {LIMIT_OPTIONS.map((n) => (
+              <button
+                key={n}
+                onClick={() => setLimit(n)}
+                className={`rounded-md px-2 py-0.5 text-xs transition-colors ${
+                  limit === n
+                    ? 'bg-primary text-primary-foreground'
+                    : 'text-muted-foreground hover:bg-muted'
+                }`}
+              >
+                Top {n}
+              </button>
+            ))}
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-1 flex-col pt-0">
+        {isLoading ? <LoadingSpinner /> : leaderboard.length === 0 ? (
+          <p className="py-8 text-center text-sm text-muted-foreground">暂无数据</p>
+        ) : (
+          <>
+            {/* Table header */}
+            <div className="grid grid-cols-[40px_1fr_100px_80px] gap-1 border-b px-1 pb-1.5 text-xs font-medium text-muted-foreground">
+              <span>#</span>
+              <span>用户</span>
+              <span className="text-right">总 Token</span>
+              <span className="text-right">积分</span>
+            </div>
+            {/* Virtual scroll area */}
+            <div
+              ref={scrollRef}
+              className="flex-1 overflow-auto"
+            >
+              <div
+                style={{ height: rowVirtualizer.getTotalSize(), position: 'relative', width: '100%' }}
+              >
+                {rowVirtualizer.getVirtualItems().map((vRow) => {
+                  const entry = leaderboard[vRow.index];
+                  return (
+                    <div
+                      key={entry.user_id}
+                      className="absolute left-0 top-0 grid w-full grid-cols-[40px_1fr_100px_80px] items-center gap-1 border-b border-border/50 px-1"
+                      style={{ height: vRow.size, transform: `translateY(${vRow.start}px)` }}
+                    >
+                      <span className={`text-sm font-semibold tabular-nums ${RANK_COLORS[entry.rank] ?? ''}`}>
+                        {entry.rank}
+                      </span>
+                      <div className="flex items-center gap-2 min-w-0">
+                        <Avatar className="h-6 w-6 shrink-0">
+                          <AvatarFallback className="text-[10px]">
+                            {(entry.nickname?.[0] ?? entry.email?.[0] ?? '?').toUpperCase()}
+                          </AvatarFallback>
+                        </Avatar>
+                        <div className="min-w-0">
+                          <p className="truncate text-sm font-medium leading-none">{entry.nickname || '—'}</p>
+                          <p className="truncate text-xs text-muted-foreground">{entry.email}</p>
+                        </div>
+                      </div>
+                      <span className="text-right text-sm tabular-nums">{fmt(entry.total_tokens)}</span>
+                      <span className="text-right text-sm tabular-nums">{fmt(entry.credits)}</span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Subscription analysis
+// ---------------------------------------------------------------------------
+
+function SubscriptionAnalysis() {
+  const { subscriptions, isLoading } = useSubscriptionAnalysis();
+
+  if (isLoading) return <LoadingSpinner />;
+
+  const byPlan = subscriptions?.by_plan ?? [];
+  const timeBuckets = subscriptions?.time_buckets ?? {};
+
+  return (
+    <Card className="flex flex-col">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">订阅分析</CardTitle>
+        <p className="text-xs text-muted-foreground">
+          活跃订阅：{fmt(subscriptions?.total_active_subscriptions)}
+        </p>
+      </CardHeader>
+      <CardContent className="flex-1 pt-0">
+        <div className="h-[220px] w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={byPlan} margin={{ top: 8, right: 8, left: -16, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+              <XAxis dataKey="plan_name" tick={{ fontSize: 11 }} className="fill-muted-foreground" />
+              <YAxis tick={{ fontSize: 11 }} className="fill-muted-foreground" allowDecimals={false} />
+              <Tooltip
+                contentStyle={TOOLTIP_STYLE}
+                formatter={(value, name) => [fmt(value as number), name]}
+              />
+              <Bar dataKey="active_count" name="活跃用户" fill="hsl(var(--primary))" radius={[4, 4, 0, 0]} />
+              <Bar dataKey="revenue" name="收入 (USD)" fill="hsl(var(--chart-2, 160 60% 45%))" radius={[4, 4, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+        <Separator className="my-3" />
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+          {Object.entries(timeBuckets).map(([k, v]) => (
+            <span key={k}>{BUCKET_LABELS[k] ?? k}：<strong className="text-foreground">{fmt(v)}</strong></span>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Content stats (pie charts)
+// ---------------------------------------------------------------------------
+
+function ContentStats() {
+  const { content, isLoading } = useContentStats();
+
+  if (isLoading) return <LoadingSpinner />;
+
+  const video = content?.video;
+  const image = content?.image;
+  const music = content?.music;
+
+  const pieData = [
+    { name: '视频成功', value: video?.completed ?? 0 },
+    { name: '视频失败', value: video?.failed ?? 0 },
+    { name: '图像成功', value: image?.completed ?? 0 },
+    { name: '图像失败', value: image?.failed ?? 0 },
+    { name: '音乐成功', value: music?.completed ?? 0 },
+    { name: '音乐失败', value: music?.failed ?? 0 },
+  ];
+
+  const successCards = [
+    { label: '视频生成', icon: Film, total: video?.total ?? 0, rate: video?.success_rate ?? 0, color: 'text-rose-500' },
+    { label: '图像生成', icon: ImageIcon, total: image?.total ?? 0, rate: image?.success_rate ?? 0, color: 'text-cyan-500' },
+    { label: '音乐生成', icon: Music, total: music?.total ?? 0, rate: music?.success_rate ?? 0, color: 'text-violet-500' },
   ];
 
   return (
-    <div className="max-w-[1200px] mx-auto w-full space-y-4">
-      <h2 className="text-3xl font-bold tracking-tight">仪表盘</h2>
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">
-              用户总数
-            </CardTitle>
-            <User className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold text-green-600">{stats.users}</div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">
-              故事总数
-            </CardTitle>
-            <BookOpen className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold text-red-600">{stats.stories}</div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">
-              生成资产数
-            </CardTitle>
-            <FileImage className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold text-blue-600">{stats.assets}</div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">
-              AI 供应商
-            </CardTitle>
-            <Bot className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold text-yellow-600">{stats.providers}</div>
-          </CardContent>
-        </Card>
+    <Card className="flex flex-col">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">内容生成统计</CardTitle>
+      </CardHeader>
+      <CardContent className="flex-1 pt-0">
+        <div className="grid grid-cols-3 gap-3 mb-3">
+          {successCards.map(({ label, icon: Icon, total, rate, color }) => (
+            <div key={label} className="rounded-lg border p-3">
+              <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <Icon className={`h-3.5 w-3.5 ${color}`} />
+                {label}
+              </div>
+              <p className="mt-1 text-lg font-bold">{fmt(total)}</p>
+              <p className="text-xs text-muted-foreground">
+                成功率：<span className="text-foreground font-medium">{rate.toFixed(1)}%</span>
+              </p>
+            </div>
+          ))}
+        </div>
+        <div className="h-[180px] w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <PieChart>
+              <Pie
+                data={pieData}
+                cx="50%"
+                cy="50%"
+                innerRadius={45}
+                outerRadius={72}
+                paddingAngle={3}
+                dataKey="value"
+                nameKey="name"
+                strokeWidth={0}
+              >
+                {pieData.map((_, i) => (
+                  <Cell key={i} fill={PIE_COLORS[i % PIE_COLORS.length]} />
+                ))}
+              </Pie>
+              <Tooltip contentStyle={TOOLTIP_STYLE} />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Operational metrics
+// ---------------------------------------------------------------------------
+
+function OperationalMetrics() {
+  const { overview, isLoading: overviewLoading } = useDashboardOverview();
+  const { content, isLoading: contentLoading } = useContentStats();
+
+  if (overviewLoading || contentLoading) return <LoadingSpinner />;
+
+  const tool = content?.tool_execution;
+
+  const metrics = [
+    { label: '工具总调用', value: fmt(overview?.tool_total_calls), icon: Wrench, color: 'text-blue-500' },
+    { label: '工具错误数', value: fmt(overview?.tool_errors), icon: AlertTriangle, color: 'text-red-500' },
+    { label: '错误率', value: pct(tool?.error_rate), icon: TrendingUp, color: 'text-amber-500' },
+    { label: '平均耗时', value: tool?.avg_duration_ms != null ? `${tool.avg_duration_ms.toFixed(0)} ms` : '—', icon: Clock, color: 'text-emerald-500' },
+  ];
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">运营指标</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+          {metrics.map(({ label, value, icon: Icon, color }) => (
+            <div key={label} className="rounded-lg border p-3">
+              <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <Icon className={`h-3.5 w-3.5 ${color}`} />
+                {label}
+              </div>
+              <p className="mt-1 text-xl font-bold tabular-nums">{value}</p>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export default function AdminDashboard() {
+  return (
+    <div className="mx-auto w-full max-w-[1400px] space-y-4 p-4">
+      <h2 className="text-2xl font-bold tracking-tight">仪表盘</h2>
+
+      {/* Row 1: Stat cards */}
+      <StatCardGrid />
+
+      {/* Row 2+3: Left stack (trend + subscription) | Right (token leaderboard spans full height) */}
+      <div className="grid gap-4 lg:grid-cols-5">
+        <div className="flex flex-col gap-4 lg:col-span-3">
+          <RegistrationTrendChart />
+          <SubscriptionAnalysis />
+        </div>
+        <div className="lg:col-span-2">
+          <TokenLeaderboard />
+        </div>
       </div>
 
-      <div className="grid gap-4 md:grid-cols-1">
-        <Card className="col-span-4">
-          <CardHeader>
-            <CardTitle>系统概览</CardTitle>
-          </CardHeader>
-          <CardContent className="pl-2">
-            <div className="h-[300px] w-full min-w-0">
-              <ResponsiveContainer width="100%" height={300}>
-                <BarChart
-                  data={data}
-                  margin={{
-                    top: 5,
-                    right: 30,
-                    left: 20,
-                    bottom: 5,
-                  }}
-                >
-                  <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis dataKey="name" />
-                  <YAxis />
-                  <Tooltip 
-                    contentStyle={{ backgroundColor: 'hsl(var(--card))', borderColor: 'hsl(var(--border))', color: 'hsl(var(--card-foreground))' }}
-                  />
-                  <Legend />
-                  <Bar dataKey="count" fill="hsl(var(--primary))" name="数量" />
-                </BarChart>
-              </ResponsiveContainer>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+      {/* Row 4: Content stats */}
+      <ContentStats />
+
+      {/* Row 4: Operational metrics */}
+      <OperationalMetrics />
     </div>
   );
 }

--- a/backend/admin/src/hooks/useDashboard.ts
+++ b/backend/admin/src/hooks/useDashboard.ts
@@ -1,0 +1,91 @@
+import useSWR from 'swr';
+import api from '@/lib/axios';
+
+const fetcher = (url: string) => api.get(url).then((r) => r.data);
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface OverviewData {
+  total_users: number;
+  active_users: number;
+  total_theaters: number;
+  total_assets: number;
+  total_video_tasks: number;
+  total_music_tasks: number;
+  total_credits_consumed: number;
+  paid_users: number;
+  paid_conversion_rate: number;
+  api_error_rate: number;
+  tool_total_calls: number;
+  tool_errors: number;
+}
+
+export interface RegistrationTrendData {
+  buckets: Record<string, number>;
+  daily: Array<{ date: string; count: number }>;
+  period: string;
+}
+
+export interface TokenLeaderboardEntry {
+  rank: number;
+  user_id: string;
+  nickname: string;
+  email: string;
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  credits: number;
+}
+
+export interface PlanBreakdown {
+  plan_id: string;
+  plan_name: string;
+  price_usd: number;
+  active_count: number;
+  revenue: number;
+}
+
+export interface SubscriptionAnalysisData {
+  total_active_subscriptions: number;
+  by_plan: PlanBreakdown[];
+  time_buckets: Record<string, number>;
+}
+
+export interface ContentStatsData {
+  video: { total: number; completed: number; failed: number; success_rate: number };
+  image: { total: number; completed: number; failed: number; success_rate: number };
+  music: { total: number; completed: number; failed: number; success_rate: number };
+  assets_by_type: Record<string, number>;
+  tool_execution: { total: number; errors: number; error_rate: number; avg_duration_ms: number | null };
+}
+
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
+
+export function useDashboardOverview() {
+  const { data, error, isLoading } = useSWR<OverviewData>('/admin/dashboard/overview', fetcher);
+  return { overview: data, error, isLoading };
+}
+
+export function useRegistrationTrend(period: string = 'month') {
+  const { data, error, isLoading } = useSWR<RegistrationTrendData>(`/admin/dashboard/registration-trend?period=${period}`, fetcher);
+  return { trend: data, error, isLoading };
+}
+
+export function useTokenLeaderboard(limit: number = 10) {
+  const { data, error, isLoading } = useSWR<TokenLeaderboardEntry[]>(`/admin/dashboard/token-leaderboard?limit=${limit}`, fetcher);
+  return { leaderboard: data ?? [], error, isLoading };
+}
+
+export function useSubscriptionAnalysis() {
+  const { data, error, isLoading } = useSWR<SubscriptionAnalysisData>('/admin/dashboard/subscription-analysis', fetcher);
+  return { subscriptions: data, error, isLoading };
+}
+
+export function useContentStats() {
+  const { data, error, isLoading } = useSWR<ContentStatsData>('/admin/dashboard/content-stats', fetcher);
+  return { content: data, error, isLoading };
+}

--- a/backend/main.py
+++ b/backend/main.py
@@ -38,7 +38,7 @@ from contextlib import asynccontextmanager
 from sqlalchemy.ext.asyncio import AsyncSession
 from database import get_db, engine, Base, AsyncSessionLocal
 from models import User
-from routers import llm_config, admin as admin_router, agents, chats, orchestrate, media, subscriptions, admin_auth, prompt_templates, videos, theaters, skills_api, admin_debug, admin_tools, music
+from routers import llm_config, admin as admin_router, agents, chats, orchestrate, media, subscriptions, admin_auth, prompt_templates, videos, theaters, skills_api, admin_debug, admin_tools, music, admin_dashboard
 from routers import auth as auth_router
 import uvicorn
 from agents import narrative_engine
@@ -157,6 +157,7 @@ app.include_router(skills_api.router)
 app.include_router(admin_debug.router)
 app.include_router(admin_tools.router)
 app.include_router(music.router)
+app.include_router(admin_dashboard.router)
 
 
 @app.get("/")

--- a/backend/routers/admin_dashboard.py
+++ b/backend/routers/admin_dashboard.py
@@ -1,0 +1,369 @@
+"""
+管理员仪表盘路由 — 核心统计、注册趋势、Token排行、订阅分析、内容生成统计
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import select, func, case, and_, desc, literal_column
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth import require_admin
+from database import get_db
+from models import (
+    Admin, User, Theater, Asset, LLMProvider,
+    VideoTask, MusicTask, CreditTransaction,
+    SubscriptionPlan, ToolExecution,
+)
+
+router = APIRouter(
+    prefix="/api/admin/dashboard",
+    tags=["admin-dashboard"],
+    responses={404: {"description": "Not found"}},
+)
+
+# ---------------------------------------------------------------------------
+# 时间分桶工具
+# ---------------------------------------------------------------------------
+
+def _time_boundaries() -> dict[str, datetime]:
+    """返回 today/yesterday/this_week/this_month 的起始时间边界。"""
+    now = datetime.now(timezone.utc)
+    today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    return {
+        "today": today_start,
+        "yesterday": today_start - timedelta(days=1),
+        "this_week": today_start - timedelta(days=today_start.weekday()),
+        "this_month": today_start.replace(day=1),
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. 核心统计概览
+# ---------------------------------------------------------------------------
+
+@router.get("/overview")
+async def dashboard_overview(
+    _admin: Admin = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    """返回仪表盘核心统计指标。"""
+    now = datetime.now(timezone.utc)
+    thirty_days_ago = now - timedelta(days=30)
+
+    # 并行查询所有计数
+    total_users = await db.scalar(select(func.count(User.id))) or 0
+    active_users = await db.scalar(
+        select(func.count(User.id)).where(User.last_login_at >= thirty_days_ago)
+    ) or 0
+    total_theaters = await db.scalar(select(func.count(Theater.id))) or 0
+    total_assets = await db.scalar(select(func.count(Asset.id))) or 0
+    total_video_tasks = await db.scalar(select(func.count(VideoTask.id))) or 0
+    total_music_tasks = await db.scalar(select(func.count(MusicTask.id))) or 0
+
+    # 积分消耗总量（负数交易的绝对值之和）
+    total_credits_consumed = await db.scalar(
+        select(func.coalesce(func.sum(func.abs(CreditTransaction.amount)), 0))
+        .where(CreditTransaction.amount < 0)
+    ) or 0
+
+    # 付费转化率
+    paid_users = await db.scalar(
+        select(func.count(User.id)).where(User.subscription_status == "active")
+    ) or 0
+    paid_conversion_rate = round(paid_users / total_users * 100, 2) if total_users else 0
+
+    # API 错误率
+    tool_total = await db.scalar(select(func.count(ToolExecution.id))) or 0
+    tool_errors = await db.scalar(
+        select(func.count(ToolExecution.id)).where(ToolExecution.status == "error")
+    ) or 0
+    api_error_rate = round(tool_errors / tool_total * 100, 2) if tool_total else 0
+
+    return {
+        "total_users": total_users,
+        "active_users": active_users,
+        "total_theaters": total_theaters,
+        "total_assets": total_assets,
+        "total_video_tasks": total_video_tasks,
+        "total_music_tasks": total_music_tasks,
+        "total_credits_consumed": round(total_credits_consumed, 2),
+        "paid_users": paid_users,
+        "paid_conversion_rate": paid_conversion_rate,
+        "api_error_rate": api_error_rate,
+        "tool_total_calls": tool_total,
+        "tool_errors": tool_errors,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 2. 注册趋势
+# ---------------------------------------------------------------------------
+
+# 时间筛选周期到天数的映射
+PERIOD_DAYS: dict[str, int] = {
+    "today": 1,
+    "yesterday": 2,
+    "week": 7,
+    "month": 30,
+    "quarter": 90,
+    "all": 3650,
+}
+
+
+@router.get("/registration-trend")
+async def registration_trend(
+    period: str = Query(default="month", description="筛选周期: today/yesterday/week/month/quarter/all"),
+    _admin: Admin = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    """按时间段和逐日统计新注册用户数。"""
+    bounds = _time_boundaries()
+
+    # 时间分桶统计
+    buckets: dict[str, int] = {}
+    bucket_defs = [
+        ("today", bounds["today"], None),
+        ("yesterday", bounds["yesterday"], bounds["today"]),
+        ("this_week", bounds["this_week"], bounds["yesterday"]),
+        ("this_month", bounds["this_month"], bounds["this_week"]),
+    ]
+    for name, start, end in bucket_defs:
+        conditions = [User.created_at >= start]
+        end is not None and conditions.append(User.created_at < end)
+        buckets[name] = await db.scalar(
+            select(func.count(User.id)).where(and_(*conditions))
+        ) or 0
+
+    buckets["older"] = await db.scalar(
+        select(func.count(User.id)).where(User.created_at < bounds["this_month"])
+    ) or 0
+
+    # 根据 period 参数决定查询范围
+    days = PERIOD_DAYS.get(period, 30)
+    now = datetime.now(timezone.utc)
+    start_date = now - timedelta(days=days)
+    daily_result = await db.execute(
+        select(
+            func.date(User.created_at).label("day"),
+            func.count(User.id).label("count"),
+        )
+        .where(User.created_at >= start_date)
+        .group_by(func.date(User.created_at))
+        .order_by(literal_column("day"))
+    )
+    daily = [{"date": str(r.day), "count": r.count} for r in daily_result.all()]
+
+    return {"buckets": buckets, "daily": daily, "period": period}
+
+
+# ---------------------------------------------------------------------------
+# 3. Token 消耗排行榜
+# ---------------------------------------------------------------------------
+
+@router.get("/token-leaderboard")
+async def token_leaderboard(
+    limit: int = Query(default=10, le=200, description="排行榜数量: 10/50/100"),
+    _admin: Admin = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    """返回 Token 消耗 Top N 用户。"""
+    total_expr = (
+        func.coalesce(User.total_input_tokens, 0)
+        + func.coalesce(User.total_output_tokens, 0)
+    )
+    result = await db.execute(
+        select(
+            User.id,
+            User.nickname,
+            User.email,
+            User.total_input_tokens,
+            User.total_output_tokens,
+            total_expr.label("total_tokens"),
+            User.credits,
+        )
+        .order_by(desc(total_expr))
+        .limit(limit)
+    )
+    rows = result.all()
+    return [
+        {
+            "rank": idx + 1,
+            "user_id": r.id,
+            "nickname": r.nickname,
+            "email": r.email,
+            "input_tokens": r.total_input_tokens or 0,
+            "output_tokens": r.total_output_tokens or 0,
+            "total_tokens": r.total_tokens or 0,
+            "credits": round(r.credits or 0, 2),
+        }
+        for idx, r in enumerate(rows)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 4. 订阅分析
+# ---------------------------------------------------------------------------
+
+@router.get("/subscription-analysis")
+async def subscription_analysis(
+    _admin: Admin = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    """按套餐维度和时间维度分析订阅情况。"""
+    # 各套餐活跃用户数
+    plan_result = await db.execute(
+        select(
+            SubscriptionPlan.id,
+            SubscriptionPlan.name,
+            SubscriptionPlan.price_usd,
+            func.count(User.id).label("active_count"),
+        )
+        .outerjoin(
+            User,
+            and_(
+                User.subscription_plan_id == SubscriptionPlan.id,
+                User.subscription_status == "active",
+            ),
+        )
+        .group_by(SubscriptionPlan.id, SubscriptionPlan.name, SubscriptionPlan.price_usd)
+        .order_by(SubscriptionPlan.sort_order)
+    )
+    by_plan = [
+        {
+            "plan_id": r.id,
+            "plan_name": r.name,
+            "price_usd": r.price_usd,
+            "active_count": r.active_count,
+            "revenue": round(r.active_count * r.price_usd, 2),
+        }
+        for r in plan_result.all()
+    ]
+
+    # 按时间段统计新增订阅
+    bounds = _time_boundaries()
+    time_buckets: dict[str, int] = {}
+    bucket_defs = [
+        ("today", bounds["today"], None),
+        ("yesterday", bounds["yesterday"], bounds["today"]),
+        ("this_week", bounds["this_week"], bounds["yesterday"]),
+        ("this_month", bounds["this_month"], bounds["this_week"]),
+    ]
+    for name, start, end in bucket_defs:
+        conditions = [
+            User.subscription_start_at >= start,
+            User.subscription_status == "active",
+        ]
+        end is not None and conditions.append(User.subscription_start_at < end)
+        time_buckets[name] = await db.scalar(
+            select(func.count(User.id)).where(and_(*conditions))
+        ) or 0
+
+    time_buckets["older"] = await db.scalar(
+        select(func.count(User.id)).where(
+            and_(
+                User.subscription_start_at < bounds["this_month"],
+                User.subscription_status == "active",
+            )
+        )
+    ) or 0
+
+    total_active = await db.scalar(
+        select(func.count(User.id)).where(User.subscription_status == "active")
+    ) or 0
+
+    return {
+        "total_active_subscriptions": total_active,
+        "by_plan": by_plan,
+        "time_buckets": time_buckets,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 5. 内容生成统计
+# ---------------------------------------------------------------------------
+
+@router.get("/content-stats")
+async def content_stats(
+    _admin: Admin = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    """返回视频/音乐/图像等内容生成的统计数据。"""
+    # 视频任务统计
+    video_total = await db.scalar(select(func.count(VideoTask.id))) or 0
+    video_completed = await db.scalar(
+        select(func.count(VideoTask.id)).where(VideoTask.status == "completed")
+    ) or 0
+    video_failed = await db.scalar(
+        select(func.count(VideoTask.id)).where(VideoTask.status == "failed")
+    ) or 0
+    video_success_rate = round(video_completed / video_total * 100, 2) if video_total else 0
+
+    # 音乐任务统计
+    music_total = await db.scalar(select(func.count(MusicTask.id))) or 0
+    music_completed = await db.scalar(
+        select(func.count(MusicTask.id)).where(MusicTask.status == "completed")
+    ) or 0
+    music_failed = await db.scalar(
+        select(func.count(MusicTask.id)).where(MusicTask.status == "failed")
+    ) or 0
+    music_success_rate = round(music_completed / music_total * 100, 2) if music_total else 0
+
+    # 图像生成统计（通过 ToolExecution 中 tool_name="generate_image" 追踪）
+    _img_filter = ToolExecution.tool_name == "generate_image"
+    image_total = await db.scalar(
+        select(func.count(ToolExecution.id)).where(_img_filter)
+    ) or 0
+    image_completed = await db.scalar(
+        select(func.count(ToolExecution.id)).where(and_(_img_filter, ToolExecution.status == "success"))
+    ) or 0
+    image_failed = await db.scalar(
+        select(func.count(ToolExecution.id)).where(and_(_img_filter, ToolExecution.status == "error"))
+    ) or 0
+    image_success_rate = round(image_completed / image_total * 100, 2) if image_total else 0
+
+    # 资产按类型分组
+    asset_result = await db.execute(
+        select(
+            Asset.file_type,
+            func.count(Asset.id).label("count"),
+        )
+        .group_by(Asset.file_type)
+    )
+    asset_by_type = {(r.file_type or "unknown"): r.count for r in asset_result.all()}
+
+    # 工具执行统计
+    tool_total = await db.scalar(select(func.count(ToolExecution.id))) or 0
+    tool_errors = await db.scalar(
+        select(func.count(ToolExecution.id)).where(ToolExecution.status == "error")
+    ) or 0
+    tool_avg_ms = await db.scalar(select(func.avg(ToolExecution.duration_ms)))
+
+    return {
+        "video": {
+            "total": video_total,
+            "completed": video_completed,
+            "failed": video_failed,
+            "success_rate": video_success_rate,
+        },
+        "image": {
+            "total": image_total,
+            "completed": image_completed,
+            "failed": image_failed,
+            "success_rate": image_success_rate,
+        },
+        "music": {
+            "total": music_total,
+            "completed": music_completed,
+            "failed": music_failed,
+            "success_rate": music_success_rate,
+        },
+        "assets_by_type": asset_by_type,
+        "tool_execution": {
+            "total": tool_total,
+            "errors": tool_errors,
+            "error_rate": round(tool_errors / tool_total * 100, 2) if tool_total else 0,
+            "avg_duration_ms": round(tool_avg_ms, 1) if tool_avg_ms else None,
+        },
+    }


### PR DESCRIPTION
- 在主应用中引入并注册 admin_dashboard 路由
- 通过更新路由导入，扩展后端功能模块
- 保持其他初始化和中间件逻辑不变
- 更新 package-lock.json 以同步 admin-dashboard 依赖变更