### PR TITLE
refactor(canvas): 清理并优化画布工具代码实现

### DIFF
--- a/backend/services/tool_manager/providers/canvas.py
+++ b/backend/services/tool_manager/providers/canvas.py
@@ -39,69 +39,7 @@ def _migrate_node_type(node_type: str) -> str:
     return NODE_TYPE_MIGRATION.get(node_type, node_type)
 
 
-# Node type definitions with descriptions for Agent understanding
-NODE_TYPE_INFO = {
-    "text": {
-        "description": "文本节点：用于剧本、文案、广告等文字内容。支持富文本格式。",
-        "fields": {
-            "title": "标题，字符串类型，必填",
-            "content": "正文内容，Markdown格式字符串。支持标题(#/##/###)、段落、加粗(**text**)、斜体(*text*)、代码块等Markdown语法。创建节点时必须提供此字段，更新节点时如果不需要修改内容则不要包含此字段。",
-            "tags": "标签列表，数组类型，可选，用于分类和筛选"
-        },
-        "example": {
-            "title": "故事大纲",
-            "content": "# 第一章\n\n故事开始...\n\n## 场景一\n\n主角登场。",
-            "tags": ["大纲", "第一章"]
-        }
-    },
-    "image": {
-        "description": "图像节点：用于角色设定、场景、海报等图像内容。需要调用生图模型生成图像，支持JPEG/PNG/JPG格式图像。",
-        "fields": {
-            "name": "图像名称，字符串类型",
-            "description": "图像描述，字符串类型，包含场景、人物等信息",
-            "imageUrl": "图片URL地址，字符串类型，支持jpeg/png/jpg格式",
-            "fitMode": "图片适配模式，字符串类型，可选值为cover(填充)或contain(适应)"
-        },
-        "example": {"name": "小明", "description": "主角，18岁，性格开朗", "imageUrl": "/media/xxx.jpg", "fitMode": "cover"}
-    },
-    "video": {
-        "description": "视频节点：用于动画、短片、视频内容。需要调用视频处理模型生成视频，支持MP4格式视频。",
-        "fields": {
-            "name": "视频名称，字符串类型",
-            "description": "视频描述，字符串类型，包含场景、时长等信息",
-            "videoUrl": "视频URL地址，字符串类型，支持mp4格式",
-            "fitMode": "视频适配模式，字符串类型，可选值为cover(填充)或contain(适应)"
-        },
-        "example": {"name": "开场动画", "description": "城市夜景转场", "videoUrl": "/media/xxx.mp4", "fitMode": "cover"}
-    },
-    "audio": {
-        "description": "音频节点：用于背景音乐、音效、配音等音频内容。支持MP3/WAV/OGG格式。",
-        "fields": {
-            "name": "音频名称，字符串类型",
-            "description": "音频描述，字符串类型，包含风格、用途等信息",
-            "audioUrl": "音频URL地址，字符串类型，支持mp3/wav/ogg格式",
-            "lyrics": "歌词文本，字符串类型，可选"
-        },
-        "example": {"name": "背景音乐", "description": "城市夜景氛围音乐", "audioUrl": "/media/xxx.mp3"}
-    },
-    "storyboard": {
-        "description": "分镜节点：用于分镜脚本、镜头设计等多维表格内容。支持自定义表格数据，支持在单元格内引用图片、视频、音频。",
-        "fields": {
-            "shotNumber": "镜头号，字符串类型，如'1-1', '2-3'",
-            "description": "镜头描述，字符串类型，描述画面内容",
-            "duration": "时长，整数类型，单位为秒",
-            "tableData": "表格数据行，数组类型，每个元素是一个对象代表一行数据。媒体列的值应为媒体URL路径（如'/api/media/xxx.jpg'）。例如：[{\"scene\": \"城市夜景\", \"type\": \"全景\", \"duration\": 5, \"ref_image\": \"/api/media/abc.jpg\"}]",
-            "tableColumns": "表格列定义，数组类型，每个元素包含key(字段名)、label(显示名)、type(列类型)。type支持: text(文本)、number(数字)、image(图片缩略图)、video(视频缩略图)、audio(音频播放器)。媒体类型列的值应为/api/media/路径或完整URL。例如：[{\"key\": \"scene\", \"label\": \"场景\", \"type\": \"text\"}, {\"key\": \"ref_image\", \"label\": \"参考图\", \"type\": \"image\"}]"
-        },
-        "example": {
-            "shotNumber": "1-1",
-            "description": "全景：城市夜景",
-            "duration": 5,
-            "tableColumns": [{"key": "scene", "label": "场景", "type": "text"}, {"key": "type", "label": "镜头类型", "type": "text"}, {"key": "duration", "label": "时长", "type": "number"}, {"key": "ref_image", "label": "参考图", "type": "image"}],
-            "tableData": [{"scene": "城市夜景", "type": "全景", "duration": 5, "ref_image": "/api/media/example1.jpg"}, {"scene": "主角特写", "type": "近景", "duration": 3, "ref_image": "/api/media/example2.jpg"}]
-        }
-    }
-}
+# Node type definitions — detailed descriptions live in SKILL.md (progressive disclosure)
 
 # Schema for validation (simplified)
 NODE_TYPE_SCHEMA = {
@@ -132,17 +70,6 @@ def _estimate_text_node_size(data: dict) -> tuple[int, int]:
 # ---------------------------------------------------------------------------
 # Tool Definitions (OpenAI format)
 # ---------------------------------------------------------------------------
-
-def _build_node_type_description() -> str:
-    lines = ["节点类型说明："]
-    for node_type, info in NODE_TYPE_INFO.items():
-        lines.append(f"\n**{node_type}**: {info['description']}")
-        lines.append("字段说明：")
-        for field, desc in info['fields'].items():
-            lines.append(f"  - {field}: {desc}")
-        lines.append("示例：") if "example" in info else None
-        ("example" in info) and lines.append(f"  {info['example']}")
-    return "\n".join(lines)
 
 
 def _build_canvas_tool_defs(target_node_types: list[str]) -> list[dict]:
@@ -189,7 +116,7 @@ def _build_canvas_tool_defs(target_node_types: list[str]) -> list[dict]:
             "type": "function",
             "function": {
                 "name": "create_canvas_node",
-                "description": "在画布上创建新节点。字段结构参见 Skill 文档中的节点类型说明。",
+                "description": "在画布上创建新节点。",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -219,7 +146,7 @@ def _build_canvas_tool_defs(target_node_types: list[str]) -> list[dict]:
             "type": "function",
             "function": {
                 "name": "update_canvas_node",
-                "description": "更新节点数据，只需提供要修改的字段（增量合并）。",
+                "description": "更新节点数据，只需提供要修改的字段（增量合并）。支持同时更新位置。",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -231,8 +158,16 @@ def _build_canvas_tool_defs(target_node_types: list[str]) -> list[dict]:
                             "type": "object",
                             "description": "要更新的字段。",
                         },
+                        "position_x": {
+                            "type": "number",
+                            "description": "新的X坐标，可选。",
+                        },
+                        "position_y": {
+                            "type": "number",
+                            "description": "新的Y坐标，可选。",
+                        },
                     },
-                    "required": ["node_id", "data"],
+                    "required": ["node_id"],
                 },
             },
         },
@@ -269,7 +204,7 @@ def _build_canvas_tool_defs(target_node_types: list[str]) -> list[dict]:
             "type": "function",
             "function": {
                 "name": "create_canvas_edge",
-                "description": "在两个节点之间创建连线。标准方向：source_handle='right-source', target_handle='left-target'。",
+                "description": "在两个节点之间创建连线。",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -534,6 +469,8 @@ async def _exec_update_node(
 ) -> str:
     node_id = args.get("node_id", "")
     new_data = args.get("data", {})
+    position_x = args.get("position_x")
+    position_y = args.get("position_y")
     migrated_target_types = [_migrate_node_type(t) for t in target_node_types] if target_node_types else []
 
     query = select(TheaterNode).where(
@@ -546,13 +483,28 @@ async def _exec_update_node(
     return _error_result("Node not found") if not node else (
         _error_result(f"Cannot update node of type '{node.node_type}'")
         if node.node_type not in migrated_target_types
-        else await _do_update_node(node, new_data, db)
+        else await _do_update_node(node, new_data, db, position_x=position_x, position_y=position_y)
     )
 
 
-async def _do_update_node(node: TheaterNode, new_data: dict, db: AsyncSession) -> str:
-    filtered_new_data = {k: v for k, v in new_data.items() if v is not None}
-    merged_data = {**(node.data or {}), **filtered_new_data}
+async def _do_update_node(
+    node: TheaterNode, new_data: dict, db: AsyncSession,
+    *, position_x: float | None = None, position_y: float | None = None,
+) -> str:
+    # 从 data 中过滤掉位置字段，避免污染 JSON 数据
+    _POSITION_KEYS = {"position_x", "position_y", "positionX", "positionY"}
+    filtered_new_data = {k: v for k, v in new_data.items() if v is not None and k not in _POSITION_KEYS}
+
+    # 兼容：如果 agent 把位置放在 data 内部，也能正确提取
+    position_x = position_x if position_x is not None else new_data.get("position_x", new_data.get("positionX"))
+    position_y = position_y if position_y is not None else new_data.get("position_y", new_data.get("positionY"))
+
+    # 更新数据库位置列
+    position_x is not None and setattr(node, "position_x", float(position_x))
+    position_y is not None and setattr(node, "position_y", float(position_y))
+
+    # 合并节点数据（增量更新）
+    merged_data = {**(node.data or {}), **filtered_new_data} if filtered_new_data else node.data
     node.data = merged_data
 
     await db.commit()

--- a/backend/skills/active_skills/canvas_tools/SKILL.md
+++ b/backend/skills/active_skills/canvas_tools/SKILL.md
@@ -2,229 +2,169 @@
 name: canvas_tools
 description: "Canvas node and edge CRUD operations. Provides tools to manage theater canvas nodes and connections between them."
 metadata:
-  builtin_skill_version: "1.2"
+  builtin_skill_version: "1.3"
 ---
 # Canvas Tools
 
 Use this skill when the user asks to view, create, update, or delete content on the theater canvas (nodes and edges).
 
-Loading this skill activates 8 tools across two categories:
-
-## Quick Reference
-
-| Tool | Purpose |
-|------|---------|
-| `list_canvas_nodes` | List all nodes (optionally filter by type) |
-| `get_canvas_node` | Get full node details by ID |
-| `create_canvas_node` | Create a new node |
-| `update_canvas_node` | Update node data (incremental merge) |
-| `delete_canvas_node` | Delete a node and its edges |
-| `list_canvas_edges` | List all edges |
-| `create_canvas_edge` | Connect two nodes |
-| `delete_canvas_edge` | Remove a connection |
+Loading this skill activates 8 tools: `list_canvas_nodes`, `get_canvas_node`, `create_canvas_node`, `update_canvas_node`, `delete_canvas_node`, `list_canvas_edges`, `create_canvas_edge`, `delete_canvas_edge`.
 
 ---
 
-## Node Types & Field Reference
-
-Available node types depend on agent configuration. Below are all supported types and their data fields.
+## Node Types & Data Fields
 
 ### text — 文本节点
-For scripts, copy, ads, and written content. Supports Markdown.
+For scripts, copy, and written content. Supports Markdown.
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `title` | string | yes | Node title |
-| `content` | string | on create | Markdown body. Supports `#/##/###` headings, `**bold**`, `*italic*`, code blocks, lists. **Omit when updating if unchanged** to save tokens. |
-| `tags` | string[] | no | Tags for categorization |
+| Field | Type | Notes |
+|-------|------|-------|
+| `title` | string | Required |
+| `content` | string | Markdown body (`#`, `**bold**`, code blocks, lists). Required on create; **omit on update if unchanged**. |
+| `tags` | string[] | Optional, for categorization |
 
 ### image — 图像节点
-For character designs, scenes, posters, and visual content.
+For character designs, scenes, posters.
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `name` | string | yes | Image name |
-| `description` | string | yes | Scene/character description |
-| `imageUrl` | string | no | Image URL (e.g. `/api/media/xxx.jpg`). Supports JPEG/PNG/WebP. |
-| `fitMode` | string | no | `"cover"` (fill) or `"contain"` (fit) |
+| Field | Type | Notes |
+|-------|------|-------|
+| `name` | string | Required |
+| `description` | string | Scene/character description |
+| `imageUrl` | string | `/api/media/xxx.jpg` — JPEG/PNG/WebP |
+| `fitMode` | string | `"cover"` or `"contain"` |
 
 ### video — 视频节点
-For animations, short films, and motion content.
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `name` | string | yes | Video name |
-| `description` | string | yes | Scene/duration description |
-| `videoUrl` | string | no | Video URL (e.g. `/api/media/xxx.mp4`). Supports MP4. |
-| `fitMode` | string | no | `"cover"` (fill) or `"contain"` (fit) |
+| Field | Type | Notes |
+|-------|------|-------|
+| `name` | string | Required |
+| `description` | string | Scene/duration description |
+| `videoUrl` | string | `/api/media/xxx.mp4` — MP4 |
+| `fitMode` | string | `"cover"` or `"contain"` |
 
 ### audio — 音频节点
-For background music, sound effects, voiceover, and audio content.
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `name` | string | yes | Audio name |
-| `description` | string | yes | Style/purpose description |
-| `audioUrl` | string | no | Audio URL (e.g. `/api/media/xxx.mp3`). Supports MP3/WAV/OGG. |
-| `lyrics` | string | no | Lyrics text |
+| Field | Type | Notes |
+|-------|------|-------|
+| `name` | string | Required |
+| `description` | string | Style/purpose description |
+| `audioUrl` | string | `/api/media/xxx.mp3` — MP3/WAV/OGG |
+| `lyrics` | string | Optional lyrics text |
 
 ### storyboard — 分镜/多维表格节点
-For shot breakdowns and multi-dimensional table content. **Supports embedding media (images, videos, audio) in table cells.**
+For shot breakdowns and table content. **Supports embedding media in cells.**
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `shotNumber` | string | no | Shot number (e.g. `"1-1"`, `"2-3"`) |
-| `description` | string | no | Shot description |
-| `duration` | integer | no | Duration in seconds |
-| `tableColumns` | array | yes (for table) | Column definitions. Each item: `{key, label, type}`. |
-| `tableData` | array | yes (for table) | Row data. Each item is an object matching column keys. |
+| Field | Type | Notes |
+|-------|------|-------|
+| `shotNumber` | string | e.g. `"1-1"` |
+| `description` | string | Shot description |
+| `duration` | integer | Seconds |
+| `tableColumns` | array | `[{key, label, type}]` — type: `"text"`, `"number"`, `"image"`, `"video"`, `"audio"` |
+| `tableData` | array | `[{key: value, ...}]` — media cells use `/api/media/xxx.ext` paths |
 
-**Column `type` options:**
-- `"text"` — plain text cell
-- `"number"` — numeric cell
-- `"image"` — renders image thumbnail from URL; click to preview full-size
-- `"video"` — renders video thumbnail with play icon; click to preview
-- `"audio"` — renders audio play button; click to play in full-screen player
+---
 
-Media cell values should be `/api/media/xxx.ext` paths or full URLs.
+## Positioning & Layout
 
-**Example — storyboard with media columns:**
-```json
-{
-  "tableColumns": [
-    {"key": "scene", "label": "场景", "type": "text"},
-    {"key": "duration", "label": "时长", "type": "number"},
-    {"key": "ref_image", "label": "参考图", "type": "image"},
-    {"key": "ref_video", "label": "参考视频", "type": "video"},
-    {"key": "bgm", "label": "背景音乐", "type": "audio"}
-  ],
-  "tableData": [
-    {
-      "scene": "城市夜景",
-      "duration": 5,
-      "ref_image": "/api/media/abc.jpg",
-      "ref_video": "/api/media/xyz.mp4",
-      "bgm": "/api/media/music.mp3"
-    }
-  ]
-}
+Nodes live on an infinite 2D canvas. Each node has `position_x` (horizontal) and `position_y` (vertical), where **right = +X**, **down = +Y**.
+
+### Auto-placement
+When creating nodes **without** specifying position, the system places them automatically to the right of existing nodes, wrapping to new rows when space runs out. **Use auto-placement by default** unless the user requests a specific layout.
+
+### Manual positioning
+Both `create_canvas_node` and `update_canvas_node` accept optional `position_x` and `position_y` parameters (top-level, not inside `data`).
+
+**Typical node sizes for spacing reference:**
+- Standard node: ~420×300 px
+- Horizontal gap: ~40–80 px
+- Vertical gap: ~60–100 px
+
+### Layout patterns
+When the user asks to "arrange" or "rearrange" nodes:
+1. Call `list_canvas_nodes` to get current positions and node list
+2. Calculate new positions based on desired layout (grid, tree, flow, etc.)
+3. Call `update_canvas_node` for each node with new `position_x` and `position_y`
+
+**Common layouts:**
+- **Horizontal flow:** nodes in a row, X increments by ~500, same Y
+- **Grid:** rows of 3–4 nodes, X increments by ~500, Y increments by ~400 per row
+- **Tree/hierarchy:** parent centered on top, children spread below
+
+Example — move a node to a new position:
+```
+update_canvas_node(node_id="uuid", position_x=800, position_y=300)
+```
+
+Example — update both data and position:
+```
+update_canvas_node(node_id="uuid", data={"title": "New Title"}, position_x=100, position_y=200)
 ```
 
 ---
 
-## Tool Usage Guide
+## Edge Conventions
 
-### list_canvas_nodes
+Edges connect nodes left-to-right. Always use the standard direction:
+- `source_handle`: `"right-source"` (default)
+- `target_handle`: `"left-target"` (default)
 
-List all nodes. Returns summaries with `id`, `node_type`, `position`, and key fields (e.g. `title` for text, `name` for image/video/audio, `shotNumber` for storyboard).
+Only deviate if the user explicitly requests a different flow direction.
 
-**Always call this first** to understand what exists before creating or modifying.
+---
 
-Parameters:
-- `node_type` (string, optional) — filter by type
+## Return Values
 
-### get_canvas_node
+| Tool | Returns |
+|------|---------|
+| `list_canvas_nodes` | `{count, nodes: [{id, node_type, position: {x, y}, ...key_fields}]}` |
+| `get_canvas_node` | Full node object with all fields, position, dimensions |
+| `create_canvas_node` | `{success: true, node: {full node object}}` |
+| `update_canvas_node` | `{success: true, node: {full node object}}` |
+| `delete_canvas_node` | `{success: true, deleted_node_id}` |
+| `list_canvas_edges` | `{count, edges: [{id, source_node_id, target_node_id, ...}]}` |
+| `create_canvas_edge` | `{success: true, edge: {edge object}}` |
+| `delete_canvas_edge` | `{success: true, deleted_edge: {source, target}}` |
 
-Get complete node data. Use when you need full field details (e.g. content text, media URLs, table data).
+---
 
-Parameters:
-- `node_id` (string, required) — node UUID from `list_canvas_nodes`
+## Workflow Patterns
 
-### create_canvas_node
-
-Create a new node. Position is auto-calculated (placed to the right of existing nodes) if omitted.
-
-Parameters:
-- `node_type` (string, required)
-- `data` (object, required) — fields matching the node type schema above
-- `position_x` (number, optional)
-- `position_y` (number, optional)
-
-**Examples:**
+### Creating a set of connected nodes
 ```
-create_canvas_node(
-  node_type="text",
-  data={"title": "第一章", "content": "# 开头\n\n故事开始...", "tags": ["大纲"]}
-)
-
-create_canvas_node(
-  node_type="image",
-  data={"name": "主角立绘", "description": "18岁，性格开朗"}
-)
-
-create_canvas_node(
-  node_type="audio",
-  data={"name": "背景音乐", "description": "城市夜景氛围钢琴曲"}
-)
+1. create_canvas_node(type="text", data={...})           → get node_id_A
+2. create_canvas_node(type="image", data={...})          → get node_id_B
+3. create_canvas_edge(source=node_id_A, target=node_id_B)
 ```
 
-### update_canvas_node
-
-Incremental merge — only provide fields you want to change. Unmentioned fields remain unchanged.
-
-Parameters:
-- `node_id` (string, required)
-- `data` (object, required) — partial fields to update
-
-**Example:**
+### Rebuilding canvas (delete all, recreate)
 ```
-update_canvas_node(
-  node_id="uuid-here",
-  data={"title": "修改后的标题", "tags": ["已修订"]}
-)
+1. list_canvas_nodes()                    → get all node IDs
+2. delete_canvas_node(node_id=...) × N   → edges auto-deleted
+3. create_canvas_node(...) × N           → new nodes
+4. create_canvas_edge(...) × M           → new connections
 ```
 
-### delete_canvas_node
-
-Delete a node and automatically remove all connected edges.
-
-Parameters:
-- `node_id` (string, required)
-
-### list_canvas_edges
-
-List all connections. Returns `id`, `source_node_id`, `target_node_id`, `source_handle`, `target_handle`.
-
-Use before creating edges to avoid duplicates.
-
-### create_canvas_edge
-
-Connect two nodes. Canvas flows left-to-right.
-
-Parameters:
-- `source_node_id` (string, required) — starting node
-- `target_node_id` (string, required) — ending node
-- `source_handle` (string, optional) — `"right-source"` (default, recommended) or `"left-source"`
-- `target_handle` (string, optional) — `"left-target"` (default, recommended) or `"right-target"`
-
-**Standard direction:** `right-source` → `left-target` (left-to-right flow). Always use this unless the user specifically requests a different layout.
-
-**Example:**
+### Rearranging existing nodes
 ```
-create_canvas_edge(
-  source_node_id="script-uuid",
-  target_node_id="storyboard-uuid",
-  source_handle="right-source",
-  target_handle="left-target"
-)
+1. list_canvas_nodes()                                  → get IDs and current positions
+2. update_canvas_node(node_id=..., position_x=, position_y=) × N
 ```
 
-### delete_canvas_edge
-
-Remove a connection between two nodes.
-
-Parameters:
-- `source_node_id` (string, required)
-- `target_node_id` (string, required)
+### Referencing media across nodes
+To embed an existing image/video/audio node's media in a storyboard table:
+```
+1. get_canvas_node(node_id="image-node-uuid")  → extract imageUrl
+2. Use that URL as the cell value in storyboard tableData
+```
 
 ---
 
 ## Best Practices
 
-1. **Always list before mutating** — call `list_canvas_nodes` to see current state before creating, updating, or deleting.
-2. **Omit position** — let the system auto-place nodes unless the user specifies coordinates.
-3. **Minimal updates** — only include changed fields in `update_canvas_node` to minimize payload.
-4. **Check edges first** — use `list_canvas_edges` before creating connections to avoid duplicates.
-5. **Standard edge direction** — always use `right-source` → `left-target` for consistent left-to-right flow.
-6. **Media references in storyboard** — when referencing existing canvas media in a storyboard table, use `get_canvas_node` to retrieve the media URL, then set it as the cell value for the corresponding `image`/`video`/`audio` column type.
-7. **Node types are restricted** — you can only create/access node types allowed by the agent configuration.
+1. **List before mutate** — always call `list_canvas_nodes` first to understand current state.
+2. **Auto-place by default** — omit position unless the user specifies coordinates or requests a layout.
+3. **Minimal updates** — only include changed fields in `update_canvas_node`. Never re-send `content` on text nodes unless it changed.
+4. **Check edges before connecting** — use `list_canvas_edges` to avoid duplicate connections.
+5. **Position is top-level** — pass `position_x`/`position_y` as top-level parameters, not inside `data`.
+6. **Batch awareness** — when creating multiple nodes, the system auto-places them in a grid. For custom layouts, create first, then rearrange with update calls.
+7. **Node types are restricted** — you can only access node types allowed by the agent configuration.

--- a/frontend/src/components/canvas/VideoNode.tsx
+++ b/frontend/src/components/canvas/VideoNode.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useState, useRef, useCallback, useMemo } from 'react';
+import React, { memo, useState, useRef, useMemo } from 'react';
 import { Handle, Position, NodeProps, Node, NodeResizer, useReactFlow } from '@xyflow/react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';


### PR DESCRIPTION
- 移除节点类型详细说明和示例，简化注释，减少冗余
- 将节点属性校验模式保留为简化版本，去除多语言描述内容
- 优化节点自动定位逻辑，使用右侧扫描方式避免重叠
- 支持更新节点时同时修改位置坐标
- 精简节点和连线操作的异步执行函数接口和实现
- 优化函数局部变量，提升代码可读性和维护性
- 移除多余的导入和日志记录代码
- 保持了功能完整性，支持节点和连线的增删改查操作