### PR TITLE
refactor(admin): 重构管理后台仪表盘及智能体页面组件

### DIFF
--- a/backend/admin/src/app/admin/agents/[id]/page.tsx
+++ b/backend/admin/src/app/admin/agents/[id]/page.tsx
@@ -76,10 +76,6 @@ export default function AgentDetailPage() {
         <Header title="创建新智能体" saving={saving} onSave={handleSave} onBack={() => router.push('/admin/agents')} />
         <div className="flex-1 overflow-y-auto bg-muted/20">
           <div className="max-w-7xl mx-auto py-12 px-6">
-            <div className="mb-8">
-              <h2 className="text-2xl font-bold tracking-tight mb-2">开始配置</h2>
-              <p className="text-muted-foreground">配置智能体的基础信息、模型参数及系统提示词。</p>
-            </div>
             <div className="bg-card rounded-xl border shadow-sm p-8">
               <AgentForm initialValues={null} onSubmit={handleSubmit} onFormInstanceReady={setFormInstance} twoColumn={true} />
             </div>

--- a/backend/admin/src/app/admin/agents/page.tsx
+++ b/backend/admin/src/app/admin/agents/page.tsx
@@ -151,6 +151,15 @@ export default function AgentsPage() {
         </div>
         
         <div className="flex items-center gap-2">
+           <div className="relative">
+             <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+             <Input 
+               placeholder="搜索智能体..." 
+               className="pl-9 w-[200px]"
+               onChange={(e) => setSearchText(e.target.value)}
+             />
+           </div>
+
            <div className="hidden md:flex items-center rounded-lg border bg-background p-1 shadow-sm">
              <Button 
                variant={viewMode === 'list' ? 'secondary' : 'ghost'} 
@@ -174,15 +183,6 @@ export default function AgentsPage() {
              <Plus className="mr-2 h-4 w-4" /> 创建智能体
            </Button>
         </div>
-      </div>
-
-      <div className="relative">
-        <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-        <Input 
-          placeholder="搜索智能体名称、描述或模型..." 
-          className="pl-9 max-w-md"
-          onChange={(e) => setSearchText(e.target.value)}
-        />
       </div>
 
       <div className="min-h-[400px]">

--- a/backend/admin/src/app/admin/llm/components/provider-form.tsx
+++ b/backend/admin/src/app/admin/llm/components/provider-form.tsx
@@ -1,4 +1,3 @@
-
 'use client';
 
 import React, { useState } from 'react';
@@ -27,13 +26,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { useToast } from '@/components/ui/use-toast';
 import { Plus, Trash2, Plug, X, ChevronDown, ChevronRight, Save, ArrowLeft } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { PRESET_COST_DIMENSIONS, MODEL_TYPE_TAGS, MODEL_TYPE_OPTIONS, PROVIDER_OPTIONS, formSchema, LLMProvider } from '../schema';
+import { PRESET_COST_DIMENSIONS, MODEL_TYPE_OPTIONS, PROVIDER_OPTIONS, formSchema, LLMProvider } from '../schema';
 
 interface ProviderFormProps {
   initialData?: LLMProvider;
@@ -61,8 +59,6 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
       base_url: initialData?.base_url || "",
       api_key: initialData?.api_key || "",
       config_json: initialData?.config_json && typeof initialData.config_json === 'object' ? JSON.stringify(initialData.config_json, null, 2) : (initialData?.config_json || "{}"),
-      is_active: initialData?.is_active ?? true,
-      is_default: initialData?.is_default ?? false,
     },
   });
 
@@ -125,7 +121,6 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
     setIsSaving(true);
     try {
       const modelNames = values.models.map(m => m.value);
-      // 清理 modelCosts 中不在 models 列表中的孤立数据
       const cleanedCosts: Record<string, Record<string, number>> = {};
       modelNames.forEach(name => {
         if (modelCosts[name]) {
@@ -133,17 +128,8 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
         }
       });
 
-      // 提取 model tags 并存入 config_json (已移除)
-      // const modelTags: Record<string, string> = {};
-      // values.models.forEach(m => {
-      //   if (m.value && m.type) {
-      //     modelTags[m.value] = m.type;
-      //   }
-      // });
-
       const configJsonObj = JSON.parse(values.config_json || '{}');
 
-      // 构造 model_metadata: {"model_name": {"model_type": "...", "display_name": "..."}}
       const modelMetadata: Record<string, { model_type?: string; display_name?: string }> = {};
       values.models.forEach(m => {
         const entry: { model_type?: string; display_name?: string } = {};
@@ -160,6 +146,8 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
         config_json: configJsonObj,
         model_costs: cleanedCosts,
         model_metadata: modelMetadata,
+        is_active: true,
+        is_default: false,
       };
 
       if (initialData) {
@@ -189,15 +177,9 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
     <>
       {/* Header */}
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <Button variant="ghost" size="icon" onClick={() => router.back()} className="text-muted-foreground hover:text-foreground">
-            <ArrowLeft className="h-5 w-5" />
-          </Button>
-          <div className="h-6 w-[1px] bg-border mx-1" />
-          <div className="flex flex-col">
-            <h2 className="text-2xl font-bold tracking-tight">{initialData ? "编辑供应商" : "创建供应商"}</h2>
-            <p className="text-muted-foreground text-sm">配置 LLM 供应商的基础信息、模型参数及连接认证。</p>
-          </div>
+        <div>
+          <h2 className="text-3xl font-bold tracking-tight">{initialData ? "编辑供应商" : "创建供应商"}</h2>
+          <p className="text-muted-foreground mt-1">配置 LLM 供应商的基础信息、模型参数及连接认证。</p>
         </div>
         <div className="flex gap-3 items-center">
           {initialData && <span className="text-xs text-muted-foreground mr-2">ID: {initialData.id}</span>}
@@ -205,475 +187,430 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
             {isTesting ? <div className="animate-spin mr-2 h-4 w-4 border-2 border-current border-t-transparent rounded-full" /> : <Plug className="mr-2 h-4 w-4" />}
             测试连接
           </Button>
+          <Button variant="outline" onClick={() => router.back()}>
+            <ArrowLeft className="mr-2 h-4 w-4" /> 返回
+          </Button>
           <Button onClick={handleSave} disabled={isSaving}>
             {isSaving ? '保存中...' : <><Save className="mr-2 h-4 w-4" /> 保存</>}
           </Button>
         </div>
       </div>
 
-      {/* Content */}
-      <div className="bg-card rounded-xl border shadow-sm p-6">
-            <Form {...form}>
-              <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
-                
-                <Card className="border-0 shadow-none">
-                  <CardHeader className="px-0 pt-0">
-                    <CardTitle>基本信息</CardTitle>
-                    <CardDescription>配置供应商的基本连接信息。</CardDescription>
-                  </CardHeader>
-                  <CardContent className="px-0 space-y-4">
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                      <FormField
-                        control={form.control}
-                        name="name"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>名称</FormLabel>
-                            <FormControl>
-                              <Input placeholder="输入名称 (如 OpenAI)" {...field} />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                      <FormField
-                        control={form.control}
-                        name="provider_type"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>品牌</FormLabel>
-                            <Select onValueChange={field.onChange} defaultValue={field.value} value={field.value}>
-                              <FormControl>
-                                <SelectTrigger>
-                                  <SelectValue placeholder="选择品牌" />
-                                </SelectTrigger>
-                              </FormControl>
-                              <SelectContent>
-                                {PROVIDER_OPTIONS.map((option) => (
-                                  <SelectItem key={option.value} value={option.value}>
-                                    <div className="flex items-center gap-2">
-                                      <div className="relative h-5 w-5 shrink-0 overflow-hidden rounded-sm">
-                                        <Image
-                                          src={option.icon}
-                                          alt={option.label}
-                                          fill
-                                          className="object-contain"
-                                        />
-                                      </div>
-                                      <span>{option.label}</span>
-                                    </div>
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                    </div>
-
+      {/* Content: Left-Right layout */}
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)}>
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            {/* ==================== Left Column ==================== */}
+            <div className="space-y-6">
+              {/* 基本信息 */}
+              <Card>
+                <CardHeader>
+                  <CardTitle>基本信息</CardTitle>
+                  <CardDescription>配置供应商的名称、品牌和标签。</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <FormField
                       control={form.control}
-                      name="tags"
+                      name="name"
                       render={({ field }) => (
                         <FormItem>
-                          <FormLabel>标签</FormLabel>
+                          <FormLabel>名称</FormLabel>
                           <FormControl>
-                            <div className="flex flex-wrap items-center gap-2 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 min-h-[2.5rem]">
-                              {field.value?.map((tag, index) => (
-                                <Badge key={index} variant="secondary" className="flex items-center gap-1">
-                                  {tag}
-                                  <X
-                                    className="h-3 w-3 cursor-pointer hover:text-destructive"
-                                    onClick={() => {
-                                      const newTags = [...(field.value || [])];
-                                      newTags.splice(index, 1);
-                                      field.onChange(newTags);
-                                    }}
-                                  />
-                                </Badge>
-                              ))}
-                              <input
-                                className="flex-1 bg-transparent outline-none placeholder:text-muted-foreground min-w-[120px]"
-                                placeholder={field.value?.length ? "" : "输入标签后按回车添加"}
-                                value={tagInput}
-                                onChange={(e) => setTagInput(e.target.value)}
-                                onKeyDown={(e) => {
-                                  if (e.key === 'Enter') {
-                                    e.preventDefault();
-                                    const val = tagInput.trim();
-                                    if (val) {
-                                      const currentTags = field.value || [];
-                                      if (!currentTags.includes(val)) {
-                                        field.onChange([...currentTags, val]);
-                                      }
-                                      setTagInput("");
-                                    }
-                                  } else if (e.key === 'Backspace' && !tagInput && field.value?.length) {
-                                    const newTags = [...(field.value || [])];
-                                    newTags.pop();
-                                    field.onChange(newTags);
-                                  }
-                                }}
-                              />
-                            </div>
+                            <Input placeholder="输入名称 (如 OpenAI)" {...field} />
                           </FormControl>
-                          <FormDescription>用于分类和筛选，支持多个标签。</FormDescription>
                           <FormMessage />
                         </FormItem>
                       )}
                     />
-                  </CardContent>
-                </Card>
-
-                <Card className="border-0 shadow-none">
-                  <CardHeader className="px-0">
-                    <CardTitle>模型配置</CardTitle>
-                    <CardDescription>添加支持的模型及其成本信息。</CardDescription>
-                  </CardHeader>
-                  <CardContent className="px-0 space-y-6">
-                    <div className="space-y-4">
-                      {fields.map((field, index) => (
-                        <div key={field.id} className="flex gap-3 items-start">
-                          <FormField
-                            control={form.control}
-                            name={`models.${index}.value`}
-                            render={({ field }) => (
-                              <FormItem className="flex-1">
-                                <FormControl>
-                                  <Input placeholder="模型名称 (例如 gpt-4)" {...field} />
-                                </FormControl>
-                                <FormMessage />
-                              </FormItem>
-                            )}
-                          />
-                          <FormField
-                            control={form.control}
-                            name={`models.${index}.display_name`}
-                            render={({ field }) => (
-                              <FormItem className="w-[160px]">
-                                <FormControl>
-                                  <Input placeholder="模型别称（选填）" {...field} />
-                                </FormControl>
-                                <FormMessage />
-                              </FormItem>
-                            )}
-                          />
-                          <FormField
-                            control={form.control}
-                            name={`models.${index}.type`}
-                            render={({ field }) => (
-                              <FormItem className="w-[140px]">
-                                <Select onValueChange={field.onChange} defaultValue={field.value} value={field.value}>
-                                  <FormControl>
-                                    <SelectTrigger>
-                                      <SelectValue placeholder="模型类型" />
-                                    </SelectTrigger>
-                                  </FormControl>
-                                  <SelectContent>
-                                    {MODEL_TYPE_OPTIONS.map((opt) => (
-                                      <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
-                                    ))}
-                                  </SelectContent>
-                                </Select>
-                                <FormMessage />
-                              </FormItem>
-                            )}
-                          />
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="icon"
-                            onClick={() => remove(index)}
-                            disabled={fields.length === 1}
-                            className="mt-1"
-                          >
-                            <Trash2 className="h-4 w-4 text-muted-foreground hover:text-destructive" />
-                          </Button>
-                        </div>
-                      ))}
-                      
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        onClick={() => append({ value: "", type: "", display_name: "" })}
-                        className="w-full border-dashed"
-                      >
-                        <Plus className="mr-2 h-4 w-4" /> 添加模型
-                      </Button>
-                      {form.formState.errors.models?.message && (
-                        <p className="text-sm font-medium text-destructive">{String(form.formState.errors.models.message)}</p>
-                      )}
-                    </div>
-
-                    {/* 模型成本配置 */}
-                    {fields.length > 0 && fields.some(f => form.getValues(`models.${fields.indexOf(f)}.value`)) && (
-                      <div className="space-y-4 pt-4 border-t">
-                        <div className="flex items-center justify-between">
-                          <h4 className="text-sm font-medium">模型成本配置 (选填)</h4>
-                          <span className="text-xs text-muted-foreground">USD / Unit</span>
-                        </div>
-                        
-                        <div className="space-y-3">
-                          {fields.map((field, index) => {
-                            const modelName = form.watch(`models.${index}.value`);
-                            if (!modelName) return null;
-                            const isExpanded = expandedModels[modelName] || false;
-                            const costs = modelCosts[modelName] || {};
-                            const customKeys = Object.keys(costs).filter(k => !(k in PRESET_COST_DIMENSIONS));
-
-                            return (
-                              <div key={field.id + '-cost'} className="rounded-lg border bg-card text-card-foreground shadow-sm">
-                                <button
-                                  type="button"
-                                  className="flex items-center gap-3 w-full p-3 text-left hover:bg-muted/50 transition-colors rounded-t-lg"
-                                  onClick={() => setExpandedModels(prev => ({ ...prev, [modelName]: !prev[modelName] }))}
-                                >
-                                  {isExpanded ? <ChevronDown className="h-4 w-4 text-muted-foreground" /> : <ChevronRight className="h-4 w-4 text-muted-foreground" />}
-                                  <span className="font-mono text-sm font-medium">{modelName}</span>
-                                  {Object.keys(costs).length > 0 && (
-                                    <Badge variant="secondary" className="ml-auto text-xs font-normal">
-                                      {Object.keys(costs).length} 项配置
-                                    </Badge>
-                                  )}
-                                </button>
-                                
-                                {isExpanded && (
-                                  <div className="p-4 pt-0 space-y-4 border-t bg-muted/10">
-                                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
-                                      {Object.entries(PRESET_COST_DIMENSIONS).map(([dimKey, dimConfig]) => (
-                                        <div key={dimKey} className="space-y-1.5">
-                                          <label className="text-xs font-medium text-muted-foreground flex justify-between">
-                                            {dimConfig.label}
-                                            <span className="opacity-70">{dimConfig.unit}</span>
-                                          </label>
-                                          <Input
-                                            type="number"
-                                            step="0.000001"
-                                            min={0}
-                                            placeholder="0"
-                                            value={costs[dimKey] ?? ''}
-                                            onChange={(e) => {
-                                              const val = e.target.value;
-                                              setModelCosts(prev => {
-                                                const updated = { ...prev };
-                                                const modelEntry = { ...(updated[modelName] || {}) };
-                                                if (val === '') {
-                                                  delete modelEntry[dimKey];
-                                                } else {
-                                                  modelEntry[dimKey] = Number(val);
-                                                }
-                                                updated[modelName] = modelEntry;
-                                                return updated;
-                                              });
-                                            }}
-                                            className="font-mono h-9 bg-background"
-                                          />
-                                        </div>
-                                      ))}
+                    <FormField
+                      control={form.control}
+                      name="provider_type"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>品牌</FormLabel>
+                          <Select onValueChange={field.onChange} defaultValue={field.value} value={field.value}>
+                            <FormControl>
+                              <SelectTrigger>
+                                <SelectValue placeholder="选择品牌" />
+                              </SelectTrigger>
+                            </FormControl>
+                            <SelectContent>
+                              {PROVIDER_OPTIONS.map((option) => (
+                                <SelectItem key={option.value} value={option.value}>
+                                  <div className="flex items-center gap-2">
+                                    <div className="relative h-5 w-5 shrink-0 overflow-hidden rounded-sm">
+                                      <Image src={option.icon} alt={option.label} fill className="object-contain" />
                                     </div>
+                                    <span>{option.label}</span>
+                                  </div>
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  </div>
 
-                                    {/* 自定义参数 */}
-                                    {customKeys.length > 0 && (
-                                      <div className="space-y-3 pt-2">
-                                        <h5 className="text-xs font-semibold text-muted-foreground">自定义参数</h5>
-                                        {customKeys.map((customKey) => (
-                                          <div key={customKey} className="flex gap-3 items-end p-2 bg-background rounded-md border">
-                                            <div className="flex-1 space-y-1">
-                                              <label className="text-xs text-muted-foreground">参数名</label>
-                                              <div className="font-mono text-sm px-2 py-1 bg-muted rounded">{customKey}</div>
-                                            </div>
-                                            <div className="flex-1 space-y-1">
-                                              <label className="text-xs text-muted-foreground">成本 (USD)</label>
-                                              <Input
-                                                type="number"
-                                                step="0.000001"
-                                                min={0}
-                                                value={costs[customKey] ?? ''}
-                                                onChange={(e) => {
-                                                  const val = e.target.value;
-                                                  setModelCosts(prev => {
-                                                    const updated = { ...prev };
-                                                    const modelEntry = { ...(updated[modelName] || {}) };
-                                                    if (val === '') {
-                                                      delete modelEntry[customKey];
-                                                    } else {
-                                                      modelEntry[customKey] = Number(val);
-                                                    }
-                                                    updated[modelName] = modelEntry;
-                                                    return updated;
-                                                  });
-                                                }}
-                                                className="font-mono h-8"
-                                              />
-                                            </div>
-                                            <Button
-                                              type="button"
-                                              variant="ghost"
-                                              size="icon"
-                                              className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive"
-                                              onClick={() => {
+                  <FormField
+                    control={form.control}
+                    name="tags"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>标签</FormLabel>
+                        <FormControl>
+                          <div className="flex flex-wrap items-center gap-2 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 min-h-[2.5rem]">
+                            {field.value?.map((tag, index) => (
+                              <Badge key={index} variant="secondary" className="flex items-center gap-1">
+                                {tag}
+                                <X
+                                  className="h-3 w-3 cursor-pointer hover:text-destructive"
+                                  onClick={() => {
+                                    const newTags = [...(field.value || [])];
+                                    newTags.splice(index, 1);
+                                    field.onChange(newTags);
+                                  }}
+                                />
+                              </Badge>
+                            ))}
+                            <input
+                              className="flex-1 bg-transparent outline-none placeholder:text-muted-foreground min-w-[120px]"
+                              placeholder={field.value?.length ? "" : "输入标签后按回车添加"}
+                              value={tagInput}
+                              onChange={(e) => setTagInput(e.target.value)}
+                              onKeyDown={(e) => {
+                                if (e.key === 'Enter') {
+                                  e.preventDefault();
+                                  const val = tagInput.trim();
+                                  if (val) {
+                                    const currentTags = field.value || [];
+                                    if (!currentTags.includes(val)) {
+                                      field.onChange([...currentTags, val]);
+                                    }
+                                    setTagInput("");
+                                  }
+                                } else if (e.key === 'Backspace' && !tagInput && field.value?.length) {
+                                  const newTags = [...(field.value || [])];
+                                  newTags.pop();
+                                  field.onChange(newTags);
+                                }
+                              }}
+                            />
+                          </div>
+                        </FormControl>
+                        <FormDescription>用于分类和筛选，支持多个标签。</FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </CardContent>
+              </Card>
+
+              {/* 连接与认证 */}
+              <Card>
+                <CardHeader>
+                  <CardTitle>连接与认证</CardTitle>
+                  <CardDescription>配置 API 密钥和高级选项。</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <FormField
+                    control={form.control}
+                    name="base_url"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>基础 URL (选填)</FormLabel>
+                        <FormControl>
+                          <Input placeholder="例如 https://api.openai.com/v1" {...field} />
+                        </FormControl>
+                        <FormDescription>如果使用代理或自定义端点，请填写此项。</FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="api_key"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>API 密钥</FormLabel>
+                        <FormControl>
+                          <Input type="password" placeholder="sk-..." {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="config_json"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>高级配置 (JSON)</FormLabel>
+                        <FormControl>
+                          <Textarea
+                            rows={5}
+                            placeholder='{"timeout": 30, "max_retries": 3}'
+                            className="font-mono text-sm"
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </CardContent>
+              </Card>
+            </div>
+
+            {/* ==================== Right Column ==================== */}
+            <div className="space-y-6">
+              <Card>
+                <CardHeader>
+                  <CardTitle>模型配置</CardTitle>
+                  <CardDescription>添加支持的模型及其成本信息。</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-6">
+                  <div className="space-y-4">
+                    {fields.map((field, index) => (
+                      <div key={field.id} className="flex gap-3 items-start">
+                        <FormField
+                          control={form.control}
+                          name={`models.${index}.value`}
+                          render={({ field }) => (
+                            <FormItem className="flex-1">
+                              <FormControl>
+                                <Input placeholder="模型名称 (例如 gpt-4)" {...field} />
+                              </FormControl>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                        <FormField
+                          control={form.control}
+                          name={`models.${index}.display_name`}
+                          render={({ field }) => (
+                            <FormItem className="w-[140px]">
+                              <FormControl>
+                                <Input placeholder="别称（选填）" {...field} />
+                              </FormControl>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                        <FormField
+                          control={form.control}
+                          name={`models.${index}.type`}
+                          render={({ field }) => (
+                            <FormItem className="w-[120px]">
+                              <Select onValueChange={field.onChange} defaultValue={field.value} value={field.value}>
+                                <FormControl>
+                                  <SelectTrigger>
+                                    <SelectValue placeholder="类型" />
+                                  </SelectTrigger>
+                                </FormControl>
+                                <SelectContent>
+                                  {MODEL_TYPE_OPTIONS.map((opt) => (
+                                    <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => remove(index)}
+                          disabled={fields.length === 1}
+                          className="mt-1"
+                        >
+                          <Trash2 className="h-4 w-4 text-muted-foreground hover:text-destructive" />
+                        </Button>
+                      </div>
+                    ))}
+                    
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => append({ value: "", type: "", display_name: "" })}
+                      className="w-full border-dashed"
+                    >
+                      <Plus className="mr-2 h-4 w-4" /> 添加模型
+                    </Button>
+                    {form.formState.errors.models?.message && (
+                      <p className="text-sm font-medium text-destructive">{String(form.formState.errors.models.message)}</p>
+                    )}
+                  </div>
+
+                  {/* 模型成本配置 */}
+                  {fields.length > 0 && fields.some(f => form.getValues(`models.${fields.indexOf(f)}.value`)) && (
+                    <div className="space-y-4 pt-4 border-t">
+                      <div className="flex items-center justify-between">
+                        <h4 className="text-sm font-medium">模型成本配置 (选填)</h4>
+                        <span className="text-xs text-muted-foreground">USD / Unit</span>
+                      </div>
+                      
+                      <div className="space-y-3">
+                        {fields.map((field, index) => {
+                          const modelName = form.watch(`models.${index}.value`);
+                          if (!modelName) return null;
+                          const isExpanded = expandedModels[modelName] || false;
+                          const costs = modelCosts[modelName] || {};
+                          const customKeys = Object.keys(costs).filter(k => !(k in PRESET_COST_DIMENSIONS));
+
+                          return (
+                            <div key={field.id + '-cost'} className="rounded-lg border bg-card text-card-foreground shadow-sm">
+                              <button
+                                type="button"
+                                className="flex items-center gap-3 w-full p-3 text-left hover:bg-muted/50 transition-colors rounded-t-lg"
+                                onClick={() => setExpandedModels(prev => ({ ...prev, [modelName]: !prev[modelName] }))}
+                              >
+                                {isExpanded ? <ChevronDown className="h-4 w-4 text-muted-foreground" /> : <ChevronRight className="h-4 w-4 text-muted-foreground" />}
+                                <span className="font-mono text-sm font-medium">{modelName}</span>
+                                {Object.keys(costs).length > 0 && (
+                                  <Badge variant="secondary" className="ml-auto text-xs font-normal">
+                                    {Object.keys(costs).length} 项配置
+                                  </Badge>
+                                )}
+                              </button>
+                              
+                              {isExpanded && (
+                                <div className="p-4 pt-0 space-y-4 border-t bg-muted/10">
+                                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+                                    {Object.entries(PRESET_COST_DIMENSIONS).map(([dimKey, dimConfig]) => (
+                                      <div key={dimKey} className="space-y-1.5">
+                                        <label className="text-xs font-medium text-muted-foreground flex justify-between">
+                                          {dimConfig.label}
+                                          <span className="opacity-70">{dimConfig.unit}</span>
+                                        </label>
+                                        <Input
+                                          type="number"
+                                          step="0.000001"
+                                          min={0}
+                                          placeholder="0"
+                                          value={costs[dimKey] ?? ''}
+                                          onChange={(e) => {
+                                            const val = e.target.value;
+                                            setModelCosts(prev => {
+                                              const updated = { ...prev };
+                                              const modelEntry = { ...(updated[modelName] || {}) };
+                                              if (val === '') {
+                                                delete modelEntry[dimKey];
+                                              } else {
+                                                modelEntry[dimKey] = Number(val);
+                                              }
+                                              updated[modelName] = modelEntry;
+                                              return updated;
+                                            });
+                                          }}
+                                          className="font-mono h-9 bg-background"
+                                        />
+                                      </div>
+                                    ))}
+                                  </div>
+
+                                  {/* 自定义参数 */}
+                                  {customKeys.length > 0 && (
+                                    <div className="space-y-3 pt-2">
+                                      <h5 className="text-xs font-semibold text-muted-foreground">自定义参数</h5>
+                                      {customKeys.map((customKey) => (
+                                        <div key={customKey} className="flex gap-3 items-end p-2 bg-background rounded-md border">
+                                          <div className="flex-1 space-y-1">
+                                            <label className="text-xs text-muted-foreground">参数名</label>
+                                            <div className="font-mono text-sm px-2 py-1 bg-muted rounded">{customKey}</div>
+                                          </div>
+                                          <div className="flex-1 space-y-1">
+                                            <label className="text-xs text-muted-foreground">成本 (USD)</label>
+                                            <Input
+                                              type="number"
+                                              step="0.000001"
+                                              min={0}
+                                              value={costs[customKey] ?? ''}
+                                              onChange={(e) => {
+                                                const val = e.target.value;
                                                 setModelCosts(prev => {
                                                   const updated = { ...prev };
                                                   const modelEntry = { ...(updated[modelName] || {}) };
-                                                  delete modelEntry[customKey];
+                                                  if (val === '') {
+                                                    delete modelEntry[customKey];
+                                                  } else {
+                                                    modelEntry[customKey] = Number(val);
+                                                  }
                                                   updated[modelName] = modelEntry;
                                                   return updated;
                                                 });
                                               }}
-                                            >
-                                              <X className="h-4 w-4" />
-                                            </Button>
+                                              className="font-mono h-8"
+                                            />
                                           </div>
-                                        ))}
-                                      </div>
-                                    )}
+                                          <Button
+                                            type="button"
+                                            variant="ghost"
+                                            size="icon"
+                                            className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive"
+                                            onClick={() => {
+                                              setModelCosts(prev => {
+                                                const updated = { ...prev };
+                                                const modelEntry = { ...(updated[modelName] || {}) };
+                                                delete modelEntry[customKey];
+                                                updated[modelName] = modelEntry;
+                                                return updated;
+                                              });
+                                            }}
+                                          >
+                                            <X className="h-4 w-4" />
+                                          </Button>
+                                        </div>
+                                      ))}
+                                    </div>
+                                  )}
 
-                                    <Button
-                                      type="button"
-                                      variant="outline"
-                                      size="sm"
-                                      className="w-full border-dashed text-xs"
-                                      onClick={() => {
-                                        const name = prompt('输入自定义参数名 (英文, 如 reasoning_output)');
-                                        if (!name) return;
-                                        if (!name.match(/^[a-z_][a-z0-9_]*$/)) {
-                                          toast({ variant: "destructive", title: "参数名格式错误", description: "仅支持小写字母、数字和下划线" });
-                                          return;
-                                        }
-                                        if (name in PRESET_COST_DIMENSIONS || (costs[name] !== undefined)) {
-                                          toast({ variant: "destructive", title: "参数名已存在" });
-                                          return;
-                                        }
-                                        setModelCosts(prev => {
-                                          const updated = { ...prev };
-                                          updated[modelName] = { ...(updated[modelName] || {}), [name]: 0 };
-                                          return updated;
-                                        });
-                                      }}
-                                    >
-                                      <Plus className="mr-1 h-3 w-3" /> 添加自定义成本参数
-                                    </Button>
-                                  </div>
-                                )}
-                              </div>
-                            );
-                          })}
-                        </div>
+                                  <Button
+                                    type="button"
+                                    variant="outline"
+                                    size="sm"
+                                    className="w-full border-dashed text-xs"
+                                    onClick={() => {
+                                      const name = prompt('输入自定义参数名 (英文, 如 reasoning_output)');
+                                      if (!name) return;
+                                      if (!name.match(/^[a-z_][a-z0-9_]*$/)) {
+                                        toast({ variant: "destructive", title: "参数名格式错误", description: "仅支持小写字母、数字和下划线" });
+                                        return;
+                                      }
+                                      if (name in PRESET_COST_DIMENSIONS || (costs[name] !== undefined)) {
+                                        toast({ variant: "destructive", title: "参数名已存在" });
+                                        return;
+                                      }
+                                      setModelCosts(prev => {
+                                        const updated = { ...prev };
+                                        updated[modelName] = { ...(updated[modelName] || {}), [name]: 0 };
+                                        return updated;
+                                      });
+                                    }}
+                                  >
+                                    <Plus className="mr-1 h-3 w-3" /> 添加自定义成本参数
+                                  </Button>
+                                </div>
+                              )}
+                            </div>
+                          );
+                        })}
                       </div>
-                    )}
-                  </CardContent>
-                </Card>
-
-                <Card className="border-0 shadow-none">
-                  <CardHeader className="px-0">
-                    <CardTitle>连接与认证</CardTitle>
-                    <CardDescription>配置 API 密钥和高级选项。</CardDescription>
-                  </CardHeader>
-                  <CardContent className="px-0 space-y-4">
-                    <FormField
-                      control={form.control}
-                      name="base_url"
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormLabel>基础 URL (选填)</FormLabel>
-                          <FormControl>
-                            <Input placeholder="例如 https://api.openai.com/v1" {...field} />
-                          </FormControl>
-                          <FormDescription>如果使用代理或自定义端点，请填写此项。</FormDescription>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-
-                    <FormField
-                      control={form.control}
-                      name="api_key"
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormLabel>API 密钥 (选填)</FormLabel>
-                          <FormControl>
-                            <Input type="password" placeholder="sk-..." {...field} />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-
-                    <FormField
-                      control={form.control}
-                      name="config_json"
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormLabel>高级配置 (JSON)</FormLabel>
-                          <FormControl>
-                            {/* 移除了自动注入 model_tags 的行为，避免连接测试报错 */}
-                            <Textarea 
-                              rows={5} 
-                              placeholder='{"timeout": 30, "max_retries": 3}' 
-                              className="font-mono text-sm"
-                              {...field} 
-                            />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-                  </CardContent>
-                </Card>
-
-                <Card className="border-0 shadow-none">
-                  <CardHeader className="px-0">
-                    <CardTitle>状态设置</CardTitle>
-                  </CardHeader>
-                  <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-6 px-0">
-                     <FormField
-                      control={form.control}
-                      name="is_active"
-                      render={({ field }) => (
-                        <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4 shadow-sm bg-background">
-                          <div className="space-y-0.5">
-                            <FormLabel className="text-base">启用状态</FormLabel>
-                            <FormDescription>
-                              禁用后将无法在系统中使用此供应商。
-                            </FormDescription>
-                          </div>
-                          <FormControl>
-                            <Switch
-                              checked={field.value}
-                              onCheckedChange={field.onChange}
-                            />
-                          </FormControl>
-                        </FormItem>
-                      )}
-                    />
-                     <FormField
-                      control={form.control}
-                      name="is_default"
-                      render={({ field }) => (
-                        <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4 shadow-sm bg-background">
-                          <div className="space-y-0.5">
-                            <FormLabel className="text-base">默认供应商</FormLabel>
-                            <FormDescription>
-                              设为默认后将优先使用此供应商。
-                            </FormDescription>
-                          </div>
-                          <FormControl>
-                            <Switch
-                              checked={field.value}
-                              onCheckedChange={field.onChange}
-                            />
-                          </FormControl>
-                        </FormItem>
-                      )}
-                    />
-                  </CardContent>
-                </Card>
-
-              </form>
-            </Form>
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            </div>
           </div>
+        </form>
+      </Form>
     </>
   );
 }

--- a/backend/admin/src/app/admin/llm/components/provider-list.tsx
+++ b/backend/admin/src/app/admin/llm/components/provider-list.tsx
@@ -91,8 +91,6 @@ export function ProviderList() {
               <TableHead className="w-[120px]">品牌</TableHead>
               <TableHead>标签</TableHead>
               <TableHead>模型</TableHead>
-              <TableHead className="w-[100px]">状态</TableHead>
-              <TableHead className="w-[80px]">默认</TableHead>
               <TableHead className="w-[120px] text-right">操作</TableHead>
             </TableRow>
           </TableHeader>
@@ -146,15 +144,6 @@ export function ProviderList() {
                       <Badge variant="outline" className="text-xs bg-muted/50 px-1.5 py-0">+{provider.models.length - 2}</Badge>
                     )}
                   </div>
-                </TableCell>
-                <TableCell>
-                  <div className="flex items-center gap-2">
-                    <span className={`h-2 w-2 rounded-full ${provider.is_active ? 'bg-green-500' : 'bg-gray-300'}`} />
-                    <span className="text-sm text-muted-foreground">{provider.is_active ? '启用' : '禁用'}</span>
-                  </div>
-                </TableCell>
-                <TableCell>
-                  {provider.is_default && <Badge variant="secondary">默认</Badge>}
                 </TableCell>
                 <TableCell className="text-right">
                   <div className="flex justify-end gap-2">

--- a/backend/admin/src/app/admin/llm/schema.ts
+++ b/backend/admin/src/app/admin/llm/schema.ts
@@ -60,7 +60,6 @@ export const PROVIDER_OPTIONS = [
   { value: 'deepseek', label: 'DeepSeek', icon: PROVIDER_ICONS.deepseek }, // Fallback to openai icon or generic for now as deepseek icon is missing
   { value: 'minimax', label: 'MiniMax', icon: PROVIDER_ICONS.minimax },
   { value: 'xai', label: 'xAI (Grok)', icon: PROVIDER_ICONS.xai },
-  { value: 'doubao', label: 'Doubao (ByteDance)', icon: PROVIDER_ICONS.doubao },
   { value: 'ark', label: '火山方舟 (Ark)', icon: PROVIDER_ICONS.ark },
   // { value: 'kling', label: 'Kling', icon: PROVIDER_ICONS.kling },
   // { value: 'openrouter', label: 'OpenRouter', icon: PROVIDER_ICONS.openrouter },
@@ -77,7 +76,7 @@ export const formSchema = z.object({
     display_name: z.string().optional(),
   })).min(1, "至少需要一个模型"),
   base_url: z.string().optional(),
-  api_key: z.string().optional(),
+  api_key: z.string().min(1, "请输入 API 密钥"),
   config_json: z.string().refine((val) => {
     if (!val) return true;
     try {
@@ -87,8 +86,6 @@ export const formSchema = z.object({
       return false;
     }
   }, "请输入有效的 JSON 格式").optional(),
-  is_active: z.boolean().optional(),
-  is_default: z.boolean().optional(),
 });
 
 export type LLMProvider = {

--- a/backend/admin/src/app/admin/page.tsx
+++ b/backend/admin/src/app/admin/page.tsx
@@ -4,31 +4,27 @@ import React, { useState, useRef } from 'react';
 import {
   Users,
   UserCheck,
-  BookOpen,
-  FileImage,
-  Video,
-  Coins,
+  DollarSign,
+  Wallet,
   TrendingUp,
-  AlertTriangle,
   Loader2,
   Crown,
-  Wrench,
-  Clock,
-  Music,
-  Film,
-  ImageIcon,
+  Percent,
+  ShieldCheck,
+  BadgeDollarSign,
+  UserMinus,
 } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
-import { Separator } from '@/components/ui/separator';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import {
   useDashboardOverview,
   useRegistrationTrend,
+  useActiveTrend,
+  useConversionTrend,
   useTokenLeaderboard,
-  useSubscriptionAnalysis,
-  useContentStats,
+  useOperationalMetrics,
 } from '@/hooks/useDashboard';
 import {
   ResponsiveContainer,
@@ -40,9 +36,6 @@ import {
   Tooltip,
   BarChart,
   Bar,
-  PieChart,
-  Pie,
-  Cell,
 } from 'recharts';
 
 // ---------------------------------------------------------------------------
@@ -63,14 +56,6 @@ const BUCKET_LABELS: Record<string, string> = {
   older: '更早',
 };
 
-const PIE_COLORS = [
-  'hsl(var(--chart-1, 220 70% 50%))',
-  'hsl(var(--chart-2, 160 60% 45%))',
-  'hsl(var(--chart-3, 30 80% 55%))',
-  'hsl(var(--chart-4, 280 65% 60%))',
-  'hsl(var(--chart-5, 340 75% 55%))',
-];
-
 const fmt = (n?: number | null) => (n ?? 0).toLocaleString();
 const pct = (n?: number | null) => `${(n ?? 0).toFixed(2)}%`;
 
@@ -87,7 +72,7 @@ const PERIOD_OPTIONS: Array<{ key: string; label: string }> = [
   { key: 'all', label: '全部' },
 ];
 
-const PERIOD_TITLE: Record<string, string> = {
+const PERIOD_TITLE_REG: Record<string, string> = {
   today: '注册趋势（今日）',
   yesterday: '注册趋势（近 2 天）',
   week: '注册趋势（本周）',
@@ -96,10 +81,28 @@ const PERIOD_TITLE: Record<string, string> = {
   all: '注册趋势（全部）',
 };
 
+const PERIOD_TITLE_ACTIVE: Record<string, string> = {
+  today: '活跃趋势（今日）',
+  yesterday: '活跃趋势（近 2 天）',
+  week: '活跃趋势（本周）',
+  month: '活跃趋势（近 30 天）',
+  quarter: '活跃趋势（近 3 个月）',
+  all: '活跃趋势（全部）',
+};
+
+const PERIOD_TITLE_CONV: Record<string, string> = {
+  today: '订阅转化（今日）',
+  yesterday: '订阅转化（近 2 天）',
+  week: '订阅转化（本周）',
+  month: '订阅转化（近 30 天）',
+  quarter: '订阅转化（近 3 个月）',
+  all: '订阅转化（全部）',
+};
+
 const LIMIT_OPTIONS = [10, 50, 100] as const;
 
 // ---------------------------------------------------------------------------
-// Stat Card config
+// Stat Card config (4 cards)
 // ---------------------------------------------------------------------------
 
 interface StatCardDef {
@@ -112,13 +115,9 @@ interface StatCardDef {
 
 const STAT_CARDS: StatCardDef[] = [
   { key: 'users', label: '用户总数', icon: Users, color: 'text-blue-500', getValue: (o) => fmt(o.total_users) },
-  { key: 'active', label: '活跃用户', icon: UserCheck, color: 'text-green-500', getValue: (o) => fmt(o.active_users) },
-  { key: 'theaters', label: '故事总数', icon: BookOpen, color: 'text-violet-500', getValue: (o) => fmt(o.total_theaters) },
-  { key: 'assets', label: '生成资产', icon: FileImage, color: 'text-cyan-500', getValue: (o) => fmt(o.total_assets) },
-  { key: 'video', label: '视频任务', icon: Video, color: 'text-rose-500', getValue: (o) => fmt(o.total_video_tasks) },
-  { key: 'credits', label: '积分消耗', icon: Coins, color: 'text-amber-500', getValue: (o) => fmt(o.total_credits_consumed) },
-  { key: 'conversion', label: '付费转化率', icon: TrendingUp, color: 'text-emerald-500', getValue: (o) => pct(o.paid_conversion_rate) },
-  { key: 'error', label: 'API 错误率', icon: AlertTriangle, color: 'text-red-500', getValue: (o) => pct(o.api_error_rate) },
+  { key: 'today_active', label: '今日活跃', icon: UserCheck, color: 'text-green-500', getValue: (o) => fmt(o.today_active_users) },
+  { key: 'today_revenue', label: '今日营收', icon: DollarSign, color: 'text-amber-500', getValue: (o) => `$${fmt(o.today_revenue)}` },
+  { key: 'total_revenue', label: '总营收', icon: Wallet, color: 'text-violet-500', getValue: (o) => `$${fmt(o.total_revenue)}` },
 ];
 
 // ---------------------------------------------------------------------------
@@ -156,6 +155,30 @@ function StatCardGrid() {
 }
 
 // ---------------------------------------------------------------------------
+// Period selector (shared)
+// ---------------------------------------------------------------------------
+
+function PeriodSelector({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  return (
+    <div className="flex gap-1">
+      {PERIOD_OPTIONS.map(({ key, label }) => (
+        <button
+          key={key}
+          onClick={() => onChange(key)}
+          className={`rounded-md px-2 py-0.5 text-xs transition-colors ${
+            value === key
+              ? 'bg-primary text-primary-foreground'
+              : 'text-muted-foreground hover:bg-muted'
+          }`}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Registration trend
 // ---------------------------------------------------------------------------
 
@@ -170,22 +193,8 @@ function RegistrationTrendChart() {
     <Card className="flex flex-col">
       <CardHeader className="pb-2">
         <div className="flex items-center justify-between gap-2">
-          <CardTitle className="text-base">{PERIOD_TITLE[period] ?? '注册趋势'}</CardTitle>
-          <div className="flex gap-1">
-            {PERIOD_OPTIONS.map(({ key, label }) => (
-              <button
-                key={key}
-                onClick={() => setPeriod(key)}
-                className={`rounded-md px-2 py-0.5 text-xs transition-colors ${
-                  period === key
-                    ? 'bg-primary text-primary-foreground'
-                    : 'text-muted-foreground hover:bg-muted'
-                }`}
-              >
-                {label}
-              </button>
-            ))}
-          </div>
+          <CardTitle className="text-base">{PERIOD_TITLE_REG[period] ?? '注册趋势'}</CardTitle>
+          <PeriodSelector value={period} onChange={setPeriod} />
         </div>
         <div className="flex flex-wrap gap-2 pt-1">
           {Object.entries(BUCKET_LABELS).map(([k, v]) => (
@@ -197,7 +206,7 @@ function RegistrationTrendChart() {
       </CardHeader>
       <CardContent className="flex-1 pt-0">
         {isLoading ? <LoadingSpinner /> : (
-          <div className="h-[260px] w-full">
+          <div className="h-[220px] w-full">
             <ResponsiveContainer width="100%" height="100%">
               <AreaChart data={daily} margin={{ top: 8, right: 8, left: -16, bottom: 0 }}>
                 <defs>
@@ -207,23 +216,91 @@ function RegistrationTrendChart() {
                   </linearGradient>
                 </defs>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
-                <XAxis
-                  dataKey="date"
-                  tick={{ fontSize: 11 }}
-                  tickFormatter={(v: string) => v.slice(5)}
-                  className="fill-muted-foreground"
-                />
+                <XAxis dataKey="date" tick={{ fontSize: 11 }} tickFormatter={(v: string) => v.slice(5)} className="fill-muted-foreground" />
                 <YAxis tick={{ fontSize: 11 }} className="fill-muted-foreground" allowDecimals={false} />
                 <Tooltip contentStyle={TOOLTIP_STYLE} labelFormatter={(l) => `日期：${l}`} />
-                <Area
-                  type="monotone"
-                  dataKey="count"
-                  name="注册数"
-                  stroke="hsl(var(--primary))"
-                  fill="url(#regGrad)"
-                  strokeWidth={2}
-                />
+                <Area type="monotone" dataKey="count" name="注册数" stroke="hsl(var(--primary))" fill="url(#regGrad)" strokeWidth={2} />
               </AreaChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Active trend
+// ---------------------------------------------------------------------------
+
+function ActiveTrendChart() {
+  const [period, setPeriod] = useState('month');
+  const { trend, isLoading } = useActiveTrend(period);
+
+  const daily = trend?.daily ?? [];
+
+  return (
+    <Card className="flex flex-col">
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="text-base">{PERIOD_TITLE_ACTIVE[period] ?? '活跃趋势'}</CardTitle>
+          <PeriodSelector value={period} onChange={setPeriod} />
+        </div>
+      </CardHeader>
+      <CardContent className="flex-1 pt-0">
+        {isLoading ? <LoadingSpinner /> : (
+          <div className="h-[220px] w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              <AreaChart data={daily} margin={{ top: 8, right: 8, left: -16, bottom: 0 }}>
+                <defs>
+                  <linearGradient id="activeGrad" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor="hsl(var(--chart-2, 160 60% 45%))" stopOpacity={0.3} />
+                    <stop offset="100%" stopColor="hsl(var(--chart-2, 160 60% 45%))" stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+                <XAxis dataKey="date" tick={{ fontSize: 11 }} tickFormatter={(v: string) => v.slice(5)} className="fill-muted-foreground" />
+                <YAxis tick={{ fontSize: 11 }} className="fill-muted-foreground" allowDecimals={false} />
+                <Tooltip contentStyle={TOOLTIP_STYLE} labelFormatter={(l) => `日期：${l}`} />
+                <Area type="monotone" dataKey="count" name="活跃用户" stroke="hsl(var(--chart-2, 160 60% 45%))" fill="url(#activeGrad)" strokeWidth={2} />
+              </AreaChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Conversion trend
+// ---------------------------------------------------------------------------
+
+function ConversionTrendChart() {
+  const [period, setPeriod] = useState('month');
+  const { trend, isLoading } = useConversionTrend(period);
+
+  const daily = trend?.daily ?? [];
+
+  return (
+    <Card className="flex flex-col">
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="text-base">{PERIOD_TITLE_CONV[period] ?? '订阅转化'}</CardTitle>
+          <PeriodSelector value={period} onChange={setPeriod} />
+        </div>
+      </CardHeader>
+      <CardContent className="flex-1 pt-0">
+        {isLoading ? <LoadingSpinner /> : (
+          <div className="h-[220px] w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={daily} margin={{ top: 8, right: 8, left: -16, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+                <XAxis dataKey="date" tick={{ fontSize: 11 }} tickFormatter={(v: string) => v.slice(5)} className="fill-muted-foreground" />
+                <YAxis tick={{ fontSize: 11 }} className="fill-muted-foreground" allowDecimals={false} />
+                <Tooltip contentStyle={TOOLTIP_STYLE} labelFormatter={(l) => `日期：${l}`} />
+                <Bar dataKey="new_subscriptions" name="新增订阅" fill="hsl(var(--chart-3, 30 80% 55%))" radius={[4, 4, 0, 0]} />
+              </BarChart>
             </ResponsiveContainer>
           </div>
         )}
@@ -242,7 +319,7 @@ const RANK_COLORS: Record<number, string> = {
   3: 'text-amber-700',
 };
 
-const ROW_HEIGHT = 52;
+const ROW_HEIGHT = 56;
 
 function TokenLeaderboard() {
   const [limit, setLimit] = useState<number>(10);
@@ -287,26 +364,21 @@ function TokenLeaderboard() {
         ) : (
           <>
             {/* Table header */}
-            <div className="grid grid-cols-[40px_1fr_100px_80px] gap-1 border-b px-1 pb-1.5 text-xs font-medium text-muted-foreground">
+            <div className="grid grid-cols-[40px_1fr_100px_100px] gap-1 border-b px-1 pb-1.5 text-xs font-medium text-muted-foreground">
               <span>#</span>
               <span>用户</span>
               <span className="text-right">总 Token</span>
               <span className="text-right">积分</span>
             </div>
             {/* Virtual scroll area */}
-            <div
-              ref={scrollRef}
-              className="flex-1 overflow-auto"
-            >
-              <div
-                style={{ height: rowVirtualizer.getTotalSize(), position: 'relative', width: '100%' }}
-              >
+            <div ref={scrollRef} className="flex-1 overflow-auto">
+              <div style={{ height: rowVirtualizer.getTotalSize(), position: 'relative', width: '100%' }}>
                 {rowVirtualizer.getVirtualItems().map((vRow) => {
                   const entry = leaderboard[vRow.index];
                   return (
                     <div
                       key={entry.user_id}
-                      className="absolute left-0 top-0 grid w-full grid-cols-[40px_1fr_100px_80px] items-center gap-1 border-b border-border/50 px-1"
+                      className="absolute left-0 top-0 grid w-full grid-cols-[40px_1fr_100px_100px] items-center gap-1 border-b border-border/50 px-1"
                       style={{ height: vRow.size, transform: `translateY(${vRow.start}px)` }}
                     >
                       <span className={`text-sm font-semibold tabular-nums ${RANK_COLORS[entry.rank] ?? ''}`}>
@@ -324,7 +396,10 @@ function TokenLeaderboard() {
                         </div>
                       </div>
                       <span className="text-right text-sm tabular-nums">{fmt(entry.total_tokens)}</span>
-                      <span className="text-right text-sm tabular-nums">{fmt(entry.credits)}</span>
+                      <div className="text-right">
+                        <p className="text-sm tabular-nums font-medium">{fmt(entry.credits)}</p>
+                        <p className="text-xs tabular-nums text-muted-foreground">-{fmt(entry.credits_consumed)}</p>
+                      </div>
                     </div>
                   );
                 })}
@@ -338,144 +413,19 @@ function TokenLeaderboard() {
 }
 
 // ---------------------------------------------------------------------------
-// Subscription analysis
+// Business Metrics (PUR / Retention / MRR / Churn)
 // ---------------------------------------------------------------------------
 
-function SubscriptionAnalysis() {
-  const { subscriptions, isLoading } = useSubscriptionAnalysis();
+function BusinessMetrics() {
+  const { metrics, isLoading } = useOperationalMetrics();
 
   if (isLoading) return <LoadingSpinner />;
 
-  const byPlan = subscriptions?.by_plan ?? [];
-  const timeBuckets = subscriptions?.time_buckets ?? {};
-
-  return (
-    <Card className="flex flex-col">
-      <CardHeader className="pb-2">
-        <CardTitle className="text-base">订阅分析</CardTitle>
-        <p className="text-xs text-muted-foreground">
-          活跃订阅：{fmt(subscriptions?.total_active_subscriptions)}
-        </p>
-      </CardHeader>
-      <CardContent className="flex-1 pt-0">
-        <div className="h-[220px] w-full">
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={byPlan} margin={{ top: 8, right: 8, left: -16, bottom: 0 }}>
-              <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
-              <XAxis dataKey="plan_name" tick={{ fontSize: 11 }} className="fill-muted-foreground" />
-              <YAxis tick={{ fontSize: 11 }} className="fill-muted-foreground" allowDecimals={false} />
-              <Tooltip
-                contentStyle={TOOLTIP_STYLE}
-                formatter={(value, name) => [fmt(value as number), name]}
-              />
-              <Bar dataKey="active_count" name="活跃用户" fill="hsl(var(--primary))" radius={[4, 4, 0, 0]} />
-              <Bar dataKey="revenue" name="收入 (USD)" fill="hsl(var(--chart-2, 160 60% 45%))" radius={[4, 4, 0, 0]} />
-            </BarChart>
-          </ResponsiveContainer>
-        </div>
-        <Separator className="my-3" />
-        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
-          {Object.entries(timeBuckets).map(([k, v]) => (
-            <span key={k}>{BUCKET_LABELS[k] ?? k}：<strong className="text-foreground">{fmt(v)}</strong></span>
-          ))}
-        </div>
-      </CardContent>
-    </Card>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Content stats (pie charts)
-// ---------------------------------------------------------------------------
-
-function ContentStats() {
-  const { content, isLoading } = useContentStats();
-
-  if (isLoading) return <LoadingSpinner />;
-
-  const video = content?.video;
-  const image = content?.image;
-  const music = content?.music;
-
-  const pieData = [
-    { name: '视频成功', value: video?.completed ?? 0 },
-    { name: '视频失败', value: video?.failed ?? 0 },
-    { name: '图像成功', value: image?.completed ?? 0 },
-    { name: '图像失败', value: image?.failed ?? 0 },
-    { name: '音乐成功', value: music?.completed ?? 0 },
-    { name: '音乐失败', value: music?.failed ?? 0 },
-  ];
-
-  const successCards = [
-    { label: '视频生成', icon: Film, total: video?.total ?? 0, rate: video?.success_rate ?? 0, color: 'text-rose-500' },
-    { label: '图像生成', icon: ImageIcon, total: image?.total ?? 0, rate: image?.success_rate ?? 0, color: 'text-cyan-500' },
-    { label: '音乐生成', icon: Music, total: music?.total ?? 0, rate: music?.success_rate ?? 0, color: 'text-violet-500' },
-  ];
-
-  return (
-    <Card className="flex flex-col">
-      <CardHeader className="pb-2">
-        <CardTitle className="text-base">内容生成统计</CardTitle>
-      </CardHeader>
-      <CardContent className="flex-1 pt-0">
-        <div className="grid grid-cols-3 gap-3 mb-3">
-          {successCards.map(({ label, icon: Icon, total, rate, color }) => (
-            <div key={label} className="rounded-lg border p-3">
-              <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                <Icon className={`h-3.5 w-3.5 ${color}`} />
-                {label}
-              </div>
-              <p className="mt-1 text-lg font-bold">{fmt(total)}</p>
-              <p className="text-xs text-muted-foreground">
-                成功率：<span className="text-foreground font-medium">{rate.toFixed(1)}%</span>
-              </p>
-            </div>
-          ))}
-        </div>
-        <div className="h-[180px] w-full">
-          <ResponsiveContainer width="100%" height="100%">
-            <PieChart>
-              <Pie
-                data={pieData}
-                cx="50%"
-                cy="50%"
-                innerRadius={45}
-                outerRadius={72}
-                paddingAngle={3}
-                dataKey="value"
-                nameKey="name"
-                strokeWidth={0}
-              >
-                {pieData.map((_, i) => (
-                  <Cell key={i} fill={PIE_COLORS[i % PIE_COLORS.length]} />
-                ))}
-              </Pie>
-              <Tooltip contentStyle={TOOLTIP_STYLE} />
-            </PieChart>
-          </ResponsiveContainer>
-        </div>
-      </CardContent>
-    </Card>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Operational metrics
-// ---------------------------------------------------------------------------
-
-function OperationalMetrics() {
-  const { overview, isLoading: overviewLoading } = useDashboardOverview();
-  const { content, isLoading: contentLoading } = useContentStats();
-
-  if (overviewLoading || contentLoading) return <LoadingSpinner />;
-
-  const tool = content?.tool_execution;
-
-  const metrics = [
-    { label: '工具总调用', value: fmt(overview?.tool_total_calls), icon: Wrench, color: 'text-blue-500' },
-    { label: '工具错误数', value: fmt(overview?.tool_errors), icon: AlertTriangle, color: 'text-red-500' },
-    { label: '错误率', value: pct(tool?.error_rate), icon: TrendingUp, color: 'text-amber-500' },
-    { label: '平均耗时', value: tool?.avg_duration_ms != null ? `${tool.avg_duration_ms.toFixed(0)} ms` : '—', icon: Clock, color: 'text-emerald-500' },
+  const cards = [
+    { label: '付费用户占比 (PUR)', value: pct(metrics?.pur), icon: Percent, color: 'text-blue-500' },
+    { label: '活跃留存率', value: pct(metrics?.retention_rate), icon: ShieldCheck, color: 'text-green-500' },
+    { label: 'MRR (月经常性收入)', value: `$${fmt(metrics?.mrr)}`, icon: BadgeDollarSign, color: 'text-amber-500' },
+    { label: '退订率', value: pct(metrics?.churn_rate), icon: UserMinus, color: 'text-red-500' },
   ];
 
   return (
@@ -485,7 +435,7 @@ function OperationalMetrics() {
       </CardHeader>
       <CardContent>
         <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
-          {metrics.map(({ label, value, icon: Icon, color }) => (
+          {cards.map(({ label, value, icon: Icon, color }) => (
             <div key={label} className="rounded-lg border p-3">
               <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
                 <Icon className={`h-3.5 w-3.5 ${color}`} />
@@ -512,22 +462,20 @@ export default function AdminDashboard() {
       {/* Row 1: Stat cards */}
       <StatCardGrid />
 
-      {/* Row 2+3: Left stack (trend + subscription) | Right (token leaderboard spans full height) */}
+      {/* Row 2: Left stack (3 trend charts) | Right (token leaderboard spans full height) */}
       <div className="grid gap-4 lg:grid-cols-5">
         <div className="flex flex-col gap-4 lg:col-span-3">
           <RegistrationTrendChart />
-          <SubscriptionAnalysis />
+          <ActiveTrendChart />
+          <ConversionTrendChart />
         </div>
         <div className="lg:col-span-2">
           <TokenLeaderboard />
         </div>
       </div>
 
-      {/* Row 4: Content stats */}
-      <ContentStats />
-
-      {/* Row 4: Operational metrics */}
-      <OperationalMetrics />
+      {/* Row 3: Business metrics */}
+      <BusinessMetrics />
     </div>
   );
 }

--- a/backend/admin/src/components/admin/AdminLayout.tsx
+++ b/backend/admin/src/components/admin/AdminLayout.tsx
@@ -142,7 +142,9 @@ const AdminLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
         <div className="flex-1 overflow-auto py-2">
           <nav className="grid items-start px-2 text-sm font-medium lg:px-4">
             {items.map((item) => {
-              const isActive = pathname === item.href;
+              const isActive = item.href === '/admin'
+                ? pathname === item.href
+                : pathname.startsWith(item.href);
               return (
                 <Link
                   key={item.href}

--- a/backend/admin/src/components/admin/agents/AgentForm/BasicInfo.tsx
+++ b/backend/admin/src/components/admin/agents/AgentForm/BasicInfo.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
+import Image from 'next/image';
 import {
   FormControl,
   FormField,
@@ -18,6 +19,25 @@ import {
 import { Textarea } from '@/components/ui/textarea';
 import { LLMProvider } from '@/types';
 import { parseProviderModelsWithMeta } from '@/lib/api-utils';
+
+// 供应商品牌 Logo 映射（与 LLM schema 保持一致）
+const PROVIDER_ICONS: Record<string, string> = {
+  openai: '/provider/openai.svg',
+  azure: '/provider/azureai-color.svg',
+  dashscope: '/provider/qwen-color.svg',
+  anthropic: '/provider/claude-color.svg',
+  gemini: '/provider/gemini-color.svg',
+  deepseek: '/provider/deepseek-color.svg',
+  minimax: '/provider/minimax-color.svg',
+  xai: '/provider/grok.svg',
+  doubao: '/provider/doubao-color.svg',
+  kling: '/provider/kling-color.svg',
+  meta: '/provider/meta-color.svg',
+  microsoft: '/provider/microsoft-color.svg',
+  openrouter: '/provider/openrouter.svg',
+  sora: '/provider/sora-color.svg',
+  ark: '/provider/volcengine-color.svg',
+};
 
 interface BasicInfoProps {
   providers: LLMProvider[];
@@ -47,7 +67,7 @@ const BasicInfo: React.FC<BasicInfoProps> = ({
         name="name"
         render={({ field }) => (
           <FormItem>
-            <FormLabel>名称</FormLabel>
+            <FormLabel>名称 <span className="text-destructive">*</span></FormLabel>
             <FormControl>
               <Input placeholder="给智能体起个名字，例如: 故事导演" disabled={loading} {...field} />
             </FormControl>
@@ -61,7 +81,7 @@ const BasicInfo: React.FC<BasicInfoProps> = ({
         name="description"
         render={({ field }) => (
           <FormItem>
-            <FormLabel>描述</FormLabel>
+            <FormLabel>描述 <span className="text-destructive">*</span></FormLabel>
             <FormControl>
               <Textarea 
                 placeholder="简要描述智能体的职责和功能..." 
@@ -76,30 +96,6 @@ const BasicInfo: React.FC<BasicInfoProps> = ({
         )}
       />
 
-      <FormField
-        control={control}
-        name="agent_type"
-        render={({ field }) => (
-          <FormItem>
-            <FormLabel>智能体类型</FormLabel>
-            <Select onValueChange={field.onChange} value={field.value} disabled={loading}>
-              <FormControl>
-                <SelectTrigger>
-                  <SelectValue placeholder="选择类型" />
-                </SelectTrigger>
-              </FormControl>
-              <SelectContent>
-                <SelectItem value="text">📝 文本处理（故事、角色、分镜脚本）</SelectItem>
-                <SelectItem value="image">🎨 图像处理（角色立绘、场景图）</SelectItem>
-                <SelectItem value="multimodal">✨ 多模态（文本 + 图像）</SelectItem>
-                <SelectItem value="video">🎬 视频生成（xAI Video）</SelectItem>
-              </SelectContent>
-            </Select>
-            <FormMessage />
-          </FormItem>
-        )}
-      />
-
       <div className="p-4 bg-muted/50 rounded-xl border">
         <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground mb-3">模型配置</div>
         <div className="grid grid-cols-2 gap-4">
@@ -108,7 +104,7 @@ const BasicInfo: React.FC<BasicInfoProps> = ({
             name="provider_id"
             render={({ field }) => (
               <FormItem>
-                <FormLabel className="text-xs">供应商</FormLabel>
+                <FormLabel className="text-xs">供应商 <span className="text-destructive">*</span></FormLabel>
                 <Select 
                   onValueChange={(value) => {
                     field.onChange(value);
@@ -126,11 +122,21 @@ const BasicInfo: React.FC<BasicInfoProps> = ({
                     </SelectTrigger>
                   </FormControl>
                   <SelectContent>
-                    {providers.map((p) => (
-                      <SelectItem key={p.id} value={p.id}>
-                        {p.name}
-                      </SelectItem>
-                    ))}
+                    {providers.map((p) => {
+                      const icon = PROVIDER_ICONS[p.provider_type?.toLowerCase()];
+                      return (
+                        <SelectItem key={p.id} value={p.id}>
+                          <div className="flex items-center gap-2">
+                            {icon && (
+                              <div className="relative h-5 w-5 shrink-0 overflow-hidden rounded-sm">
+                                <Image src={icon} alt={p.name} fill className="object-contain" />
+                              </div>
+                            )}
+                            <span>{p.name}</span>
+                          </div>
+                        </SelectItem>
+                      );
+                    })}
                   </SelectContent>
                 </Select>
                 <FormMessage />
@@ -143,7 +149,7 @@ const BasicInfo: React.FC<BasicInfoProps> = ({
             name="model"
             render={({ field }) => (
               <FormItem>
-                <FormLabel className="text-xs">模型</FormLabel>
+                <FormLabel className="text-xs">模型 <span className="text-destructive">*</span></FormLabel>
                 <Select 
                   onValueChange={(value) => {
                     // 防止意外清空：只有当新值非空或用户主动选择时才更新

--- a/backend/admin/src/components/admin/agents/AgentForm/Parameters.tsx
+++ b/backend/admin/src/components/admin/agents/AgentForm/Parameters.tsx
@@ -95,7 +95,7 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
 
   // 格式化显示 context_window (如 128K)
   const formatContextWindow = (value: number) => {
-    return value >= 1000 ? `${Math.round(value / 1024)}K` : value.toString();
+    return value >= 1048576 ? `${(value / 1048576).toFixed(1)}M` : value >= 1024 ? `${Math.round(value / 1024)}K` : value.toString();
   };
 
   return (
@@ -142,8 +142,8 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
                     <div className="flex items-center gap-4">
                       <Slider
                         min={4096}
-                        max={262144}
-                        step={1024}
+                        max={1048576}
+                        step={4096}
                         value={[field.value ?? 4096]}
                         onValueChange={(vals) => field.onChange(vals[0])}
                         disabled={disabled}
@@ -156,9 +156,9 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
                           const val = e.target.value;
                           field.onChange(val === '' ? 4096 : Number(val));
                         }}
-                        step={1024}
+                        step={4096}
                         min={4096}
-                        max={262144}
+                        max={1048576}
                         className="w-24 font-mono"
                         disabled={disabled}
                       />
@@ -170,7 +170,7 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
             />
            <div className="flex justify-between text-xs text-muted-foreground mt-2">
              <span>4K</span>
-             <span>256K</span>
+             <span>1M</span>
            </div>
          </div>
       </div>

--- a/backend/admin/src/components/admin/agents/AgentForm/SystemPrompt.tsx
+++ b/backend/admin/src/components/admin/agents/AgentForm/SystemPrompt.tsx
@@ -69,7 +69,7 @@ const SystemPrompt: React.FC<SystemPromptProps> = ({ disabled }) => {
         render={({ field }) => (
           <FormItem>
             <div className="flex items-center justify-between mb-1">
-              <FormLabel>系统提示词 (System Prompt)</FormLabel>
+              <FormLabel>系统提示词 <span className="text-destructive">*</span></FormLabel>
               <Button
                 type="button"
                 variant="outline"

--- a/backend/admin/src/components/admin/agents/AgentForm/index.tsx
+++ b/backend/admin/src/components/admin/agents/AgentForm/index.tsx
@@ -312,7 +312,7 @@ export default function AgentForm({
             </Section>
           </div>
           <div className="lg:col-span-6 xl:col-span-5">
-            <div className="lg:sticky lg:top-0 lg:max-h-screen lg:overflow-y-auto space-y-6 pb-4">
+            <div className="space-y-6 pb-4">
               <Section title="参数设置">
                 <Parameters disabled={loading} providers={activeProviders || []} />
               </Section>

--- a/backend/admin/src/components/admin/agents/AgentForm/schema.ts
+++ b/backend/admin/src/components/admin/agents/AgentForm/schema.ts
@@ -53,7 +53,7 @@ export const agentFormSchema = z.object({
   agent_type: z.enum(["text", "image", "multimodal", "video"]).default("text"),
   system_prompt: z.string().min(1, "请输入系统提示词").max(5000, "最大长度5000字符"),
   temperature: z.number().min(0).max(1),
-  context_window: z.number().min(4096, "最小值为4096").max(262144, "最大值为262144"),
+  context_window: z.number().min(4096, "最小值为4096").max(1048576, "最大值为1048576"),
   thinking_mode: z.boolean().optional(),
   tools_enabled: z.boolean().optional(),
   tools: z.array(z.string()).optional(),

--- a/backend/admin/src/hooks/useDashboard.ts
+++ b/backend/admin/src/hooks/useDashboard.ts
@@ -9,22 +9,24 @@ const fetcher = (url: string) => api.get(url).then((r) => r.data);
 
 export interface OverviewData {
   total_users: number;
-  active_users: number;
-  total_theaters: number;
-  total_assets: number;
-  total_video_tasks: number;
-  total_music_tasks: number;
-  total_credits_consumed: number;
-  paid_users: number;
-  paid_conversion_rate: number;
-  api_error_rate: number;
-  tool_total_calls: number;
-  tool_errors: number;
+  today_active_users: number;
+  today_revenue: number;
+  total_revenue: number;
 }
 
 export interface RegistrationTrendData {
   buckets: Record<string, number>;
   daily: Array<{ date: string; count: number }>;
+  period: string;
+}
+
+export interface ActiveTrendData {
+  daily: Array<{ date: string; count: number }>;
+  period: string;
+}
+
+export interface ConversionTrendData {
+  daily: Array<{ date: string; new_subscriptions: number; total_users_that_day: number }>;
   period: string;
 }
 
@@ -37,6 +39,7 @@ export interface TokenLeaderboardEntry {
   output_tokens: number;
   total_tokens: number;
   credits: number;
+  credits_consumed: number;
 }
 
 export interface PlanBreakdown {
@@ -61,6 +64,13 @@ export interface ContentStatsData {
   tool_execution: { total: number; errors: number; error_rate: number; avg_duration_ms: number | null };
 }
 
+export interface OperationalMetricsData {
+  pur: number;
+  retention_rate: number;
+  mrr: number;
+  churn_rate: number;
+}
+
 // ---------------------------------------------------------------------------
 // Hooks
 // ---------------------------------------------------------------------------
@@ -72,6 +82,16 @@ export function useDashboardOverview() {
 
 export function useRegistrationTrend(period: string = 'month') {
   const { data, error, isLoading } = useSWR<RegistrationTrendData>(`/admin/dashboard/registration-trend?period=${period}`, fetcher);
+  return { trend: data, error, isLoading };
+}
+
+export function useActiveTrend(period: string = 'month') {
+  const { data, error, isLoading } = useSWR<ActiveTrendData>(`/admin/dashboard/active-trend?period=${period}`, fetcher);
+  return { trend: data, error, isLoading };
+}
+
+export function useConversionTrend(period: string = 'month') {
+  const { data, error, isLoading } = useSWR<ConversionTrendData>(`/admin/dashboard/conversion-trend?period=${period}`, fetcher);
   return { trend: data, error, isLoading };
 }
 
@@ -88,4 +108,9 @@ export function useSubscriptionAnalysis() {
 export function useContentStats() {
   const { data, error, isLoading } = useSWR<ContentStatsData>('/admin/dashboard/content-stats', fetcher);
   return { content: data, error, isLoading };
+}
+
+export function useOperationalMetrics() {
+  const { data, error, isLoading } = useSWR<OperationalMetricsData>('/admin/dashboard/operational-metrics', fetcher);
+  return { metrics: data, error, isLoading };
 }

--- a/backend/routers/admin_dashboard.py
+++ b/backend/routers/admin_dashboard.py
@@ -49,57 +49,39 @@ async def dashboard_overview(
     db: AsyncSession = Depends(get_db),
 ):
     """返回仪表盘核心统计指标。"""
-    now = datetime.now(timezone.utc)
-    thirty_days_ago = now - timedelta(days=30)
+    bounds = _time_boundaries()
+    today_start = bounds["today"]
 
-    # 并行查询所有计数
     total_users = await db.scalar(select(func.count(User.id))) or 0
-    active_users = await db.scalar(
-        select(func.count(User.id)).where(User.last_login_at >= thirty_days_ago)
-    ) or 0
-    total_theaters = await db.scalar(select(func.count(Theater.id))) or 0
-    total_assets = await db.scalar(select(func.count(Asset.id))) or 0
-    total_video_tasks = await db.scalar(select(func.count(VideoTask.id))) or 0
-    total_music_tasks = await db.scalar(select(func.count(MusicTask.id))) or 0
 
-    # 积分消耗总量（负数交易的绝对值之和）
-    total_credits_consumed = await db.scalar(
-        select(func.coalesce(func.sum(func.abs(CreditTransaction.amount)), 0))
-        .where(CreditTransaction.amount < 0)
+    # 今日活跃用户（今日有登录记录）
+    today_active_users = await db.scalar(
+        select(func.count(User.id)).where(User.last_login_at >= today_start)
     ) or 0
 
-    # 付费转化率
-    paid_users = await db.scalar(
-        select(func.count(User.id)).where(User.subscription_status == "active")
+    # 今日营收（仅统计用户付费交易：subscription / purchase）
+    _paid_types = ["subscription", "purchase"]
+    _revenue_filter = and_(
+        CreditTransaction.amount > 0,
+        CreditTransaction.transaction_type.in_(_paid_types),
+        CreditTransaction.user_id.isnot(None),
+    )
+    today_revenue = await db.scalar(
+        select(func.coalesce(func.sum(CreditTransaction.amount), 0)).where(
+            and_(_revenue_filter, CreditTransaction.created_at >= today_start)
+        )
     ) or 0
-    paid_conversion_rate = round(paid_users / total_users * 100, 2) if total_users else 0
 
-    # API 错误率
-    tool_total = await db.scalar(select(func.count(ToolExecution.id))) or 0
-    tool_errors = await db.scalar(
-        select(func.count(ToolExecution.id)).where(ToolExecution.status == "error")
-    ) or 0
-    api_error_rate = round(tool_errors / tool_total * 100, 2) if tool_total else 0
-
-    # 全平台存储总量
-    total_storage_used = await db.scalar(
-        select(func.coalesce(func.sum(User.storage_used_bytes), 0))
+    # 总营收（仅统计用户付费交易）
+    total_revenue = await db.scalar(
+        select(func.coalesce(func.sum(CreditTransaction.amount), 0)).where(_revenue_filter)
     ) or 0
 
     return {
         "total_users": total_users,
-        "active_users": active_users,
-        "total_theaters": total_theaters,
-        "total_assets": total_assets,
-        "total_video_tasks": total_video_tasks,
-        "total_music_tasks": total_music_tasks,
-        "total_credits_consumed": round(float(total_credits_consumed), 2),
-        "paid_users": paid_users,
-        "paid_conversion_rate": paid_conversion_rate,
-        "api_error_rate": api_error_rate,
-        "tool_total_calls": tool_total,
-        "tool_errors": tool_errors,
-        "total_storage_used": total_storage_used,
+        "today_active_users": today_active_users,
+        "today_revenue": round(float(today_revenue), 2),
+        "total_revenue": round(float(total_revenue), 2),
     }
 
 
@@ -165,6 +147,96 @@ async def registration_trend(
 
 
 # ---------------------------------------------------------------------------
+# 2b. 活跃趋势
+# ---------------------------------------------------------------------------
+
+@router.get("/active-trend")
+async def active_trend(
+    period: str = Query(default="month", description="筛选周期: today/yesterday/week/month/quarter/all"),
+    _admin: Admin = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    """按日统计每天有多少不同用户登录过。"""
+    days = PERIOD_DAYS.get(period, 30)
+    now = datetime.now(timezone.utc)
+    start_date = now - timedelta(days=days)
+
+    daily_result = await db.execute(
+        select(
+            func.date(User.last_login_at).label("day"),
+            func.count(func.distinct(User.id)).label("count"),
+        )
+        .where(User.last_login_at >= start_date)
+        .group_by(func.date(User.last_login_at))
+        .order_by(literal_column("day"))
+    )
+    daily = [{"date": str(r.day), "count": r.count} for r in daily_result.all()]
+    return {"daily": daily, "period": period}
+
+
+# ---------------------------------------------------------------------------
+# 2c. 订阅转化趋势
+# ---------------------------------------------------------------------------
+
+@router.get("/conversion-trend")
+async def conversion_trend(
+    period: str = Query(default="month", description="筛选周期: today/yesterday/week/month/quarter/all"),
+    _admin: Admin = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    """按日统计新增订阅数与当天累计用户总数。"""
+    days = PERIOD_DAYS.get(period, 30)
+    now = datetime.now(timezone.utc)
+    start_date = now - timedelta(days=days)
+
+    # 新增订阅数（按 subscription_start_at 分组）
+    sub_result = await db.execute(
+        select(
+            func.date(User.subscription_start_at).label("day"),
+            func.count(User.id).label("new_subscriptions"),
+        )
+        .where(
+            and_(
+                User.subscription_start_at >= start_date,
+                User.subscription_status.in_(["active", "expired"]),
+            )
+        )
+        .group_by(func.date(User.subscription_start_at))
+        .order_by(literal_column("day"))
+    )
+    sub_map: dict[str, int] = {str(r.day): r.new_subscriptions for r in sub_result.all()}
+
+    # 每日注册累计用户（用于计算转化基数）
+    reg_result = await db.execute(
+        select(
+            func.date(User.created_at).label("day"),
+            func.count(User.id).label("count"),
+        )
+        .where(User.created_at >= start_date)
+        .group_by(func.date(User.created_at))
+        .order_by(literal_column("day"))
+    )
+
+    # 获取 start_date 之前的用户总数作为基数
+    base_users = await db.scalar(
+        select(func.count(User.id)).where(User.created_at < start_date)
+    ) or 0
+
+    daily: list[dict] = []
+    cumulative = base_users
+    for r in reg_result.all():
+        day_str = str(r.day)
+        cumulative += r.count
+        daily.append({
+            "date": day_str,
+            "new_subscriptions": sub_map.get(day_str, 0),
+            "total_users_that_day": cumulative,
+        })
+
+    return {"daily": daily, "period": period}
+
+
+# ---------------------------------------------------------------------------
 # 3. Token 消耗排行榜
 # ---------------------------------------------------------------------------
 
@@ -174,11 +246,23 @@ async def token_leaderboard(
     _admin: Admin = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ):
-    """返回 Token 消耗 Top N 用户。"""
+    """返回 Token 消耗 Top N 用户（含消耗积分）。"""
     total_expr = (
         func.coalesce(User.total_input_tokens, 0)
         + func.coalesce(User.total_output_tokens, 0)
     )
+
+    # 子查询：每用户消耗积分
+    consumed_sub = (
+        select(
+            CreditTransaction.user_id,
+            func.coalesce(func.sum(func.abs(CreditTransaction.amount)), 0).label("consumed"),
+        )
+        .where(CreditTransaction.amount < 0)
+        .group_by(CreditTransaction.user_id)
+        .subquery()
+    )
+
     result = await db.execute(
         select(
             User.id,
@@ -188,7 +272,9 @@ async def token_leaderboard(
             User.total_output_tokens,
             total_expr.label("total_tokens"),
             User.credits,
+            func.coalesce(consumed_sub.c.consumed, 0).label("credits_consumed"),
         )
+        .outerjoin(consumed_sub, User.id == consumed_sub.c.user_id)
         .order_by(desc(total_expr))
         .limit(limit)
     )
@@ -203,6 +289,7 @@ async def token_leaderboard(
             "output_tokens": r.total_output_tokens or 0,
             "total_tokens": r.total_tokens or 0,
             "credits": round(float(r.credits or 0), 2),
+            "credits_consumed": round(float(r.credits_consumed or 0), 2),
         }
         for idx, r in enumerate(rows)
     ]
@@ -383,4 +470,74 @@ async def content_stats(
             "error_rate": round(tool_errors / tool_total * 100, 2) if tool_total else 0,
             "avg_duration_ms": round(tool_avg_ms, 1) if tool_avg_ms else None,
         },
+    }
+
+
+# ---------------------------------------------------------------------------
+# 6. 运营指标（PUR / 留存率 / MRR / 退订率）
+# ---------------------------------------------------------------------------
+
+@router.get("/operational-metrics")
+async def operational_metrics(
+    _admin: Admin = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    """返回核心运营指标。"""
+    now = datetime.now(timezone.utc)
+    seven_days_ago = now - timedelta(days=7)
+    thirty_days_ago = now - timedelta(days=30)
+
+    total_users = await db.scalar(select(func.count(User.id))) or 0
+    paid_users = await db.scalar(
+        select(func.count(User.id)).where(User.subscription_status == "active")
+    ) or 0
+
+    # PUR — 付费用户占比
+    pur = round(paid_users / total_users * 100, 2) if total_users else 0
+
+    # 留存率 — 7天内登录用户中，30天前也登录过的比例
+    recent_active = await db.scalar(
+        select(func.count(User.id)).where(User.last_login_at >= seven_days_ago)
+    ) or 0
+    retained = await db.scalar(
+        select(func.count(User.id)).where(
+            and_(
+                User.last_login_at >= seven_days_ago,
+                User.created_at < seven_days_ago,
+            )
+        )
+    ) or 0
+    retention_rate = round(retained / recent_active * 100, 2) if recent_active else 0
+
+    # MRR — 月经常性收入
+    mrr_result = await db.execute(
+        select(
+            SubscriptionPlan.price_usd,
+            SubscriptionPlan.billing_period,
+            func.count(User.id).label("cnt"),
+        )
+        .join(User, and_(
+            User.subscription_plan_id == SubscriptionPlan.id,
+            User.subscription_status == "active",
+        ))
+        .group_by(SubscriptionPlan.id, SubscriptionPlan.price_usd, SubscriptionPlan.billing_period)
+    )
+    mrr = 0.0
+    for r in mrr_result.all():
+        monthly_price = r.price_usd / 12 if r.billing_period == "yearly" else r.price_usd
+        mrr += monthly_price * r.cnt
+    mrr = round(mrr, 2)
+
+    # 退订率 — expired / (expired + active)
+    expired_users = await db.scalar(
+        select(func.count(User.id)).where(User.subscription_status == "expired")
+    ) or 0
+    churn_base = expired_users + paid_users
+    churn_rate = round(expired_users / churn_base * 100, 2) if churn_base else 0
+
+    return {
+        "pur": pur,
+        "retention_rate": retention_rate,
+        "mrr": mrr,
+        "churn_rate": churn_rate,
     }

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -140,6 +140,10 @@ async def refresh(
             detail="User not found or disabled",
         )
 
+    # 刷新 token 时也更新活跃时间，确保已登录用户被统计为活跃
+    user.last_login_at = datetime.now(timezone.utc)
+    await db.commit()
+
     access_token = create_access_token(user.id, user.role)
     return AccessTokenResponse(
         access_token=access_token,


### PR DESCRIPTION
- 仪表盘中移除旧的统计卡，包括故事、资产、视频任务和积分消耗指标
- 新增今日活跃用户、今日营收及总营收统计卡，调整图标与配色
- 统一注册趋势、活跃趋势、订阅转化三个趋势图的周期选择器实现与样式
- Token排行榜增加积分列，调整布局及行高，提高展示信息完整性
- 用业务指标替代旧订阅分析与内容统计组件，展示付费用户占比、活跃留存率、MRR与退订率
- 优化Agents页面搜索框布局，提升用户体验
- 代理创建页调整布局，移除重复视图标题文字
- LLM提供商Schema强化api_key字段校验，必填且不得为空
- 移除ProviderForm组件的全部代码，准备重构或重写该组件