### PR TITLE
feat(canvas): 支持虚拟人像标签并优化视频生成面板交互

### DIFF
--- a/frontend/src/components/canvas/RefTagInput.tsx
+++ b/frontend/src/components/canvas/RefTagInput.tsx
@@ -16,10 +16,11 @@ export interface RefImage {
   name: string;
   refType: RefType; // 参考类型：image / video / audio
   previewUrl?: string; // 虚拟人像用：展示缩略图（preview_url），提交时用 url（asset://...）
+  sourceNodeId?: string; // 来源画布节点 ID，用于自动连线
 }
 
 export interface RefTagInputRef {
-  insertTag: (refIdx: number, name: string, refType?: RefType) => void;
+  insertTag: (refIdx: number, name: string, refType?: RefType, isVirtualHuman?: boolean) => void;
   focus: () => void;
 }
 
@@ -30,6 +31,8 @@ interface RefTagInputProps {
   placeholder?: string;
   disabled?: boolean;
   onSubmit?: () => void;
+  /** Override max-height for the editor (e.g. when user drags resize handle) */
+  maxHeight?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -59,24 +62,40 @@ const TAG_COLORS: Record<RefType, { bg: string; border: string; color: string }>
   audio: { bg: '#14b8a6 15%', border: '#14b8a6 25%', color: '#0d9488' },
 };
 
-function tagStyle(refType: RefType) {
-  const c = TAG_COLORS[refType];
+const VH_TAG_COLORS = { bg: '#a855f7 15%', border: '#a855f7 25%', color: '#9333ea' };
+
+function tagStyle(refType: RefType, isVirtualHuman = false) {
+  const c = isVirtualHuman ? VH_TAG_COLORS : TAG_COLORS[refType];
   return [
     'display:inline-flex', 'align-items:center', 'gap:3px',
     'padding:0 6px', 'margin:0 1px', 'border-radius:4px',
+    'position:relative',
     `background:color-mix(in srgb, ${c.bg}, transparent)`,
     `color:${c.color}`,
     'font-size:11px', 'font-weight:500', 'vertical-align:baseline',
-    'cursor:grab', 'user-select:none', 'white-space:nowrap',
+    'cursor:grab', 'user-select:all', 'white-space:nowrap',
     `border:1px solid color-mix(in srgb, ${c.border}, transparent)`,
     'line-height:1.6',
   ].join(';');
 }
 
-function tagHtml(idx: number, name: string, refType: RefType = 'image') {
-  const svg = TYPE_SVG[refType];
-  const style = tagStyle(refType);
-  return `<span contenteditable="false" draggable="true" data-ref-idx="${idx}" data-ref-type="${refType}" style="${style}">${svg}<span style="max-width:72px;overflow:hidden;text-overflow:ellipsis">${esc(name)}</span></span>`;
+const VH_SVG =
+  '<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink:0"><circle cx="12" cy="8" r="5"/><path d="M20 21a8 8 0 0 0-16 0"/></svg>';
+
+function tagHtml(idx: number, name: string, refType: RefType = 'image', isVirtualHuman = false) {
+  const svg = isVirtualHuman ? VH_SVG : TYPE_SVG[refType];
+  const style = tagStyle(refType, isVirtualHuman);
+  const delBtnStyle = [
+    'position:absolute', 'top:-5px', 'right:-5px',
+    'display:flex', 'align-items:center', 'justify-content:center',
+    'width:12px', 'height:12px', 'border-radius:50%',
+    'background:var(--background)', 'border:1px solid var(--border)',
+    'cursor:pointer', 'flex-shrink:0', 'padding:0',
+    'color:var(--muted-foreground)', 'font-size:9px', 'line-height:1',
+    'opacity:0', 'transition:opacity 0.15s', 'pointer-events:auto',
+    'box-shadow:0 1px 2px rgba(0,0,0,0.1)',
+  ].join(';');
+  return `<span contenteditable="false" draggable="true" data-ref-idx="${idx}" data-ref-type="${refType}"${isVirtualHuman ? ' data-vh="1"' : ''} style="${style}" onmouseover="this.querySelector('[data-ref-delete]').style.opacity='1'" onmouseout="this.querySelector('[data-ref-delete]').style.opacity='0'">${svg}<span style="max-width:72px;overflow:hidden;text-overflow:ellipsis">${esc(name)}</span><span data-ref-delete="1" style="${delBtnStyle}">×</span></span>`;
 }
 
 /** Compute type-specific index for a ref at array position `pos` */
@@ -102,7 +121,8 @@ function toHtml(text: string, refs: RefImage[]) {
     const idx = parseInt(n);
     const list = byType[refType];
     const r = list?.[idx - 1];
-    return r ? tagHtml(idx, r.name, refType) : `&lt;${prefix}_${n}&gt;`;
+    const isVh = r ? r.url.startsWith('asset://') : false;
+    return r ? tagHtml(idx, r.name, refType, isVh) : `&lt;${prefix}_${n}&gt;`;
   });
   return html;
 }
@@ -142,21 +162,24 @@ function insertNodeAtCursor(el: HTMLElement, node: Node) {
 // ---------------------------------------------------------------------------
 
 const RefTagInput = React.forwardRef<RefTagInputRef, RefTagInputProps>(
-  function RefTagInput({ value, onChange, referenceImages, placeholder, disabled, onSubmit }, ref) {
+  function RefTagInput({ value, onChange, referenceImages, placeholder, disabled, onSubmit, maxHeight }, ref) {
     const { t } = useTranslation();
     const edRef = useRef<HTMLDivElement>(null);
     const lastVal = useRef(value);
     const [atMenu, setAtMenu] = useState(false);
     const menuRef = useRef<HTMLDivElement>(null);
 
+    // Default max-height: 12 lines (~252px). Can be overridden via prop.
+    const effectiveMaxH = maxHeight ?? 252;
+
     // -- expose API --
     useImperativeHandle(ref, () => ({
-      insertTag(idx: number, name: string, refType: RefType = 'image') {
+      insertTag(idx: number, name: string, refType: RefType = 'image', isVirtualHuman = false) {
         const el = edRef.current;
         el || (void 0);
         if (!el) return;
         const tmp = document.createElement('div');
-        tmp.innerHTML = tagHtml(idx, name, refType);
+        tmp.innerHTML = tagHtml(idx, name, refType, isVirtualHuman);
         insertNodeAtCursor(el, tmp.firstElementChild!);
         const txt = serialize(el);
         lastVal.current = txt;
@@ -214,60 +237,149 @@ const RefTagInput = React.forwardRef<RefTagInputRef, RefTagInputProps>(
       document.execCommand('insertText', false, txt);
     };
 
+    // -- click delegation: delete button on tags --
+    const handleClick = useCallback((e: React.MouseEvent) => {
+      const delBtn = (e.target as HTMLElement).closest?.('[data-ref-delete]');
+      delBtn && (() => {
+        e.preventDefault();
+        e.stopPropagation();
+        const tagSpan = delBtn.closest('[data-ref-idx]') as HTMLElement | null;
+        const el = edRef.current;
+        tagSpan && el && (() => {
+          // Remove the tag span from DOM
+          tagSpan.remove();
+          // Re-serialize and sync
+          const txt = serialize(el);
+          lastVal.current = txt;
+          onChange(txt);
+        })();
+      })();
+    }, [onChange]);
+
     // -- tag drag & drop within editor --
+    // 使用系统原生 caret 显示拖放位置，不再渲染自定义指示条
     const dragIdxRef = useRef<number | null>(null);
     const dragTypeRef = useRef<RefType>('image');
 
+    // 根据鼠标坐标解析出一个 collapsed Range；避免副作用，仅计算
+    const rangeFromPoint = useCallback((x: number, y: number): Range | null => {
+      const caretPos = document.caretPositionFromPoint?.(x, y);
+      const viaPos = caretPos
+        ? (() => { const r = document.createRange(); r.setStart(caretPos.offsetNode, caretPos.offset); r.collapse(true); return r; })()
+        : null;
+      const viaRange = !viaPos && (document as any).caretRangeFromPoint
+        ? ((document as any).caretRangeFromPoint(x, y) as Range | null)
+        : null;
+      return viaPos ?? viaRange ?? null;
+    }, []);
+
     const handleDragStart = useCallback((e: React.DragEvent) => {
       const target = (e.target as HTMLElement).closest?.('[data-ref-idx]') as HTMLElement | null;
-      target && (dragIdxRef.current = Number(target.getAttribute('data-ref-idx')), dragTypeRef.current = (target.getAttribute('data-ref-type') || 'image') as RefType);
-      !target && e.preventDefault();
+      !target && (e.preventDefault(), void 0);
+      target && (() => {
+        dragIdxRef.current = Number(target.getAttribute('data-ref-idx'));
+        dragTypeRef.current = (target.getAttribute('data-ref-type') || 'image') as RefType;
+        // 必须写入 dataTransfer，否则 Firefox 等浏览器无法触发 drop
+        e.dataTransfer.setData('text/plain', '');
+        e.dataTransfer.effectAllowed = 'move';
+      })();
     }, []);
 
     const handleDragOver = useCallback((e: React.DragEvent) => {
-      dragIdxRef.current !== null && e.preventDefault();
-    }, []);
+      dragIdxRef.current !== null && (() => {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'move';
+        const el = edRef.current;
+        // 在 dragover 时把真实 selection 同步到落点，让浏览器显示原生 caret
+        el && (() => {
+          const range = rangeFromPoint(e.clientX, e.clientY);
+          range && el.contains(range.startContainer) && (() => {
+            const sel = window.getSelection();
+            sel && (sel.removeAllRanges(), sel.addRange(range));
+          })();
+        })();
+      })();
+    }, [rangeFromPoint]);
 
     const handleDrop = useCallback((e: React.DragEvent) => {
       const idx = dragIdxRef.current;
       const refType = dragTypeRef.current;
       dragIdxRef.current = null;
       const el = edRef.current;
-      (idx === null || !el) && (void 0);
-      idx !== null && el && (() => {
+      (idx !== null && el) && (() => {
         e.preventDefault();
-        // Remove the original tag span from DOM
-        const orig = el.querySelector(`[data-ref-idx="${idx}"][data-ref-type="${refType}"]`) || el.querySelector(`[data-ref-idx="${idx}"]`);
-        orig?.remove();
 
-        // Place caret at drop point
-        const caretPos = document.caretPositionFromPoint?.(e.clientX, e.clientY);
-        const caretRange = (document as any).caretRangeFromPoint?.(e.clientX, e.clientY) as Range | null;
+        // 1) 必须先基于当前 DOM 计算落点 Range，在原标签被移除前拿到稳定坐标
+        const dropRange = rangeFromPoint(e.clientX, e.clientY);
 
-        const sel = window.getSelection();
-        const range = caretPos
-          ? (() => { const r = document.createRange(); r.setStart(caretPos.offsetNode, caretPos.offset); r.collapse(true); return r; })()
-          : caretRange;
+        // 2) 定位原标签
+        const orig = (el.querySelector(`[data-ref-idx="${idx}"][data-ref-type="${refType}"]`)
+          || el.querySelector(`[data-ref-idx="${idx}"]`)) as HTMLElement | null;
 
-        range && sel && el.contains(range.startContainer)
-          ? (sel.removeAllRanges(), sel.addRange(range))
-          : (void 0);
-
-        // Re-create and insert tag at new position — find ref by type+idx
-        const byType = referenceImages.filter(r => r.refType === refType);
-        const ref = byType[idx - 1];
-        ref && (() => {
-          const tmp = document.createElement('div');
-          tmp.innerHTML = tagHtml(idx, ref.name, refType);
-          insertNodeAtCursor(el, tmp.firstElementChild!);
+        // 3) 如果落点就在原标签内部，视为原地拖放，不做任何处理
+        const dropInsideOrig = !!(dropRange && orig && orig.contains(dropRange.startContainer));
+        dropInsideOrig && (() => {
+          const txt = serialize(el);
+          lastVal.current = txt;
+          onChange(txt);
         })();
 
-        // Serialize and sync
-        const txt = serialize(el);
-        lastVal.current = txt;
-        onChange(txt);
+        !dropInsideOrig && (() => {
+          // 4) 捕获 dropRange 指向的文本节点与偏移（后续 DOM 变动可能影响 Range 引用）
+          const anchorNode = dropRange?.startContainer ?? null;
+          const anchorOffset = dropRange?.startOffset ?? 0;
+          const anchorValid = !!(anchorNode && el.contains(anchorNode) && (!orig || !orig.contains(anchorNode)));
+
+          // 5) 移除原标签
+          orig?.remove();
+
+          // 6) 将光标精确放置到落点（锚点节点在标签外部，不会因移除而失效）
+          const sel = window.getSelection();
+          anchorValid && sel && (() => {
+            const r = document.createRange();
+            // 防御：若 anchorNode 是文本节点，按字符偏移；否则按子节点偏移
+            const maxOff = anchorNode!.nodeType === Node.TEXT_NODE
+              ? (anchorNode!.textContent?.length ?? 0)
+              : anchorNode!.childNodes.length;
+            r.setStart(anchorNode!, Math.min(anchorOffset, maxOff));
+            r.collapse(true);
+            sel.removeAllRanges();
+            sel.addRange(r);
+          })();
+
+          // 7) 光标定位失败则回退到末尾
+          !anchorValid && sel && (() => {
+            const r = document.createRange();
+            r.selectNodeContents(el);
+            r.collapse(false);
+            sel.removeAllRanges();
+            sel.addRange(r);
+          })();
+
+          // 8) 在当前光标位置插入新标签（insertNodeAtCursor 内部会把 caret 移到标签之后）
+          const byType = referenceImages.filter(r => r.refType === refType);
+          const ref = byType[idx! - 1];
+          ref && (() => {
+            const tmp = document.createElement('div');
+            const isVh = ref.url.startsWith('asset://');
+            tmp.innerHTML = tagHtml(idx!, ref.name, refType, isVh);
+            insertNodeAtCursor(el, tmp.firstElementChild!);
+          })();
+
+          const txt = serialize(el);
+          lastVal.current = txt;
+          onChange(txt);
+        })();
       })();
-    }, [referenceImages, onChange]);
+    }, [referenceImages, onChange, rangeFromPoint]);
+
+    const handleDragLeave = useCallback(() => {
+      // 交给浏览器原生 caret，无需额外处理
+    }, []);
+
+    const handleDragEnd = useCallback(() => {
+      dragIdxRef.current = null;
+    }, []);
 
     // -- @ select: remove '@', insert tag with type-specific index --
     const handleAtSelect = (arrayPos: number) => {
@@ -292,7 +404,8 @@ const RefTagInput = React.forwardRef<RefTagInputRef, RefTagInputProps>(
 
       // insert tag
       const tmp = document.createElement('div');
-      tmp.innerHTML = tagHtml(idx, r.name, refType);
+      const isVh = r.url.startsWith('asset://');
+      tmp.innerHTML = tagHtml(idx, r.name, refType, isVh);
       insertNodeAtCursor(el, tmp.firstElementChild!);
       handleInput();
       setAtMenu(false);
@@ -325,15 +438,19 @@ const RefTagInput = React.forwardRef<RefTagInputRef, RefTagInputProps>(
           onInput={handleInput}
           onKeyDown={handleKeyDown}
           onPaste={handlePaste}
+          onClick={handleClick}
           onDragStart={handleDragStart}
           onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDragEnd={handleDragEnd}
           onDrop={handleDrop}
           className={cn(
             'w-full bg-transparent border-0 outline-none text-sm text-foreground cursor-text',
-            'min-h-[44px] max-h-[400px] overflow-y-auto py-2.5 px-3 pb-1',
+            'overflow-y-auto py-2.5 px-3 pb-1',
             'focus:ring-0 focus:outline-none whitespace-pre-wrap break-words',
             disabled && 'opacity-50 pointer-events-none',
           )}
+          style={{ minHeight: '44px', maxHeight: `${effectiveMaxH}px` }}
           role="textbox"
           aria-multiline="true"
         />
@@ -352,6 +469,7 @@ const RefTagInput = React.forwardRef<RefTagInputRef, RefTagInputProps>(
               const prefix = TYPE_TAG_PREFIX[r.refType];
               const isAud = r.refType === 'audio';
               const isVid = r.refType === 'video';
+              const isVh = r.refType === 'image' && r.url.startsWith('asset://');
               return (
               <button
                 key={i}
@@ -367,6 +485,13 @@ const RefTagInput = React.forwardRef<RefTagInputRef, RefTagInputProps>(
                   <div className="h-6 w-6 shrink-0 rounded border border-border/30 bg-muted flex items-center justify-center">
                     <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-amber-400"><rect x="2" y="2" width="20" height="20" rx="2.18" ry="2.18"/><line x1="7" y1="2" x2="7" y2="22"/><line x1="17" y1="2" x2="17" y2="22"/></svg>
                   </div>
+                ) : isVh ? (
+                  <div className="h-6 w-6 shrink-0 relative">
+                    <img src={r.previewUrl || r.url} alt="" className="h-6 w-6 rounded object-cover border border-purple-400/40" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; (e.target as HTMLImageElement).nextElementSibling?.classList.remove('hidden'); }} />
+                    <div className="hidden h-6 w-6 rounded border border-purple-400/40 bg-muted flex items-center justify-center absolute inset-0">
+                      <UserRound className="w-3 h-3 text-purple-400" />
+                    </div>
+                  </div>
                 ) : (
                   <div className="h-6 w-6 shrink-0 relative">
                     <img src={r.previewUrl || r.url} alt="" className="h-6 w-6 rounded object-cover border border-border/30" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; (e.target as HTMLImageElement).nextElementSibling?.classList.remove('hidden'); }} />
@@ -378,7 +503,7 @@ const RefTagInput = React.forwardRef<RefTagInputRef, RefTagInputProps>(
                 <span className="font-medium truncate text-foreground">{r.name}</span>
                 <span className={cn(
                   'text-[10px] ml-auto whitespace-nowrap',
-                  isAud ? 'text-teal-500' : isVid ? 'text-amber-500' : 'text-muted-foreground',
+                  isAud ? 'text-teal-500' : isVid ? 'text-amber-500' : isVh ? 'text-purple-500' : 'text-muted-foreground',
                 )}>{`${prefix}_${tIdx}`}</span>
               </button>
               );

--- a/frontend/src/components/canvas/VideoGeneratePanel.tsx
+++ b/frontend/src/components/canvas/VideoGeneratePanel.tsx
@@ -42,6 +42,31 @@ const PROVIDER_ICONS: Record<string, string> = {
 };
 
 // ---------------------------------------------------------------------------
+// Aspect ratio SVG icon — proportional rectangle
+// ---------------------------------------------------------------------------
+
+function AspectRatioIcon({ ratio, className }: { ratio: string; className?: string }) {
+  // Parse ratio like '16:9' → w=16, h=9
+  const [w, h] = ratio.split(':').map(Number);
+  const isAuto = !w || !h;
+  const maxDim = 14;
+  const scale = maxDim / Math.max(w || 1, h || 1);
+  const rw = isAuto ? 10 : Math.round(w * scale);
+  const rh = isAuto ? 10 : Math.round(h * scale);
+  const ox = (16 - rw) / 2;
+  const oy = (16 - rh) / 2;
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" className={className}>
+      {isAuto ? (
+        <text x="8" y="11" textAnchor="middle" fontSize="9" fontWeight="600" fill="currentColor">A</text>
+      ) : (
+        <rect x={ox} y={oy} width={rw} height={rh} rx="1.5" stroke="currentColor" strokeWidth="1.5" fill="none" />
+      )}
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Props — parent (VideoNode) owns task state
 // ---------------------------------------------------------------------------
 
@@ -60,6 +85,12 @@ export interface VideoGeneratePanelProps {
   canvasNodes?: CanvasNode[];
   /** Pre-fill form from history entry (e.g. drag from history) */
   initialConfig?: Partial<VideoGenHistoryEntry> | null;
+  /** Current video node ID — used for auto-linking source nodes */
+  nodeId?: string;
+  /** Called when a source node is selected as material — parent should create edge */
+  onLinkNode?: (sourceNodeId: string) => void;
+  /** Called when a source node material is removed — parent should remove edge */
+  onUnlinkNode?: (sourceNodeId: string) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -172,6 +203,9 @@ export default function VideoGeneratePanel({
   onApplyToNextNode,
   canvasNodes = [],
   initialConfig,
+  nodeId,
+  onLinkNode,
+  onUnlinkNode,
 }: VideoGeneratePanelProps) {
   const { t } = useTranslation();
 
@@ -191,6 +225,12 @@ export default function VideoGeneratePanel({
 
   // Config state
   const [videoMode, setVideoMode] = useState('text_to_video');
+  const [showModeDropdown, setShowModeDropdown] = useState(false);
+  const modeDropdownRef = useRef<HTMLDivElement>(null);
+  const [showQualityDropdown, setShowQualityDropdown] = useState(false);
+  const qualityDropdownRef = useRef<HTMLDivElement>(null);
+  const [showAspectDropdown, setShowAspectDropdown] = useState(false);
+  const aspectDropdownRef = useRef<HTMLDivElement>(null);
   const [imageUrl, setImageUrl] = useState('');
   const [lastFrameImageUrl, setLastFrameImageUrl] = useState('');
   const [referenceImages, setReferenceImages] = useState<RefImage[]>([]);
@@ -200,6 +240,31 @@ export default function VideoGeneratePanel({
   const [aspectRatio, setAspectRatio] = useState('16:9');
   const [promptOptimizer, setPromptOptimizer] = useState(true);
   const [fastPretreatment, setFastPretreatment] = useState(false);
+
+  // Track source node IDs for single-attachment slots (imageUrl / lastFrame / extensionVideo)
+  const imageNodeIdRef = useRef<string | null>(null);
+  const lastFrameNodeIdRef = useRef<string | null>(null);
+  const extensionVideoNodeIdRef = useRef<string | null>(null);
+
+  // Link / unlink helpers
+  const linkNode = useCallback((sourceId: string) => {
+    onLinkNode?.(sourceId);
+  }, [onLinkNode]);
+
+  const unlinkNode = useCallback((sourceId: string | null) => {
+    sourceId && onUnlinkNode?.(sourceId);
+  }, [onUnlinkNode]);
+
+  // Unlink all currently linked nodes (used on mode switch / model change)
+  const unlinkAll = useCallback(() => {
+    unlinkNode(imageNodeIdRef.current);
+    unlinkNode(lastFrameNodeIdRef.current);
+    unlinkNode(extensionVideoNodeIdRef.current);
+    referenceImages.forEach(r => r.sourceNodeId && unlinkNode(r.sourceNodeId));
+    imageNodeIdRef.current = null;
+    lastFrameNodeIdRef.current = null;
+    extensionVideoNodeIdRef.current = null;
+  }, [unlinkNode, referenceImages]);
 
   // Derived
   const selectedModel = models.find((m) => `${m.provider_id}::${m.model_name}` === selectedModelKey) || null;
@@ -220,6 +285,7 @@ export default function VideoGeneratePanel({
 
   // Clear attachments when switching modes
   useEffect(() => {
+    unlinkAll();
     videoMode === 'text_to_video' && (setImageUrl(''), setLastFrameImageUrl(''), setReferenceImages([]), setExtensionVideoUrl(''));
     videoMode === 'image_to_video' && (setReferenceImages([]), setExtensionVideoUrl(''));
     videoMode === 'reference_images' && (setImageUrl(''), setLastFrameImageUrl(''), setExtensionVideoUrl(''));
@@ -234,6 +300,33 @@ export default function VideoGeneratePanel({
     showConfig && document.addEventListener('mousedown', handle);
     return () => document.removeEventListener('mousedown', handle);
   }, [showConfig]);
+
+  // Click outside closes mode dropdown
+  useEffect(() => {
+    const handle = (e: MouseEvent) => {
+      modeDropdownRef.current && !modeDropdownRef.current.contains(e.target as HTMLElement) && setShowModeDropdown(false);
+    };
+    showModeDropdown && document.addEventListener('mousedown', handle);
+    return () => document.removeEventListener('mousedown', handle);
+  }, [showModeDropdown]);
+
+  // Click outside closes quality dropdown
+  useEffect(() => {
+    const handle = (e: MouseEvent) => {
+      qualityDropdownRef.current && !qualityDropdownRef.current.contains(e.target as HTMLElement) && setShowQualityDropdown(false);
+    };
+    showQualityDropdown && document.addEventListener('mousedown', handle);
+    return () => document.removeEventListener('mousedown', handle);
+  }, [showQualityDropdown]);
+
+  // Click outside closes aspect ratio dropdown
+  useEffect(() => {
+    const handle = (e: MouseEvent) => {
+      aspectDropdownRef.current && !aspectDropdownRef.current.contains(e.target as HTMLElement) && setShowAspectDropdown(false);
+    };
+    showAspectDropdown && document.addEventListener('mousedown', handle);
+    return () => document.removeEventListener('mousedown', handle);
+  }, [showAspectDropdown]);
 
   // Apply initialConfig once when models are available
   const appliedInitRef = useRef(false);
@@ -345,7 +438,7 @@ export default function VideoGeneratePanel({
       }]);
       // Auto-switch to reference_images mode when adding a virtual human in image_to_video mode
       videoMode === 'image_to_video' && setVideoMode('reference_images');
-      inputRef.current?.insertTag(imageRefCount + 1, preset.name);
+      inputRef.current?.insertTag(imageRefCount + 1, preset.name, 'image', true);
       imageRefCount + 1 >= maxRefImages && setShowVhPicker(false);
     })();
   };
@@ -357,6 +450,7 @@ export default function VideoGeneratePanel({
   const TAG_PREFIX_MAP: Record<RefType, string> = { image: 'IMAGE', video: 'VIDEO', audio: 'AUDIO' };
   const handleRemoveRefImage = (removeIdx: number) => {
     const removedRef = referenceImages[removeIdx];
+    removedRef.sourceNodeId && unlinkNode(removedRef.sourceNodeId);
     const newRefs = referenceImages.filter((_, i) => i !== removeIdx);
     setReferenceImages(newRefs);
     const removedType = removedRef.refType;
@@ -378,15 +472,15 @@ export default function VideoGeneratePanel({
     // single_image: set imageUrl
     pickerMode === 'single_image' && (() => {
       const url = getImageNodeUrl(node);
-      url && setImageUrl(url);
+      url && (unlinkNode(imageNodeIdRef.current), setImageUrl(url), imageNodeIdRef.current = node.id, linkNode(node.id));
       setShowNodePicker(false);
     })();
     // first_last_frame: fill first frame first, then last frame
     pickerMode === 'first_last_frame' && (() => {
       const url = getImageNodeUrl(node);
       url && (!imageUrl
-        ? setImageUrl(url)
-        : (setLastFrameImageUrl(url), setShowNodePicker(false)));
+        ? (setImageUrl(url), imageNodeIdRef.current = node.id, linkNode(node.id))
+        : (setLastFrameImageUrl(url), lastFrameNodeIdRef.current = node.id, linkNode(node.id), setShowNodePicker(false)));
     })();
     // multi_image: append to referenceImages — supports image/video/audio node types
     pickerMode === 'multi_image' && (() => {
@@ -405,7 +499,8 @@ export default function VideoGeneratePanel({
       const url = urlMap[nt]?.() ?? getImageNodeUrl(node);
       const [count, max] = limitMap[nt] ?? [imageRefCount, maxRefImages];
       url && count < max && (() => {
-        setReferenceImages((prev) => [...prev, { url, name: nodeName, refType }]);
+        setReferenceImages((prev) => [...prev, { url, name: nodeName, refType, sourceNodeId: node.id }]);
+        linkNode(node.id);
         // Insert type-specific tag: <IMAGE_N>, <VIDEO_N>, or <AUDIO_N>
         inputRef.current?.insertTag(count + 1, nodeName, refType);
       })();
@@ -414,7 +509,7 @@ export default function VideoGeneratePanel({
     // video: set extensionVideoUrl
     pickerMode === 'video' && (() => {
       const url = getVideoNodeUrl(node);
-      url && setExtensionVideoUrl(url);
+      url && (unlinkNode(extensionVideoNodeIdRef.current), setExtensionVideoUrl(url), extensionVideoNodeIdRef.current = node.id, linkNode(node.id));
       setShowNodePicker(false);
     })();
   };
@@ -422,6 +517,7 @@ export default function VideoGeneratePanel({
   const canSubmit = !!selectedModel && prompt.trim().length > 0 && !isSubmitting && !taskActive;
 
   const handleModelChange = (key: string) => {
+    unlinkAll();
     setSelectedModelKey(key);
     setVideoMode('text_to_video');
     setDuration(6);
@@ -477,18 +573,61 @@ export default function VideoGeneratePanel({
     return () => document.removeEventListener('mousedown', handle);
   }, [showModelDropdown]);
 
-  // Group models by provider for the dropdown
-  const groupedModels = useMemo(() => {
-    const groups: { providerName: string; providerId: string; providerType: string; models: typeof models }[] = [];
+  // Resize handle for input container
+  const [inputMaxHeight, setInputMaxHeight] = useState<number | null>(null);
+  const resizingRef = useRef(false);
+  const resizeStartY = useRef(0);
+  const resizeStartH = useRef(0);
+  const inputContainerRef = useRef<HTMLDivElement>(null);
+
+  const handleResizePointerDown = useCallback((e: React.PointerEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    resizingRef.current = true;
+    resizeStartY.current = e.clientY;
+    const edEl = inputContainerRef.current?.querySelector('[role="textbox"]') as HTMLElement | null;
+    resizeStartH.current = edEl?.offsetHeight ?? 44;
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+  }, []);
+
+  const handleResizePointerMove = useCallback((e: React.PointerEvent) => {
+    resizingRef.current && (() => {
+      const delta = e.clientY - resizeStartY.current;
+      const newH = Math.max(44, Math.min(400, resizeStartH.current + delta));
+      setInputMaxHeight(newH);
+    })();
+  }, []);
+
+  const handleResizePointerUp = useCallback((e: React.PointerEvent) => {
+    resizingRef.current = false;
+    (e.target as HTMLElement).releasePointerCapture(e.pointerId);
+  }, []);
+
+  // Flatten models with provider info — logo shown per-item, no grouping headers
+  const flatModels = useMemo(() => {
+    const list: { key: string; model: typeof models[number]; providerType: string; providerName: string }[] = [];
+    const covered = new Set<string>();
     for (const p of providers) {
-      const pModels = models.filter(m => m.provider_id === p.id);
-      pModels.length > 0 && groups.push({ providerName: p.name, providerId: p.id, providerType: p.provider_type, models: pModels });
+      covered.add(p.id);
+      for (const m of models.filter(mm => mm.provider_id === p.id)) {
+        list.push({
+          key: `${m.provider_id}::${m.model_name}`,
+          model: m,
+          providerType: p.provider_type,
+          providerName: p.name,
+        });
+      }
     }
     // Include any models not matched to a provider
-    const coveredIds = new Set(providers.map(p => p.id));
-    const orphans = models.filter(m => !coveredIds.has(m.provider_id));
-    orphans.length > 0 && groups.push({ providerName: 'Other', providerId: '__other__', providerType: '', models: orphans });
-    return groups;
+    for (const m of models.filter(mm => !covered.has(mm.provider_id))) {
+      list.push({
+        key: `${m.provider_id}::${m.model_name}`,
+        model: m,
+        providerType: '',
+        providerName: 'Other',
+      });
+    }
+    return list;
   }, [models, providers]);
 
   const handleModelSelect = useCallback((key: string) => {
@@ -498,9 +637,8 @@ export default function VideoGeneratePanel({
 
   // Resolve current provider logo for the trigger button
   const selectedProviderType = useMemo(() => {
-    const group = groupedModels.find(g => g.models.some(m => `${m.provider_id}::${m.model_name}` === selectedModelKey));
-    return group?.providerType || '';
-  }, [groupedModels, selectedModelKey]);
+    return flatModels.find(f => f.key === selectedModelKey)?.providerType || '';
+  }, [flatModels, selectedModelKey]);
   const selectedProviderLogo = PROVIDER_ICONS[selectedProviderType] || '';
 
 
@@ -508,14 +646,14 @@ export default function VideoGeneratePanel({
   return (
     <div className="w-full space-y-1.5" onClick={(e) => e.stopPropagation()} onPointerDown={(e) => e.stopPropagation()}>
       {/* Main input container — MessageInput style */}
-      <div className="bg-muted/50 rounded-xl border border-border/50 focus-within:border-primary/30 focus-within:ring-1 focus-within:ring-primary/20 transition-all duration-200 flex flex-col">
+      <div ref={inputContainerRef} className="bg-muted/50 rounded-xl border border-border/50 focus-within:border-primary/30 focus-within:ring-1 focus-within:ring-primary/20 transition-all duration-200 flex flex-col relative">
         {/* Attachment previews — image(s) or video */}
         {/* Single image (non-first_last_frame modes) */}
         {pickerMode === 'single_image' && imageUrl && (
           <div className="px-3 pt-2.5 pb-0">
             <div className="relative inline-block group/imgpreview">
-              <img src={imageUrl} alt="Reference" className="h-16 w-16 rounded-lg object-cover border border-border/50" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
-              <button type="button" onClick={() => setImageUrl('')} className="absolute -top-1.5 -right-1.5 h-4 w-4 rounded-full bg-background border border-border/50 shadow-sm flex items-center justify-center opacity-0 group-hover/imgpreview:opacity-100 transition-opacity hover:bg-destructive hover:text-destructive-foreground">
+              <img src={imageUrl} alt="Reference" draggable={false} className="h-16 w-16 rounded-lg object-cover border border-border/50" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
+              <button type="button" onClick={() => { unlinkNode(imageNodeIdRef.current); imageNodeIdRef.current = null; setImageUrl(''); }} className="absolute -top-1.5 -right-1.5 h-4 w-4 rounded-full bg-background border border-border/50 shadow-sm flex items-center justify-center opacity-0 group-hover/imgpreview:opacity-100 transition-opacity hover:bg-destructive hover:text-destructive-foreground">
                 <X className="h-2.5 w-2.5" />
               </button>
               <div className="absolute bottom-0.5 left-0.5 px-1 py-0.5 rounded text-[8px] font-medium bg-black/60 text-white backdrop-blur-sm">
@@ -530,8 +668,8 @@ export default function VideoGeneratePanel({
           <div className="px-3 pt-2.5 pb-0 flex items-center gap-1.5">
             {/* First frame */}
             <div className="relative inline-block group/firstframe">
-              <img src={imageUrl} alt="First frame" className="h-16 w-16 rounded-lg object-cover border border-border/50" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
-              <button type="button" onClick={() => { setImageUrl(''); setLastFrameImageUrl(''); }} className="absolute -top-1.5 -right-1.5 h-4 w-4 rounded-full bg-background border border-border/50 shadow-sm flex items-center justify-center opacity-0 group-hover/firstframe:opacity-100 transition-opacity hover:bg-destructive hover:text-destructive-foreground">
+              <img src={imageUrl} alt="First frame" draggable={false} className="h-16 w-16 rounded-lg object-cover border border-border/50" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
+              <button type="button" onClick={() => { unlinkNode(imageNodeIdRef.current); unlinkNode(lastFrameNodeIdRef.current); imageNodeIdRef.current = null; lastFrameNodeIdRef.current = null; setImageUrl(''); setLastFrameImageUrl(''); }} className="absolute -top-1.5 -right-1.5 h-4 w-4 rounded-full bg-background border border-border/50 shadow-sm flex items-center justify-center opacity-0 group-hover/firstframe:opacity-100 transition-opacity hover:bg-destructive hover:text-destructive-foreground">
                 <X className="h-2.5 w-2.5" />
               </button>
               <div className="absolute bottom-0.5 left-0.5 px-1 py-0.5 rounded text-[8px] font-semibold bg-emerald-600/80 text-white backdrop-blur-sm">
@@ -543,8 +681,8 @@ export default function VideoGeneratePanel({
             {/* Last frame or placeholder */}
             {lastFrameImageUrl ? (
               <div className="relative inline-block group/lastframe">
-                <img src={lastFrameImageUrl} alt="Last frame" className="h-16 w-16 rounded-lg object-cover border border-border/50" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
-                <button type="button" onClick={() => setLastFrameImageUrl('')} className="absolute -top-1.5 -right-1.5 h-4 w-4 rounded-full bg-background border border-border/50 shadow-sm flex items-center justify-center opacity-0 group-hover/lastframe:opacity-100 transition-opacity hover:bg-destructive hover:text-destructive-foreground">
+                <img src={lastFrameImageUrl} alt="Last frame" draggable={false} className="h-16 w-16 rounded-lg object-cover border border-border/50" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
+                <button type="button" onClick={() => { unlinkNode(lastFrameNodeIdRef.current); lastFrameNodeIdRef.current = null; setLastFrameImageUrl(''); }} className="absolute -top-1.5 -right-1.5 h-4 w-4 rounded-full bg-background border border-border/50 shadow-sm flex items-center justify-center opacity-0 group-hover/lastframe:opacity-100 transition-opacity hover:bg-destructive hover:text-destructive-foreground">
                   <X className="h-2.5 w-2.5" />
                 </button>
                 <div className="absolute bottom-0.5 left-0.5 px-1 py-0.5 rounded text-[8px] font-semibold bg-amber-600/80 text-white backdrop-blur-sm">
@@ -564,31 +702,56 @@ export default function VideoGeneratePanel({
           </div>
         )}
 
+        {/* Empty first+last frame placeholders when no image loaded yet */}
+        {pickerMode === 'first_last_frame' && !imageUrl && (
+          <div className="px-3 pt-2.5 pb-0 flex items-center gap-1.5">
+            <button
+              type="button"
+              onClick={() => setShowNodePicker(true)}
+              className="h-16 w-16 rounded-lg border-2 border-dashed border-border/60 hover:border-emerald-500/40 flex flex-col items-center justify-center gap-0.5 transition-colors cursor-pointer group/addfirst"
+            >
+              <ImageIcon className="w-3.5 h-3.5 text-muted-foreground/50 group-hover/addfirst:text-emerald-500/60 transition-colors" />
+              <span className="text-[8px] text-muted-foreground/60 group-hover/addfirst:text-emerald-500/60 transition-colors">{t('canvas.node.video.firstFrame')}</span>
+            </button>
+            <ArrowRight className="w-3.5 h-3.5 text-muted-foreground/30 shrink-0" />
+            <button
+              type="button"
+              onClick={() => setShowNodePicker(true)}
+              disabled
+              className="h-16 w-16 rounded-lg border-2 border-dashed border-border/40 flex flex-col items-center justify-center gap-0.5 opacity-40 cursor-not-allowed"
+            >
+              <ImageIcon className="w-3.5 h-3.5 text-muted-foreground/50" />
+              <span className="text-[8px] text-muted-foreground/60">{t('canvas.node.video.lastFrame')}</span>
+            </button>
+          </div>
+        )}
+
         {pickerMode === 'multi_image' && referenceImages.length > 0 && (
           <div className="px-3 pt-2.5 pb-0 flex gap-1.5 flex-wrap">
             {referenceImages.map((ref, idx) => {
               const isImg = ref.refType === 'image';
               const isVid = ref.refType === 'video';
               const isAud = ref.refType === 'audio';
+              const isVirtualHuman = isImg && ref.url.startsWith('asset://');
               // Image-only index for <IMAGE_N> tag
               const imgIdx = isImg ? referenceImages.slice(0, idx).filter(r => r.refType === 'image').length + 1 : 0;
-              const tagColor = isVid ? 'text-amber-300' : isAud ? 'text-teal-300' : 'text-blue-300';
+              const tagColor = isVid ? 'text-amber-300' : isAud ? 'text-teal-300' : isVirtualHuman ? 'text-purple-300' : 'text-blue-300';
               const tagLabel = isVid ? `VIDEO_${referenceImages.slice(0, idx).filter(r => r.refType === 'video').length + 1}`
                 : isAud ? `AUDIO_${referenceImages.slice(0, idx).filter(r => r.refType === 'audio').length + 1}`
                 : `IMAGE_${imgIdx}`;
-              const TypeIcon = isVid ? Film : isAud ? Music : ImageIcon;
+              const TypeIcon = isVid ? Film : isAud ? Music : isVirtualHuman ? UserRound : ImageIcon;
               return (
                 <div key={idx} className="relative inline-block group/imgpreview">
                   {isVid ? (
                     <div className="h-14 w-14 rounded-lg border border-border/50 bg-muted overflow-hidden">
-                      <video src={ref.url} className="w-full h-full object-cover" preload="metadata" muted />
+                      <video src={ref.url} draggable={false} className="w-full h-full object-cover" preload="metadata" muted />
                     </div>
                   ) : isAud ? (
                     <div className="h-14 w-14 rounded-lg border border-border/50 bg-muted flex items-center justify-center">
                       <Music className="w-6 h-6 text-teal-400/60" />
                     </div>
                   ) : (ref.previewUrl || ref.url) && !(ref.url.startsWith('asset://') && !ref.previewUrl) ? (
-                    <img src={ref.previewUrl || ref.url} alt={ref.name} className="h-14 w-14 rounded-lg object-cover border border-border/50" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; (e.target as HTMLImageElement).nextElementSibling?.classList.remove('hidden'); }} />
+                    <img src={ref.previewUrl || ref.url} alt={ref.name} draggable={false} className="h-14 w-14 rounded-lg object-cover border border-border/50" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; (e.target as HTMLImageElement).nextElementSibling?.classList.remove('hidden'); }} />
                   ) : null}
                   {isImg && (
                     <div className={cn('h-14 w-14 rounded-lg border border-border/50 bg-muted flex items-center justify-center', (ref.previewUrl || (!ref.url.startsWith('asset://') && ref.url)) ? 'hidden absolute inset-0' : '')}>
@@ -605,7 +768,7 @@ export default function VideoGeneratePanel({
                   </div>
                   {/* Type badge */}
                   <div className="absolute top-0.5 left-0.5">
-                    <TypeIcon className={cn('w-3 h-3', isVid ? 'text-amber-400' : isAud ? 'text-teal-400' : 'text-emerald-400')} />
+                    <TypeIcon className={cn('w-3 h-3', isVid ? 'text-amber-400' : isAud ? 'text-teal-400' : isVirtualHuman ? 'text-purple-400' : 'text-emerald-400')} />
                   </div>
                 </div>
               );
@@ -618,9 +781,9 @@ export default function VideoGeneratePanel({
           <div className="px-3 pt-2.5 pb-0">
             <div className="relative inline-block group/vidpreview">
               <div className="h-16 w-24 rounded-lg bg-muted border border-border/50 flex items-center justify-center overflow-hidden">
-                <video src={extensionVideoUrl} className="w-full h-full object-cover" preload="metadata" muted />
+                <video src={extensionVideoUrl} draggable={false} className="w-full h-full object-cover" preload="metadata" muted />
               </div>
-              <button type="button" onClick={() => setExtensionVideoUrl('')} className="absolute -top-1.5 -right-1.5 h-4 w-4 rounded-full bg-background border border-border/50 shadow-sm flex items-center justify-center opacity-0 group-hover/vidpreview:opacity-100 transition-opacity hover:bg-destructive hover:text-destructive-foreground">
+              <button type="button" onClick={() => { unlinkNode(extensionVideoNodeIdRef.current); extensionVideoNodeIdRef.current = null; setExtensionVideoUrl(''); }} className="absolute -top-1.5 -right-1.5 h-4 w-4 rounded-full bg-background border border-border/50 shadow-sm flex items-center justify-center opacity-0 group-hover/vidpreview:opacity-100 transition-opacity hover:bg-destructive hover:text-destructive-foreground">
                 <X className="h-2.5 w-2.5" />
               </button>
               <div className="absolute bottom-0.5 left-0.5 px-1 py-0.5 rounded text-[8px] font-medium bg-black/60 text-white backdrop-blur-sm">
@@ -639,6 +802,7 @@ export default function VideoGeneratePanel({
           placeholder={t('canvas.node.video.promptPlaceholder')}
           disabled={taskActive}
           onSubmit={() => canSubmit && handleSubmit()}
+          maxHeight={inputMaxHeight ?? undefined}
         />
 
         {/* Bottom toolbar */}
@@ -665,38 +829,31 @@ export default function VideoGeneratePanel({
                 )} />
               </button>
 
-              {/* Custom model dropdown */}
+              {/* Custom model dropdown — flat list with per-item provider logo */}
               {showModelDropdown && (
                 <div className="absolute top-full left-0 mt-1 w-64 max-h-72 overflow-y-auto rounded-lg border border-border/50 bg-popover shadow-lg z-50 animate-in fade-in zoom-in-95 duration-100 custom-scrollbar">
-                  {groupedModels.map((group) => {
-                    const logoSrc = PROVIDER_ICONS[group.providerType];
+                  {flatModels.map(({ key, model: m, providerType, providerName }) => {
+                    const logoSrc = PROVIDER_ICONS[providerType];
+                    const isSelected = key === selectedModelKey;
                     return (
-                      <div key={group.providerId}>
-                        <div className="px-2.5 py-1.5 text-[10px] font-semibold text-muted-foreground/70 uppercase tracking-wider bg-muted/30 sticky top-0 border-b border-border/30 flex items-center gap-1.5">
-                          {logoSrc && <img src={logoSrc} alt="" className="w-3.5 h-3.5 object-contain" />}
-                          {group.providerName}
-                        </div>
-                        {group.models.map((m) => {
-                          const key = `${m.provider_id}::${m.model_name}`;
-                          const isSelected = key === selectedModelKey;
-                          return (
-                            <button
-                              key={key}
-                              type="button"
-                              onClick={() => handleModelSelect(key)}
-                              className={cn(
-                                'w-full flex items-center gap-2 px-2.5 py-2 text-xs transition-colors cursor-pointer',
-                                isSelected
-                                  ? 'bg-primary/10 text-primary'
-                                  : 'text-foreground hover:bg-accent',
-                              )}
-                            >
-                              <span className="flex-1 text-left font-medium truncate">{m.display_name}</span>
-                              {isSelected && <Check className="w-3.5 h-3.5 shrink-0 text-primary" />}
-                            </button>
-                          );
-                        })}
-                      </div>
+                      <button
+                        key={key}
+                        type="button"
+                        onClick={() => handleModelSelect(key)}
+                        title={providerName}
+                        className={cn(
+                          'w-full flex items-center gap-2 px-2.5 py-2 text-xs transition-colors cursor-pointer',
+                          isSelected
+                            ? 'bg-primary/10 text-primary'
+                            : 'text-foreground hover:bg-accent',
+                        )}
+                      >
+                        {logoSrc
+                          ? <img src={logoSrc} alt="" className="w-4 h-4 object-contain shrink-0" />
+                          : <span className="w-4 h-4 shrink-0" />}
+                        <span className="flex-1 text-left font-medium truncate">{m.display_name}</span>
+                        {isSelected && <Check className="w-3.5 h-3.5 shrink-0 text-primary" />}
+                      </button>
                     );
                   })}
                   {models.length === 0 && !modelsLoading && (
@@ -950,6 +1107,16 @@ export default function VideoGeneratePanel({
             )}
           </div>
         </div>
+
+        {/* Resize handle — at bottom edge of the input container */}
+        <div
+          className="absolute -bottom-1 left-1/2 -translate-x-1/2 flex items-center justify-center h-3 w-12 cursor-ns-resize group/resize select-none z-10"
+          onPointerDown={handleResizePointerDown}
+          onPointerMove={handleResizePointerMove}
+          onPointerUp={handleResizePointerUp}
+        >
+          <div className="w-8 h-[3px] rounded-full bg-border/40 group-hover/resize:bg-border/80 group-active/resize:bg-primary/60 transition-colors" />
+        </div>
       </div>
 
       {/* "Apply to Node" / "Apply to Next Node" button — shown when task done */}
@@ -976,13 +1143,39 @@ export default function VideoGeneratePanel({
           {visibility.showModeSelect && (
             <div className="space-y-1">
               <label className="text-[11px] font-medium text-muted-foreground">{t('canvas.node.video.mode')}</label>
-              <select value={videoMode} onChange={(e) => setVideoMode(e.target.value)} className={SELECT_CLS} style={SELECT_ARROW_STYLE}>
-                {capabilities?.modes.map((mode) => (
-                  <option key={mode} value={mode}>
-                    {VIDEO_MODE_LABELS[mode] || mode}
-                  </option>
-                ))}
-              </select>
+              <div className="relative" ref={modeDropdownRef}>
+                <button
+                  type="button"
+                  onClick={() => setShowModeDropdown(v => !v)}
+                  className={cn(SELECT_CLS, 'flex items-center justify-between')}
+                  style={SELECT_ARROW_STYLE}
+                >
+                  {VIDEO_MODE_LABELS[videoMode] || videoMode}
+                </button>
+                {showModeDropdown && (
+                  <div className="absolute top-full left-0 mt-1 w-full rounded-lg border border-border/50 bg-popover shadow-lg z-50 animate-in fade-in zoom-in-95 duration-100 overflow-hidden">
+                    {capabilities?.modes.map((mode) => {
+                      const isSelected = mode === videoMode;
+                      return (
+                        <button
+                          key={mode}
+                          type="button"
+                          onClick={() => { setVideoMode(mode); setShowModeDropdown(false); }}
+                          className={cn(
+                            'w-full flex items-center gap-2 px-2.5 py-1.5 text-[11px] transition-colors cursor-pointer',
+                            isSelected
+                              ? 'bg-primary/10 text-primary font-medium'
+                              : 'text-foreground hover:bg-accent',
+                          )}
+                        >
+                          <span className="flex-1 text-left">{VIDEO_MODE_LABELS[mode] || mode}</span>
+                          {isSelected && <Check className="w-3 h-3 shrink-0 text-primary" />}
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
             </div>
           )}
 
@@ -1025,23 +1218,77 @@ export default function VideoGeneratePanel({
           <div className="grid grid-cols-2 gap-2">
             <div className="space-y-1">
               <label className="text-[11px] font-medium text-muted-foreground">{t('canvas.node.video.quality')}</label>
-              <select value={quality} onChange={(e) => setQuality(e.target.value)} className={SELECT_CLS} style={SELECT_ARROW_STYLE}>
-                {visibility.resolutionOptions.map((r) => (
-                  <option key={r} value={r}>
-                    {RESOLUTION_LABELS[r] || r}
-                  </option>
-                ))}
-              </select>
+              <div className="relative" ref={qualityDropdownRef}>
+                <button
+                  type="button"
+                  onClick={() => setShowQualityDropdown(v => !v)}
+                  className={cn(SELECT_CLS, 'flex items-center justify-between')}
+                  style={SELECT_ARROW_STYLE}
+                >
+                  {RESOLUTION_LABELS[quality] || quality}
+                </button>
+                {showQualityDropdown && (
+                  <div className="absolute top-full left-0 mt-1 w-full rounded-lg border border-border/50 bg-popover shadow-lg z-50 animate-in fade-in zoom-in-95 duration-100 overflow-hidden">
+                    {visibility.resolutionOptions.map((r) => {
+                      const isSelected = r === quality;
+                      return (
+                        <button
+                          key={r}
+                          type="button"
+                          onClick={() => { setQuality(r); setShowQualityDropdown(false); }}
+                          className={cn(
+                            'w-full flex items-center gap-2 px-2.5 py-1.5 text-[11px] transition-colors cursor-pointer',
+                            isSelected
+                              ? 'bg-primary/10 text-primary font-medium'
+                              : 'text-foreground hover:bg-accent',
+                          )}
+                        >
+                          <span className="flex-1 text-left">{RESOLUTION_LABELS[r] || r}</span>
+                          {isSelected && <Check className="w-3 h-3 shrink-0 text-primary" />}
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
             </div>
             <div className="space-y-1">
               <label className="text-[11px] font-medium text-muted-foreground">{t('canvas.node.video.aspectRatio')}</label>
-              <select value={aspectRatio} onChange={(e) => setAspectRatio(e.target.value)} className={SELECT_CLS} style={SELECT_ARROW_STYLE}>
-                {visibility.aspectRatioOptions.map((ar) => (
-                  <option key={ar} value={ar}>
-                    {ASPECT_RATIO_LABELS[ar] || ar}
-                  </option>
-                ))}
-              </select>
+              <div className="relative" ref={aspectDropdownRef}>
+                <button
+                  type="button"
+                  onClick={() => setShowAspectDropdown(v => !v)}
+                  className={cn(SELECT_CLS, 'flex items-center gap-1.5')}
+                  style={SELECT_ARROW_STYLE}
+                >
+                  <AspectRatioIcon ratio={aspectRatio} className="w-4 h-4 text-muted-foreground shrink-0" />
+                  {ASPECT_RATIO_LABELS[aspectRatio] || aspectRatio}
+                </button>
+                {showAspectDropdown && (
+                  <div className="absolute top-full left-0 mt-1 w-full rounded-lg border border-border/50 bg-popover shadow-lg z-50 animate-in fade-in zoom-in-95 duration-100 overflow-hidden">
+                    {visibility.aspectRatioOptions.map((ar) => {
+                      const isSelected = ar === aspectRatio;
+                      return (
+                        <button
+                          key={ar}
+                          type="button"
+                          onClick={() => { setAspectRatio(ar); setShowAspectDropdown(false); }}
+                          className={cn(
+                            'w-full flex items-center gap-2 px-2.5 py-1.5 text-[11px] transition-colors cursor-pointer',
+                            isSelected
+                              ? 'bg-primary/10 text-primary font-medium'
+                              : 'text-foreground hover:bg-accent',
+                          )}
+                        >
+                          <AspectRatioIcon ratio={ar} className={cn('w-4 h-4 shrink-0', isSelected ? 'text-primary' : 'text-muted-foreground')} />
+                          <span className="flex-1 text-left">{ASPECT_RATIO_LABELS[ar] || ar}</span>
+                          {isSelected && <Check className="w-3 h-3 shrink-0 text-primary" />}
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
             </div>
           </div>
 

--- a/frontend/src/components/canvas/VideoNode.tsx
+++ b/frontend/src/components/canvas/VideoNode.tsx
@@ -123,12 +123,23 @@ const VideoNode = ({ id, data, selected }: NodeProps<Node<VideoNodeData>>) => {
     videoTask.reset();
   }, [videoTask.status?.video_url, videoTask.reset, id, getEdges, getNode, updateNodeData, addNode, t]);
 
-  const handleRetryGenerate = useCallback(() => {
-    // Restore original video and reset task
-    const prevUrl = prevVideoUrlRef.current;
-    prevUrl && updateNodeData(id, { videoUrl: prevUrl } as Partial<VideoNodeData>);
-    videoTask.reset();
-  }, [videoTask.reset, updateNodeData, id]);
+  // ── Auto-linking: connect source material nodes to this video node ──
+  const handleLinkNode = useCallback((sourceNodeId: string) => {
+    const edges = getEdges();
+    const alreadyLinked = edges.some(e => e.source === sourceNodeId && e.target === id);
+    alreadyLinked || useCanvasStore.getState().onConnect({
+      source: sourceNodeId,
+      sourceHandle: 'right-source',
+      target: id,
+      targetHandle: 'left-target',
+    });
+  }, [id, getEdges]);
+
+  const handleUnlinkNode = useCallback((sourceNodeId: string) => {
+    const edges = getEdges();
+    const edge = edges.find(e => e.source === sourceNodeId && e.target === id);
+    edge && useCanvasStore.getState().deleteEdge(edge.id);
+  }, [id, getEdges]);
 
   const [showHistory, setShowHistory] = useState(false);
   const historyVideos = data.generatedVideos || [];
@@ -568,23 +579,12 @@ const VideoNode = ({ id, data, selected }: NodeProps<Node<VideoNodeData>>) => {
                   title={t('canvas.node.video.dragToMove')}
                 />
 
-                {/* Hover overlay: refresh + resolution badge — top-right */}
+                {/* Hover overlay: resolution badge — top-right */}
                 <div className="absolute top-2 right-2 flex items-center gap-1.5 opacity-0 group-hover/video:opacity-100 transition-opacity duration-200 z-[15] nodrag">
                   {videoTask.status?.quality && (
                     <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-black/60 text-white backdrop-blur-sm">
                       {videoTask.status.quality}
                     </span>
-                  )}
-                  {taskDone && (
-                    <button
-                      type="button"
-                      onClick={(e) => { e.stopPropagation(); handleRetryGenerate(); }}
-                      onPointerDown={(e) => e.stopPropagation()}
-                      className="w-7 h-7 rounded-lg bg-black/60 backdrop-blur-sm text-white hover:bg-black/80 flex items-center justify-center transition-colors"
-                      title={t('canvas.node.video.retryGenerate')}
-                    >
-                      <RefreshCw className="w-3.5 h-3.5" />
-                    </button>
                   )}
                 </div>
               </div>
@@ -803,6 +803,9 @@ const VideoNode = ({ id, data, selected }: NodeProps<Node<VideoNodeData>>) => {
             onApplyToNextNode={handleApplyToNextNode}
             canvasNodes={canvasNodes}
             initialConfig={data.initialGenConfig || null}
+            nodeId={id}
+            onLinkNode={handleLinkNode}
+            onUnlinkNode={handleUnlinkNode}
           />
         </div>
 

--- a/frontend/src/i18n/locales/en-US.json
+++ b/frontend/src/i18n/locales/en-US.json
@@ -316,7 +316,6 @@
         "applyToNextNode": "Apply to Next Node",
         "aiGenerated": "AI Generated",
                 "historyToggle": "Generation History",
-        "retryGenerate": "Retry",
                 "selectImageNode": "Select image from canvas",
                 "selectVideoNode": "Select video from canvas",
                 "selectRefImages": "Select references (max {{max}})",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -316,7 +316,6 @@
         "applyToNextNode": "应用到下一个节点",
         "aiGenerated": "AI 生成",
                 "historyToggle": "生成历史",
-        "retryGenerate": "重新生成",
                 "selectImageNode": "从画布选择图片",
                 "selectVideoNode": "从画布选择视频",
                 "selectRefImages": "选择参考素材（最多{{max}}个）",


### PR DESCRIPTION
- RefTagInput 组件新增虚拟人像标签支持，添加 isVirtualHuman 参数
- 标签样式及图标区分虚拟人像与普通资源，增加删除按钮鼠标交互效果
- 实现标签拖拽移动，拖放时使用原生光标显示，无自定义指示条
- VideoGeneratePanel 支持节点自动链接和解绑，管理资源来源节点 ID
- 新增多种下拉菜单点击外部关闭逻辑，提升交互体验
- 支持对输入区的动态最大高度调整，添加拖拽调整输入框大小功能
- 优化模型列表展示，扁平化显示并展示提供商信息
- 引入比例图标组件 AspectRatioIcon，支持比例显示和自适应情况
- 资源预览支持虚拟人像专属样式及预览图显示，图片禁用拖拽防止误操作
- 清理和解绑相关资源链接，确保模式切换时资源状态同步正确