### PR TITLE
feat(video): 集成阿里云 DashScope HappyHorse 视频生成适配器

### DIFF
--- a/backend/routers/videos.py
+++ b/backend/routers/videos.py
@@ -108,17 +108,19 @@ async def create_video_task(
     provider_type = extract_video_provider_type(provider.provider_type) or infer_provider_type(request.model, provider.provider_type)
     
     # ── 本地 /api/media/ 路径转 base64 data URL（供应商需要 HTTPS 或 base64） ──
-    image_url = _resolve_local_media_to_data_url(request.image_url)
-    last_frame_image = _resolve_local_media_to_data_url(request.last_frame_image)
-    extension_video_url = _resolve_local_media_to_data_url(request.extension_video_url)
+    # DashScope HappyHorse 不支持 data URL, 由适配器内部通过上传策略处理本地文件
+    _prep = lambda u: _prepare_media_url(provider_type, u)
+    image_url = _prep(request.image_url)
+    last_frame_image = _prep(request.last_frame_image)
+    extension_video_url = _prep(request.extension_video_url)
     reference_images = [
-        {**img, "url": _resolve_local_media_to_data_url(img.get("url"))} for img in (request.reference_images or [])
+        {**img, "url": _prep(img.get("url"))} for img in (request.reference_images or [])
     ]
     reference_videos = [
-        {**v, "url": _resolve_local_media_to_data_url(v.get("url"))} for v in (request.reference_videos or [])
+        {**v, "url": _prep(v.get("url"))} for v in (request.reference_videos or [])
     ]
     reference_audios = [
-        {**a, "url": _resolve_local_media_to_data_url(a.get("url"))} for a in (request.reference_audios or [])
+        {**a, "url": _prep(a.get("url"))} for a in (request.reference_audios or [])
     ]
 
     # 构建视频上下文
@@ -141,6 +143,7 @@ async def create_video_task(
         reference_videos=reference_videos,
         reference_audios=reference_audios,
         return_last_frame=request.return_last_frame,
+        base_url=provider.base_url,
     )
 
     # 提交到供应商 (根据 provider_type 自动路由)
@@ -205,7 +208,7 @@ async def get_video_task_status(
 
     # 轮询供应商 (根据 provider_type 自动选择适配器)
     provider_type = extract_video_provider_type(provider.provider_type) or infer_provider_type(task.model or "", provider.provider_type)
-    poll_result = await poll_video_task(provider.api_key, task.xai_task_id, provider_type)
+    poll_result = await poll_video_task(provider.api_key, task.xai_task_id, provider_type, base_url=provider.base_url)
 
     # 超时保护：pending 且有错误超过 5 分钟 → 判定失败
     poll_has_error = poll_result.error and poll_result.status == "pending"
@@ -480,3 +483,18 @@ def _resolve_local_media_to_data_url(url: str | None) -> str | None:
     raw = filepath.read_bytes()
     b64 = base64.b64encode(raw).decode("ascii")
     return f"data:{mime_type};base64,{b64}"
+
+
+# 不需要 base64 转换的供应商 (由适配器自行处理媒体 URL)
+_BYPASS_BASE64_PROVIDERS = {"dashscope"}
+
+
+def _prepare_media_url(provider_type: str, url: str | None) -> str | None:
+    """根据供应商选择媒体 URL 预处理策略
+    
+    - dashscope (HappyHorse): 原样透传, 由适配器内部通过 OSS 上传策略处理本地文件
+    - 其他供应商: 保持原有 base64 data URL 转换逻辑
+    """
+    if provider_type in _BYPASS_BASE64_PROVIDERS:
+        return url
+    return _resolve_local_media_to_data_url(url)

--- a/backend/services/video_generation.py
+++ b/backend/services/video_generation.py
@@ -6,6 +6,7 @@
   - MiniMax (Hailuo)
   - Gemini (Veo)
   - Ark (Seedance)
+  - DashScope (HappyHorse)
 
 使用方式:
   from services.video_generation import submit_video_task, poll_video_task, VideoContext
@@ -13,16 +14,17 @@
 架构:
   video_generation.py (工厂 + 兼容层)
   └── video_providers/
-      ├── base.py              (抽象基类)
-      ├── model_capabilities.py (模型能力配置)
-      ├── xai_provider.py      (xAI 适配器)
-      ├── minimax_provider.py  (MiniMax 适配器)
-      ├── gemini_provider.py   (Gemini 适配器)
-      └── ark_provider.py      (Ark Seedance 适配器)
+      ├── base.py                (抽象基类)
+      ├── model_capabilities.py  (模型能力配置)
+      ├── xai_provider.py        (xAI 适配器)
+      ├── minimax_provider.py    (MiniMax 适配器)
+      ├── gemini_provider.py     (Gemini 适配器)
+      ├── ark_provider.py        (Ark Seedance 适配器)
+      └── dashscope_provider.py  (DashScope HappyHorse 适配器)
 """
 from __future__ import annotations
 
-from typing import Dict, Type
+from typing import Dict, Optional, Type
 import logging
 
 # 从适配器模块导入核心类型
@@ -34,6 +36,7 @@ from .video_providers import (
     MiniMaxVideoAdapter,
     GeminiVeoAdapter,
     ArkSeedanceAdapter,
+    DashScopeVideoAdapter,
     extract_video_provider_type,
 )
 
@@ -54,6 +57,7 @@ _PROVIDER_REGISTRY: Dict[str, Type[VideoProviderAdapter]] = {
     "minimax": MiniMaxVideoAdapter,
     "gemini": GeminiVeoAdapter,
     "ark": ArkSeedanceAdapter,
+    "dashscope": DashScopeVideoAdapter,
 }
 
 
@@ -100,7 +104,12 @@ async def submit_video_task(ctx: VideoContext) -> VideoResult:
     return await adapter.submit(ctx)
 
 
-async def poll_video_task(api_key: str, task_id: str, provider_type: str = "xai") -> VideoResult:
+async def poll_video_task(
+    api_key: str,
+    task_id: str,
+    provider_type: str = "xai",
+    base_url: Optional[str] = None,
+) -> VideoResult:
     """
     轮询视频任务状态 (统一入口)
     
@@ -108,14 +117,18 @@ async def poll_video_task(api_key: str, task_id: str, provider_type: str = "xai"
         api_key: API 密钥
         task_id: 任务 ID
         provider_type: 供应商类型 (默认 xai)
+        base_url: 供应商 Endpoint 覆盖 (DashScope 支持地域切换)
         
     Returns:
         VideoResult: 轮询结果
     """
     adapter = get_provider_adapter(provider_type)
     
-    # 使用带 key 的轮询方法
-    result = await adapter.poll_with_key(api_key, task_id)
+    # DashScope 支持 base_url 参数; 其他供应商保持兼容签名
+    if provider_type == "dashscope":
+        result = await adapter.poll_with_key(api_key, task_id, base_url=base_url)
+    else:
+        result = await adapter.poll_with_key(api_key, task_id)
     
     # MiniMax 需要额外获取视频 URL
     (provider_type == "minimax" and result.status == "completed" and result.file_id) and (
@@ -134,6 +147,7 @@ _MODEL_PREFIX_PROVIDER_MAP = [
     (["veo-"], "gemini"),
     (["hailuo", "minimax", "t2v-01", "i2v-01", "s2v-01"], "minimax"),
     (["seedance", "doubao-seedance"], "ark"),
+    (["happyhorse"], "dashscope"),
 ]
 
 

--- a/backend/services/video_providers/__init__.py
+++ b/backend/services/video_providers/__init__.py
@@ -6,17 +6,19 @@
 - MiniMax (Hailuo)
 - Gemini (Veo)
 - Ark (Seedance)
+- DashScope (HappyHorse)
 """
 from .base import VideoProviderAdapter, VideoContext, VideoResult
 from .xai_provider import XAIVideoAdapter
 from .minimax_provider import MiniMaxVideoAdapter
 from .gemini_provider import GeminiVeoAdapter
 from .ark_provider import ArkSeedanceAdapter
+from .dashscope_provider import DashScopeVideoAdapter
 
 # ---------------------------------------------------------------------------
 # 已注册的视频供应商类型 (代码级注册表，与 _PROVIDER_REGISTRY 对应)
 # ---------------------------------------------------------------------------
-VIDEO_PROVIDER_TYPES = frozenset({"xai", "minimax", "gemini", "ark"})
+VIDEO_PROVIDER_TYPES = frozenset({"xai", "minimax", "gemini", "ark", "dashscope"})
 
 
 def extract_video_provider_type(provider_type: str) -> str | None:
@@ -24,7 +26,7 @@ def extract_video_provider_type(provider_type: str) -> str | None:
     从 LLMProvider.provider_type 提取视频供应商类型
     
     支持的格式:
-      - 直接匹配: "xai", "minimax", "gemini", "ark"
+      - 直接匹配: "xai", "minimax", "gemini", "ark", "dashscope"
       - 前缀匹配: "xai_video", "gemini_chat" -> 提取 "xai", "gemini"
     
     Args:
@@ -50,6 +52,7 @@ __all__ = [
     "MiniMaxVideoAdapter",
     "GeminiVeoAdapter",
     "ArkSeedanceAdapter",
+    "DashScopeVideoAdapter",
     "VIDEO_PROVIDER_TYPES",
     "extract_video_provider_type",
 ]

--- a/backend/services/video_providers/base.py
+++ b/backend/services/video_providers/base.py
@@ -46,6 +46,8 @@ class VideoContext:
     return_last_frame: bool = False
     # 联网搜索工具 (Seedance 2.0 支持)
     enable_web_search: bool = False
+    # 供应商 Endpoint 覆盖 (DashScope HappyHorse 支持北京/新加坡切换)
+    base_url: Optional[str] = None
 
 
 @dataclass

--- a/backend/services/video_providers/dashscope_provider.py
+++ b/backend/services/video_providers/dashscope_provider.py
@@ -1,0 +1,414 @@
+"""
+阿里云 DashScope 百炼 HappyHorse 视频生成适配器
+
+支持模型:
+  - happyhorse-1.0-t2v         (文生视频)
+  - happyhorse-1.0-i2v         (图生视频, 首帧)
+  - happyhorse-1.0-r2v         (参考生视频, 多图)
+  - happyhorse-1.0-video-edit  (视频编辑)
+
+REST 端点:
+  提交: POST {base}/api/v1/services/aigc/video-generation/video-synthesis
+  轮询: GET  {base}/api/v1/tasks/{task_id}
+  上传策略: GET {base}/api/v1/uploads?action=getPolicy&model={model}
+
+HappyHorse 要求媒体必须为公网 HTTP(S) URL 或 oss:// URL；本地文件需通过 DashScope
+文件上传策略先上传到 OSS 后再引用。
+"""
+from __future__ import annotations
+
+import base64
+import logging
+import mimetypes
+import os
+import re
+import uuid
+from pathlib import Path
+from typing import ClassVar, Dict, List, Optional
+
+import httpx
+
+from .base import VideoProviderAdapter, VideoContext, VideoResult
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE_URL = "https://dashscope.aliyuncs.com"
+
+# 本地 /api/media/ 前缀对应的物理根目录 (与 services.media_utils.MEDIA_DIR 保持一致)
+_MEDIA_DIR = Path(__file__).resolve().parents[2] / "media"
+
+
+class DashScopeVideoAdapter(VideoProviderAdapter):
+    """DashScope 百炼 HappyHorse 视频适配器"""
+
+    SUPPORTED_MODELS: ClassVar[List[str]] = [
+        "happyhorse-1.0-t2v",
+        "happyhorse-1.0-i2v",
+        "happyhorse-1.0-r2v",
+        "happyhorse-1.0-video-edit",
+    ]
+
+    STATUS_MAP: ClassVar[Dict[str, str]] = {
+        "PENDING": "pending",
+        "RUNNING": "processing",
+        "SUCCEEDED": "completed",
+        "FAILED": "failed",
+        "CANCELED": "failed",
+        "UNKNOWN": "failed",
+    }
+
+    # 分辨率映射: 内部 quality -> DashScope resolution
+    RESOLUTION_MAP: ClassVar[Dict[str, str]] = {
+        "480p": "720P",  # DashScope 不支持 480p, 降级到 720P
+        "720p": "720P",
+        "1080p": "1080P",
+    }
+
+    # 支持的宽高比 (t2v / r2v)
+    _SUPPORTED_RATIOS: ClassVar[set] = {"16:9", "9:16", "1:1", "4:3", "3:4"}
+
+    # 模型能力桶 (避免运行时 if 判断, 集合查找)
+    _T2V_MODELS: ClassVar[set] = {"happyhorse-1.0-t2v"}
+    _I2V_MODELS: ClassVar[set] = {"happyhorse-1.0-i2v"}
+    _R2V_MODELS: ClassVar[set] = {"happyhorse-1.0-r2v"}
+    _EDIT_MODELS: ClassVar[set] = {"happyhorse-1.0-video-edit"}
+
+    # ---------------------------------------------------------------------
+    # 提交
+    # ---------------------------------------------------------------------
+    async def submit(self, ctx: VideoContext) -> VideoResult:
+        """提交 HappyHorse 视频生成任务"""
+        base_url = self._resolve_base_url(ctx.base_url)
+
+        # 按模型构造请求 body (含媒体 URL 规范化)
+        try:
+            payload = await self._build_payload(ctx, base_url)
+        except Exception as exc:
+            logger.error(f"DashScope build payload failed: {exc}", exc_info=True)
+            return VideoResult(status="failed", error=f"构造请求失败: {exc}")
+
+        return await self._call_submit(ctx, base_url, payload)
+
+    def _resolve_base_url(self, base_url: Optional[str]) -> str:
+        """解析 endpoint; 允许 LLMProvider.base_url 覆盖"""
+        cleaned = (base_url or "").rstrip("/")
+        return cleaned or _DEFAULT_BASE_URL
+
+    async def _build_payload(self, ctx: VideoContext, base_url: str) -> dict:
+        """根据模型类型构造请求 payload"""
+        model = ctx.model
+        media: List[dict] = []
+
+        # I2V: 首帧图片 (必填)
+        (model in self._I2V_MODELS and ctx.image_url) and media.append({
+            "type": "first_frame",
+            "url": await self._ensure_public_url(ctx.api_key, ctx.image_url, model, base_url),
+        })
+        (model in self._I2V_MODELS and not ctx.image_url) and (_ for _ in ()).throw(
+            ValueError(f"模型 {model} 需要提供首帧图片 (image_url)")
+        )
+
+        # R2V: 多张参考图 (1~9 张)
+        if model in self._R2V_MODELS:
+            refs = [r.get("url") for r in (ctx.reference_images or []) if r and r.get("url")]
+            refs or (_ for _ in ()).throw(ValueError(f"模型 {model} 至少需要 1 张参考图"))
+            for url in refs[:9]:
+                media.append({
+                    "type": "reference_image",
+                    "url": await self._ensure_public_url(ctx.api_key, url, model, base_url),
+                })
+
+        # Video-Edit: 源视频 (必填) + 参考图 (0~5 张)
+        if model in self._EDIT_MODELS:
+            src = ctx.extension_video_url
+            src or (_ for _ in ()).throw(ValueError(f"模型 {model} 需要提供待编辑视频 (extension_video_url)"))
+            media.append({
+                "type": "video",
+                "url": await self._ensure_public_url(ctx.api_key, src, model, base_url),
+            })
+            refs = [r.get("url") for r in (ctx.reference_images or []) if r and r.get("url")]
+            for url in refs[:5]:
+                media.append({
+                    "type": "reference_image",
+                    "url": await self._ensure_public_url(ctx.api_key, url, model, base_url),
+                })
+
+        # 组装 input
+        input_body: dict = {"prompt": ctx.prompt or ""}
+        media and input_body.update({"media": media})
+
+        # 组装 parameters
+        parameters = self._build_parameters(ctx)
+
+        payload = {
+            "model": model,
+            "input": input_body,
+            "parameters": parameters,
+        }
+        return payload
+
+    def _build_parameters(self, ctx: VideoContext) -> dict:
+        """构造 parameters 字段"""
+        params: dict = {}
+
+        # 分辨率 (所有模型通用)
+        resolution = self.RESOLUTION_MAP.get((ctx.quality or "").lower(), "1080P")
+        params["resolution"] = resolution
+
+        # 时长约束: HappyHorse 支持 3~15 秒整数; video-edit 由输入视频决定, 但 API 不使用此参数
+        duration = int(ctx.duration or 5)
+        duration = max(3, min(15, duration))
+        (ctx.model not in self._EDIT_MODELS) and params.update({"duration": duration})
+
+        # 宽高比: 仅 t2v / r2v 支持 (i2v 跟随首帧, video-edit 跟随源视频)
+        supports_ratio = ctx.model in self._T2V_MODELS or ctx.model in self._R2V_MODELS
+        ratio = ctx.aspect_ratio if ctx.aspect_ratio in self._SUPPORTED_RATIOS else "16:9"
+        supports_ratio and params.update({"ratio": ratio})
+
+        # seed (可选)
+        (ctx.seed is not None) and params.update({"seed": int(ctx.seed)})
+
+        # video-edit 专有: audio_setting (默认 auto, 不显式传)
+        # watermark 默认 True, 当前不暴露给用户, 不主动传
+
+        return params
+
+    async def _call_submit(self, ctx: VideoContext, base_url: str, payload: dict) -> VideoResult:
+        """POST 创建任务"""
+        url = f"{base_url}/api/v1/services/aigc/video-generation/video-synthesis"
+        headers = {
+            "Authorization": f"Bearer {ctx.api_key}",
+            "Content-Type": "application/json",
+            "X-DashScope-Async": "enable",
+        }
+
+        log_payload = {
+            "model": payload.get("model"),
+            "prompt_len": len(payload.get("input", {}).get("prompt", "")),
+            "media_count": len(payload.get("input", {}).get("media", []) or []),
+            "parameters": payload.get("parameters"),
+        }
+        logger.info(f"DashScope video submit — mode={ctx.video_mode}, {log_payload}")
+
+        try:
+            async with httpx.AsyncClient(timeout=60) as client:
+                resp = await client.post(url, headers=headers, json=payload)
+
+            if resp.status_code >= 400:
+                err = self._extract_error(resp)
+                logger.error(f"DashScope submit error {resp.status_code}: {err}")
+                return VideoResult(status="failed", error=err)
+
+            data = resp.json()
+            output = data.get("output", {}) or {}
+            task_id = output.get("task_id", "")
+            raw_status = output.get("task_status", "PENDING")
+            mapped = self._map_status(raw_status)
+
+            task_id or logger.error(f"DashScope submit missing task_id: {data}")
+            logger.info(f"DashScope video submit OK — task_id={task_id}, status={raw_status}")
+
+            return VideoResult(
+                task_id=task_id,
+                status=mapped if task_id else "failed",
+                error="" if task_id else "未返回 task_id",
+            )
+
+        except Exception as e:
+            logger.error(f"DashScope submit failed: {e}", exc_info=True)
+            return VideoResult(status="failed", error=str(e))
+
+    # ---------------------------------------------------------------------
+    # 轮询
+    # ---------------------------------------------------------------------
+    async def poll(self, task_id: str) -> VideoResult:
+        """占位 — 统一通过 poll_with_key 调用"""
+        return VideoResult(task_id=task_id, status="pending")
+
+    async def poll_with_key(
+        self,
+        api_key: str,
+        task_id: str,
+        base_url: Optional[str] = None,
+    ) -> VideoResult:
+        """GET /api/v1/tasks/{task_id} 查询任务状态"""
+        base = self._resolve_base_url(base_url)
+        url = f"{base}/api/v1/tasks/{task_id}"
+        headers = {"Authorization": f"Bearer {api_key}"}
+
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.get(url, headers=headers)
+
+            if resp.status_code >= 400:
+                err = self._extract_error(resp)
+                logger.error(f"DashScope poll error {resp.status_code} for {task_id}: {err}")
+                return VideoResult(task_id=task_id, status="pending", error=err)
+
+            data = resp.json()
+            output = data.get("output", {}) or {}
+            usage = data.get("usage", {}) or {}
+
+            raw_status = output.get("task_status", "PENDING")
+            mapped = self._map_status(raw_status)
+
+            result = VideoResult(task_id=task_id, status=mapped)
+
+            # 完成: 填充视频 URL 和时长
+            (mapped == "completed") and (
+                setattr(result, "video_url", output.get("video_url", "")),
+                setattr(result, "duration_seconds", float(usage.get("output_video_duration", 0) or 0)),
+                setattr(result, "video_width", int(usage.get("SR", 0) or 0)),
+            )
+
+            # 失败: 携带错误信息
+            if mapped == "failed":
+                code = output.get("code", "")
+                msg = output.get("message", "") or raw_status
+                result.error = f"{code}: {msg}" if code else msg
+
+            logger.info(f"DashScope video poll — task_id={task_id}, status={raw_status} -> {mapped}")
+            return result
+
+        except Exception as e:
+            logger.error(f"DashScope poll failed for {task_id}: {e}", exc_info=True)
+            return VideoResult(task_id=task_id, status="pending", error=str(e))
+
+    # ---------------------------------------------------------------------
+    # 媒体 URL 规范化 (本地/data → oss://)
+    # ---------------------------------------------------------------------
+    async def _ensure_public_url(
+        self,
+        api_key: str,
+        url: str,
+        model: str,
+        base_url: str,
+    ) -> str:
+        """确保媒体 URL 是 DashScope 可访问的公网/OSS URL"""
+        if not url:
+            return url
+
+        # 已是 http(s) 或 oss 协议 → 直接返回
+        if url.startswith("http://") or url.startswith("https://") or url.startswith("oss://"):
+            return url
+
+        # data URL → 解码为二进制上传
+        if url.startswith("data:"):
+            filename, content = self._decode_data_url(url)
+            return await self._upload_binary(api_key, base_url, model, filename, content)
+
+        # 本地 /api/media/xxx 或 相对路径 → 读盘上传
+        local_path = self._resolve_local_path(url)
+        local_path or (_ for _ in ()).throw(ValueError(f"无法解析本地媒体路径: {url}"))
+        filename = local_path.name
+        content = local_path.read_bytes()
+        return await self._upload_binary(api_key, base_url, model, filename, content)
+
+    def _resolve_local_path(self, url: str) -> Optional[Path]:
+        """把 /api/media/xxx 或 相对路径解析为磁盘 Path"""
+        rel = url.replace("/api/media/", "", 1) if url.startswith("/api/media/") else url
+        candidate = _MEDIA_DIR / rel
+        return candidate if candidate.is_file() else None
+
+    def _decode_data_url(self, data_url: str) -> tuple[str, bytes]:
+        """解析 data:<mime>;base64,<body>, 返回 (filename, bytes)"""
+        match = re.match(r"^data:([^;]+);base64,(.+)$", data_url, re.DOTALL)
+        match or (_ for _ in ()).throw(ValueError("非法的 data URL"))
+        mime_type = match.group(1)
+        body = match.group(2)
+        ext = mimetypes.guess_extension(mime_type) or ".bin"
+        filename = f"{uuid.uuid4().hex}{ext}"
+        return filename, base64.b64decode(body)
+
+    async def _upload_binary(
+        self,
+        api_key: str,
+        base_url: str,
+        model: str,
+        filename: str,
+        content: bytes,
+    ) -> str:
+        """
+        通过 DashScope 上传策略把二进制上传到 OSS, 返回 oss:// URL
+
+        Flow:
+          1. GET /api/v1/uploads?action=getPolicy&model={model}
+          2. POST {upload_host} multipart form (OSS 直传)
+          3. 拼接 oss://{bucket}/{upload_dir}/{filename}
+        """
+        policy_url = f"{base_url}/api/v1/uploads"
+        async with httpx.AsyncClient(timeout=60) as client:
+            # Step 1: 获取上传策略
+            policy_resp = await client.get(
+                policy_url,
+                params={"action": "getPolicy", "model": model},
+                headers={"Authorization": f"Bearer {api_key}"},
+            )
+            if policy_resp.status_code >= 400:
+                raise RuntimeError(f"获取上传策略失败 {policy_resp.status_code}: {policy_resp.text[:200]}")
+
+            policy_data = (policy_resp.json().get("data") or {})
+            policy = policy_data.get("policy")
+            signature = policy_data.get("signature")
+            upload_dir = policy_data.get("upload_dir")
+            upload_host = policy_data.get("upload_host")
+            oss_access_key_id = policy_data.get("oss_access_key_id")
+            x_oss_object_acl = policy_data.get("x_oss_object_acl", "public-read")
+            x_oss_forbid_overwrite = policy_data.get("x_oss_forbid_overwrite", "false")
+
+            # 必要字段校验
+            missing = [
+                k for k, v in [
+                    ("policy", policy), ("signature", signature),
+                    ("upload_dir", upload_dir), ("upload_host", upload_host),
+                    ("oss_access_key_id", oss_access_key_id),
+                ] if not v
+            ]
+            missing and (_ for _ in ()).throw(RuntimeError(f"上传策略缺失字段: {missing}"))
+
+            # 生成 OSS key
+            key_name = f"{uuid.uuid4().hex}{os.path.splitext(filename)[1] or '.bin'}"
+            oss_key = f"{upload_dir}/{key_name}"
+
+            # Step 2: 直传 OSS
+            mime_type = mimetypes.guess_type(filename)[0] or "application/octet-stream"
+            form = {
+                "OSSAccessKeyId": oss_access_key_id,
+                "Signature": signature,
+                "policy": policy,
+                "key": oss_key,
+                "x-oss-object-acl": x_oss_object_acl,
+                "x-oss-forbid-overwrite": x_oss_forbid_overwrite,
+                "success_action_status": "200",
+            }
+            files = {"file": (filename, content, mime_type)}
+
+            upload_resp = await client.post(upload_host, data=form, files=files)
+            if upload_resp.status_code not in (200, 204):
+                raise RuntimeError(
+                    f"OSS 上传失败 {upload_resp.status_code}: {upload_resp.text[:200]}"
+                )
+
+        # Step 3: 从 upload_host 推断 bucket, 组装 oss:// URL
+        bucket = self._extract_bucket(upload_host)
+        oss_url = f"oss://{bucket}/{oss_key}" if bucket else f"oss://{oss_key}"
+        logger.info(f"DashScope uploaded local file to {oss_url}")
+        return oss_url
+
+    def _extract_bucket(self, upload_host: str) -> str:
+        """从 https://{bucket}.oss-cn-xxx.aliyuncs.com 提取 bucket"""
+        match = re.match(r"^https?://([^.]+)\.", upload_host or "")
+        return match.group(1) if match else ""
+
+    # ---------------------------------------------------------------------
+    # 错误解析
+    # ---------------------------------------------------------------------
+    def _extract_error(self, resp: httpx.Response) -> str:
+        """从 httpx.Response 提取 DashScope 错误信息"""
+        try:
+            data = resp.json()
+            code = data.get("code", "")
+            msg = data.get("message", "")
+            return f"{code}: {msg}" if code else (msg or resp.text[:200])
+        except Exception:
+            return resp.text[:200]

--- a/backend/services/video_providers/model_capabilities.py
+++ b/backend/services/video_providers/model_capabilities.py
@@ -469,6 +469,84 @@ VIDEO_MODEL_CAPABILITIES: Dict[str, VideoModelCapabilities] = {
         "supports_fast_pretreatment": False,
         "aspect_ratios": ["16:9", "9:16", "4:3", "3:4", "1:1", "21:9"],
     },
+
+    # =========================================================================
+    # 阿里云 DashScope 百炼 HappyHorse 模型
+    # =========================================================================
+
+    # HappyHorse 1.0 T2V: 文生视频
+    "happyhorse-1.0-t2v": {
+        "provider": "dashscope",
+        "modes": ["text_to_video"],
+        "durations": list(range(3, 16)),  # 3-15 秒
+        "resolutions": ["720p", "1080p"],
+        "supports_first_frame": False,
+        "supports_last_frame": False,
+        "supports_reference_images": False,
+        "supports_video_extension": False,
+        "supports_video_edit": False,
+        "supports_audio": False,
+        "max_reference_images": 0,
+        "supports_prompt_optimizer": False,
+        "supports_fast_pretreatment": False,
+        "aspect_ratios": ["16:9", "9:16", "1:1", "4:3", "3:4"],
+    },
+
+    # HappyHorse 1.0 I2V: 图生视频 (首帧)
+    "happyhorse-1.0-i2v": {
+        "provider": "dashscope",
+        "modes": ["image_to_video"],
+        "durations": list(range(3, 16)),
+        "resolutions": ["720p", "1080p"],
+        "supports_first_frame": True,
+        "supports_last_frame": False,
+        "supports_reference_images": False,
+        "supports_video_extension": False,
+        "supports_video_edit": False,
+        "supports_audio": False,
+        "max_reference_images": 0,
+        "supports_prompt_optimizer": False,
+        "supports_fast_pretreatment": False,
+        # 宽高比跟随首帧图像, 此处声明为 adaptive
+        "aspect_ratios": ["adaptive"],
+    },
+
+    # HappyHorse 1.0 R2V: 参考生视频 (1-9 张参考图)
+    "happyhorse-1.0-r2v": {
+        "provider": "dashscope",
+        "modes": ["reference_images"],
+        "durations": list(range(3, 16)),
+        "resolutions": ["720p", "1080p"],
+        "supports_first_frame": False,
+        "supports_last_frame": False,
+        "supports_reference_images": True,
+        "supports_video_extension": False,
+        "supports_video_edit": False,
+        "supports_audio": False,
+        "max_reference_images": 9,
+        "supports_prompt_optimizer": False,
+        "supports_fast_pretreatment": False,
+        "aspect_ratios": ["16:9", "9:16", "1:1", "4:3", "3:4"],
+    },
+
+    # HappyHorse 1.0 Video Edit: 视频编辑 (视频 + 0-5 张参考图)
+    "happyhorse-1.0-video-edit": {
+        "provider": "dashscope",
+        "modes": ["edit"],
+        "durations": list(range(3, 16)),  # 输出跟随输入视频长度
+        "resolutions": ["720p", "1080p"],
+        "supports_first_frame": False,
+        "supports_last_frame": False,
+        "supports_reference_images": True,
+        "supports_video_extension": False,
+        "supports_video_edit": True,
+        "supports_audio": True,
+        "max_reference_images": 5,
+        "supports_prompt_optimizer": False,
+        "supports_fast_pretreatment": False,
+        # 宽高比跟随输入视频
+        "aspect_ratios": ["adaptive"],
+    },
 }
 
 

--- a/frontend/src/components/ai-assistant/MessageInput.tsx
+++ b/frontend/src/components/ai-assistant/MessageInput.tsx
@@ -15,9 +15,6 @@ import {
   AlertCircle,
   Copy,
   UploadCloud,
-  ScrollText,
-  Film,
-  Clapperboard,
   Paperclip,
   Square,
   Toolbox
@@ -34,8 +31,9 @@ import { AnimatePresence, motion } from 'framer-motion';
 import type { AgentInfo, NodeAttachment, UploadedFile, PastedContent } from '@/store/useAIAssistantStore';
 import { NodePreviewCard } from './NodePreviewCard';
 import type { CanvasNode } from '@/store/useCanvasStore';
-import type { LucideIcon } from 'lucide-react';
+import { selectNodesByUpdatedDesc } from '@/store/useCanvasStore';
 import { extractNodeAttachment } from '@/lib/nodeAttachmentUtils';
+import { NodePickerDropdown, type NodePickerItem } from '@/components/canvas/NodePickerDropdown';
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 const MAX_FILES = 10;
@@ -254,16 +252,6 @@ const FilePreviewCard: React.FC<{ file: UploadedFile; onRemove: (id: string) => 
       : <GenericFileCard file={file} onRemove={onRemove} />;
 };
 
-// ─── Node type icons ─────────────────────────────────────────────────────────
-const NODE_TYPE_ICONS: Record<string, { icon: LucideIcon; color: string; label: string }> = {
-  text:       { icon: ScrollText,   color: 'text-node-blue',   label: '文本' },
-  image:      { icon: ImageIcon,    color: 'text-node-green',  label: '图片' },
-  video:      { icon: Film,         color: 'text-node-yellow', label: '视频' },
-  storyboard: { icon: Clapperboard, color: 'text-node-purple', label: '分镜' },
-};
-
-const DEFAULT_NODE_ICON = { icon: FileText, color: 'text-muted-foreground', label: '节点' };
-
 // ─── Props ───────────────────────────────────────────────────────────────────
 interface MessageInputProps {
   onSend: (content: string, files: UploadedFile[], pastedContents: PastedContent[]) => void;
@@ -339,6 +327,19 @@ export function MessageInput({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  // 节点选择下拉状态
+  const [showNodePicker, setShowNodePicker] = useState(false);
+  const nodePickerRef = useRef<HTMLDivElement>(null);
+
+  // 点击外部关闭节点选择下拉
+  useEffect(() => {
+    const handle = (e: MouseEvent) => {
+      nodePickerRef.current && !nodePickerRef.current.contains(e.target as HTMLElement) && setShowNodePicker(false);
+    };
+    showNodePicker && document.addEventListener('mousedown', handle);
+    return () => document.removeEventListener('mousedown', handle);
+  }, [showNodePicker]);
+
   // ── 撤销历史栈 ──
   const [undoHistory, setUndoHistory] = useState<string[]>(['']);
   const [undoIndex, setUndoIndex] = useState(0);
@@ -386,9 +387,12 @@ export function MessageInput({
     })();
   }, [undoIndex, undoHistory]);
 
-  // 过滤已附加的节点，生成可选节点列表
+  // 过滤已附加的节点，生成可选节点列表（按 updatedAt 倒序）
   const attachedNodeIds = useMemo(() => new Set(nodeAttachments.map(a => a.nodeId)), [nodeAttachments]);
-  const availableNodes = useMemo(() => canvasNodes.filter(n => !attachedNodeIds.has(n.id)), [canvasNodes, attachedNodeIds]);
+  const availableNodes = useMemo(
+    () => selectNodesByUpdatedDesc(canvasNodes.filter(n => !attachedNodeIds.has(n.id))),
+    [canvasNodes, attachedNodeIds],
+  );
 
   // 清理撤销历史定时器
   useEffect(() => {
@@ -717,57 +721,37 @@ export function MessageInput({
             {/* 右侧：节点附件 + 发送按钮 */}
             <div className="flex items-center gap-1">
               {/* 节点选择器 */}
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    type="button"
-                    size="icon"
-                    variant="ghost"
-                    className="h-8 w-8 text-muted-foreground hover:text-foreground hover:bg-accent flex-shrink-0"
-                    disabled={isDisabled || availableNodes.length === 0}
-                    title={t('ai.addNode')}
-                  >
-                    <Paperclip className="h-4 w-4" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="w-64 max-h-72 overflow-y-auto">
-                  <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground border-b border-border/50 mb-1">
-                    {t('ai.selectNode')}
-                  </div>
-                  {availableNodes.length === 0 && (
-                    <div className="p-3 text-xs text-muted-foreground text-center">
-                      {t('ai.noAvailableNodes')}
-                    </div>
+              <div className="relative" ref={nodePickerRef}>
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="ghost"
+                  onClick={() => setShowNodePicker(v => !v)}
+                  className={cn(
+                    'h-8 w-8 text-muted-foreground hover:text-foreground hover:bg-accent flex-shrink-0',
+                    showNodePicker && 'bg-accent text-foreground',
                   )}
-                  {availableNodes.map((node) => {
-                    const cfg = NODE_TYPE_ICONS[node.type || ''] ?? DEFAULT_NODE_ICON;
-                    const Icon = cfg.icon;
-                    const nodeData = node.data as Record<string, unknown>;
-                    const label = (nodeData.title || nodeData.name || nodeData.description || `${cfg.label} ${node.id.slice(0, 6)}`) as string;
-                    const excerpt = ((nodeData.description || '') as string).slice(0, 60);
-                    return (
-                      <DropdownMenuItem
-                        key={node.id}
-                        className="text-xs cursor-pointer py-2"
-                        onClick={() => {
-                          onAddNodeAttachment?.(extractNodeAttachment(node));
-                        }}
-                      >
-                        <div className="flex items-center gap-2 w-full min-w-0">
-                          <Icon className={cn('h-4 w-4 shrink-0', cfg.color)} />
-                          <div className="flex flex-col gap-0.5 min-w-0 flex-1">
-                            <span className="font-medium truncate">{label}</span>
-                            {excerpt && (
-                              <span className="text-[10px] text-muted-foreground line-clamp-1">{excerpt}</span>
-                            )}
-                          </div>
-                          <span className="text-[9px] text-muted-foreground/70 shrink-0">{cfg.label}</span>
-                        </div>
-                      </DropdownMenuItem>
-                    );
+                  disabled={isDisabled || availableNodes.length === 0}
+                  title={t('ai.addNode')}
+                >
+                  <Paperclip className="h-4 w-4" />
+                </Button>
+                <NodePickerDropdown
+                  open={showNodePicker}
+                  anchor="bottom"
+                  align="right"
+                  title={t('ai.selectNode')}
+                  emptyText={t('ai.noAvailableNodes')}
+                  items={availableNodes.map<NodePickerItem>((node) => {
+                    const attachment = extractNodeAttachment(node);
+                    return { node, label: attachment.label, thumbUrl: attachment.thumbnailUrl };
                   })}
-                </DropdownMenuContent>
-              </DropdownMenu>
+                  onSelect={(node) => {
+                    onAddNodeAttachment?.(extractNodeAttachment(node));
+                    setShowNodePicker(false);
+                  }}
+                />
+              </div>
 
               {/* 发送 / 停止生成 按钮 */}
               {isLoading ? (

--- a/frontend/src/components/canvas/AudioNode.tsx
+++ b/frontend/src/components/canvas/AudioNode.tsx
@@ -324,7 +324,7 @@ const AudioNode = ({ id, data, selected }: NodeProps<Node<AudioNodeData>>) => {
           </div>
         </div>
 
-        <Card className={`w-full h-full flex flex-col bg-card ${selected ? 'ring-2 ring-primary' : 'border border-border/50'} overflow-hidden relative z-[2]`}>
+        <Card className={`w-full h-full flex flex-col bg-card ${selected ? 'ring-2 ring-primary' : ''} overflow-hidden relative z-[2]`}>
           <CardContent 
             className="flex flex-col items-center justify-center relative custom-scrollbar flex-1 p-4 overflow-hidden" 
           >

--- a/frontend/src/components/canvas/ImageGeneratePanel.tsx
+++ b/frontend/src/components/canvas/ImageGeneratePanel.tsx
@@ -18,6 +18,8 @@ import {
   type ImageMode,
 } from '@/hooks/useImageGeneration';
 import type { ImageGenHistoryEntry, CanvasNode, CharacterNodeData } from '@/store/useCanvasStore';
+import { selectNodesByUpdatedDesc } from '@/store/useCanvasStore';
+import { NodePickerDropdown, type NodePickerItem } from './NodePickerDropdown';
 
 // ---------------------------------------------------------------------------
 // Provider logo mapping（与 VideoGeneratePanel 对齐）
@@ -216,12 +218,12 @@ export default function ImageGeneratePanel({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode]);
 
-  // 可用作参考图的画布节点（带 URL 且未被选择）
+  // 可用作参考图的画布节点（带 URL 且未被选择，按 updatedAt 倒序）
   const pickableNodes = useMemo(() => {
     const selectedIds = new Set(referenceImages.map((r) => r.sourceNodeId));
-    return (canvasNodes || [])
-      .map((n) => ({ node: n, url: getImageNodeUrl(n) }))
-      .filter((x) => !!x.url && !selectedIds.has(x.node.id));
+    const filtered = (canvasNodes || [])
+      .filter((n) => !selectedIds.has(n.id) && !!getImageNodeUrl(n));
+    return selectNodesByUpdatedDesc(filtered).map((n) => ({ node: n, url: getImageNodeUrl(n) }));
   }, [canvasNodes, referenceImages]);
 
   const maxRefs = IMAGE_MODE_MAX_REFS[mode] || 0;
@@ -415,7 +417,7 @@ export default function ImageGeneratePanel({
                   src={r.url}
                   alt={r.name}
                   draggable={false}
-                  className="h-14 w-14 rounded-lg object-cover border border-border/50"
+                  className="h-14 w-14 rounded-lg object-cover"
                 />
                 <button
                   type="button"
@@ -430,9 +432,6 @@ export default function ImageGeneratePanel({
                   <span className="text-blue-300">&lt;IMAGE_{i + 1}&gt;</span>
                   <br />
                   <span className="opacity-80">{r.name}</span>
-                </div>
-                <div className="absolute top-0.5 left-0.5">
-                  <ImageIcon className="w-3 h-3 text-emerald-400" />
                 </div>
               </div>
             ))}
@@ -537,46 +536,24 @@ export default function ImageGeneratePanel({
                   <Paperclip className="w-4 h-4" />
                 </button>
                 {showNodePicker && (
-                  <div className="absolute bottom-full right-0 mb-1 w-56 max-h-60 overflow-y-auto rounded-lg border border-border/50 bg-popover shadow-lg z-50 animate-in fade-in zoom-in-95 duration-100">
-                    <div className="px-2 py-1.5 text-[10px] font-medium text-muted-foreground border-b border-border/50">
-                      {t('canvas.node.image.pickRefNodeHint', '已选 {{c}}/{{m}}', { c: referenceImages.length, m: maxRefs })}
-                    </div>
-                    {pickableNodes.length === 0 ? (
-                      <div className="p-3 text-[10px] text-muted-foreground text-center">
-                        {t('canvas.node.image.noPickableNodes', '画布中没有可用的图像节点')}
-                      </div>
-                    ) : (
-                      pickableNodes.map(({ node, url }) => {
-                        const data = node.data as CharacterNodeData;
-                        const nm = data.name || node.id.slice(0, 8);
-                        const atLimit = referenceImages.length >= maxRefs;
-                        return (
-                          <button
-                            key={node.id}
-                            type="button"
-                            onClick={() => handleSelectNode(node)}
-                            disabled={atLimit}
-                            className={cn(
-                              'w-full flex items-center gap-2 px-2 py-1.5 text-xs hover:bg-accent transition-colors cursor-pointer',
-                              atLimit && 'opacity-40 cursor-not-allowed',
-                            )}
-                          >
-                            {url ? (
-                              <img src={url} alt="" className="h-8 w-8 rounded object-cover shrink-0 border border-border/30" />
-                            ) : (
-                              <div className="h-8 w-8 rounded bg-muted border border-border/30 shrink-0 flex items-center justify-center">
-                                <ImageIcon className="w-4 h-4 text-muted-foreground/50" />
-                              </div>
-                            )}
-                            <div className="flex flex-col min-w-0 flex-1 text-left">
-                              <span className="font-medium truncate text-foreground">{nm}</span>
-                            </div>
-                            <ImageIcon className="w-3 h-3 shrink-0 text-node-green" />
-                          </button>
-                        );
-                      })
-                    )}
-                  </div>
+                  <NodePickerDropdown
+                    open={showNodePicker}
+                    anchor="bottom"
+                    align="right"
+                    title={t('canvas.node.image.pickRefNodeHint', '已选 {{c}}/{{m}}', { c: referenceImages.length, m: maxRefs })}
+                    emptyText={t('canvas.node.image.noPickableNodes', '画布中没有可用的图像节点')}
+                    items={pickableNodes.map<NodePickerItem>(({ node, url }) => {
+                      const data = node.data as CharacterNodeData;
+                      const atLimit = referenceImages.length >= maxRefs;
+                      return {
+                        node,
+                        label: data.name || node.id.slice(0, 8),
+                        thumbUrl: url,
+                        disabled: atLimit,
+                      };
+                    })}
+                    onSelect={handleSelectNode}
+                  />
                 )}
               </div>
             )}

--- a/frontend/src/components/canvas/ImageNode.tsx
+++ b/frontend/src/components/canvas/ImageNode.tsx
@@ -928,7 +928,7 @@ const CharacterNode = ({ id, data, selected }: NodeProps<Node<CharacterNodeData>
           )}
         </div>
 
-        <Card className={`w-full h-full flex flex-col bg-card ${selected ? 'ring-2 ring-primary' : 'border border-border/50'} overflow-hidden relative z-[2]`}>
+        <Card className={`w-full h-full flex flex-col bg-card ${selected ? 'ring-2 ring-primary' : ''} overflow-hidden relative z-[2]`}>
           <CardContent 
             className="flex flex-col items-center justify-center relative custom-scrollbar flex-1 p-0 overflow-hidden" 
           >

--- a/frontend/src/components/canvas/NodePickerDropdown.tsx
+++ b/frontend/src/components/canvas/NodePickerDropdown.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import React from 'react';
+import { cn } from '@/lib/utils';
+import {
+  ImageIcon,
+  Film,
+  Music,
+  ScrollText,
+  Clapperboard,
+  FileText,
+  type LucideIcon,
+} from 'lucide-react';
+import type { CanvasNode } from '@/store/useCanvasStore';
+
+// ─── Shared node-type icon + color mapping ────────────────────────────────
+
+export interface NodeTypeConfig {
+  icon: LucideIcon;
+  color: string;
+  label: string;
+}
+
+export const NODE_TYPE_CONFIG: Record<string, NodeTypeConfig> = {
+  image:      { icon: ImageIcon,    color: 'text-node-green',  label: '图片' },
+  video:      { icon: Film,         color: 'text-amber-400',   label: '视频' },
+  audio:      { icon: Music,        color: 'text-teal-400',    label: '音频' },
+  text:       { icon: ScrollText,   color: 'text-node-blue',   label: '文本' },
+  storyboard: { icon: Clapperboard, color: 'text-node-purple', label: '分镜' },
+};
+
+export const DEFAULT_NODE_TYPE_CONFIG: NodeTypeConfig = {
+  icon: FileText,
+  color: 'text-muted-foreground',
+  label: '节点',
+};
+
+export const getNodeTypeConfig = (nodeType: string | undefined): NodeTypeConfig =>
+  NODE_TYPE_CONFIG[nodeType || ''] ?? DEFAULT_NODE_TYPE_CONFIG;
+
+// ─── Picker item shape ─────────────────────────────────────────────────────
+
+export interface NodePickerItem {
+  node: CanvasNode;
+  /** Display label for the node. */
+  label: string;
+  /** Thumbnail URL for image/video. Null for audio/text/storyboard. */
+  thumbUrl: string | null;
+  /** Disable interaction for this item. */
+  disabled?: boolean;
+}
+
+export interface NodePickerDropdownProps {
+  /** Whether the dropdown is visible. */
+  open: boolean;
+  /** Title text shown at top of panel. */
+  title: string;
+  /** Text shown when no items available. */
+  emptyText: string;
+  /** Items to render. */
+  items: NodePickerItem[];
+  /** Anchor direction — top opens downward, bottom opens upward. */
+  anchor?: 'top' | 'bottom';
+  /** Horizontal alignment. */
+  align?: 'left' | 'right';
+  /** Width Tailwind class (default w-56). */
+  widthClass?: string;
+  /** Max height Tailwind class (default max-h-60). */
+  maxHeightClass?: string;
+  /** Item click handler. */
+  onSelect: (node: CanvasNode) => void;
+}
+
+/**
+ * 统一的节点选择下拉面板（视觉基准：VideoGeneratePanel 原生下拉样式）。
+ * 仅渲染面板，不负责触发按钮或 open 状态。
+ */
+export function NodePickerDropdown({
+  open,
+  title,
+  emptyText,
+  items,
+  anchor = 'top',
+  align = 'right',
+  widthClass = 'w-56',
+  maxHeightClass = 'max-h-60',
+  onSelect,
+}: NodePickerDropdownProps) {
+  if (!open) return null;
+
+  const positionClass = anchor === 'bottom'
+    ? 'bottom-full mb-1'
+    : 'top-full mt-1';
+  const alignClass = align === 'right' ? 'right-0' : 'left-0';
+
+  return (
+    <div
+      className={cn(
+        'absolute z-50 overflow-y-auto rounded-lg border border-border/50 bg-popover shadow-lg',
+        'animate-in fade-in zoom-in-95 duration-100',
+        positionClass,
+        alignClass,
+        widthClass,
+        maxHeightClass,
+      )}
+    >
+      <div className="px-2 py-1.5 text-[10px] font-medium text-muted-foreground border-b border-border/50">
+        {title}
+      </div>
+      {items.length === 0 ? (
+        <div className="p-3 text-[10px] text-muted-foreground text-center">
+          {emptyText}
+        </div>
+      ) : (
+        items.map((item) => {
+          const { node, label, thumbUrl, disabled } = item;
+          const cfg = getNodeTypeConfig(node.type);
+          const TypeIcon = cfg.icon;
+          const isVideo = node.type === 'video';
+          const isAudio = node.type === 'audio';
+          const isImage = node.type === 'image';
+
+          return (
+            <button
+              key={node.id}
+              type="button"
+              onClick={() => !disabled && onSelect(node)}
+              disabled={disabled}
+              className={cn(
+                'w-full flex items-center gap-2 px-2 py-1.5 text-xs hover:bg-accent transition-colors cursor-pointer',
+                disabled && 'opacity-40 cursor-not-allowed',
+              )}
+            >
+              {/* Thumbnail / placeholder */}
+              {isVideo && thumbUrl ? (
+                <div className="h-8 w-12 rounded bg-muted shrink-0 overflow-hidden">
+                  <video src={thumbUrl} className="w-full h-full object-cover" preload="metadata" muted />
+                </div>
+              ) : isAudio ? (
+                <div className="h-8 w-8 rounded bg-muted shrink-0 flex items-center justify-center">
+                  <Music className="w-4 h-4 text-teal-400/60" />
+                </div>
+              ) : isImage && thumbUrl ? (
+                <img src={thumbUrl} alt="" className="h-8 w-8 rounded object-cover shrink-0" />
+              ) : (
+                <div className="h-8 w-8 rounded bg-muted shrink-0 flex items-center justify-center">
+                  <TypeIcon className={cn('w-4 h-4', cfg.color, 'opacity-70')} />
+                </div>
+              )}
+              {/* Label */}
+              <div className="flex flex-col min-w-0 flex-1 text-left">
+                <span className="font-medium truncate text-foreground">{label}</span>
+              </div>
+              {/* Type indicator */}
+              <TypeIcon className={cn('w-3 h-3 shrink-0', cfg.color)} />
+            </button>
+          );
+        })
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/canvas/StoryboardNode.tsx
+++ b/frontend/src/components/canvas/StoryboardNode.tsx
@@ -198,7 +198,7 @@ const StoryboardNode = ({ id, data, selected }: NodeProps<Node<StoryboardNodeDat
           </div>
         </div>
 
-        <Card className={`w-full h-full flex flex-col bg-card ${selected ? 'ring-2 ring-primary' : 'border border-border/50'} overflow-hidden relative z-[2] shadow-sm hover:shadow-md transition-all`}>
+        <Card className={`w-full h-full flex flex-col bg-card ${selected ? 'ring-2 ring-primary' : ''} overflow-hidden relative z-[2] transition-all`}>
           <CardContent className={`p-0 flex-1 flex flex-col bg-background/50 overflow-hidden ${isEditing ? 'nowheel' : ''}`}>
               {hasData ? (
                 <div

--- a/frontend/src/components/canvas/TextNode.tsx
+++ b/frontend/src/components/canvas/TextNode.tsx
@@ -232,7 +232,7 @@ const ScriptNode = ({ id, data, selected }: NodeProps<Node<ScriptNodeData>>) => 
           </div>
         </div>
 
-      <Card className={`w-full h-full flex flex-col bg-card ${selected && !isEditing ? 'ring-2 ring-primary' : 'border border-border/50'} overflow-hidden relative z-[2]`}>
+      <Card className={`w-full h-full flex flex-col bg-card ${selected && !isEditing ? 'ring-2 ring-primary' : ''} overflow-hidden relative z-[2]`}>
         <CardContent className="script-node__content p-0 flex-1 flex flex-col">
           <div className="text-sm text-foreground flex-1 min-h-[40px] flex flex-col">
             <ScriptEditor

--- a/frontend/src/components/canvas/VideoGeneratePanel.tsx
+++ b/frontend/src/components/canvas/VideoGeneratePanel.tsx
@@ -17,7 +17,9 @@ import {
   type VideoCreateParams,
 } from '@/hooks/useVideoGeneration';
 import type { CanvasNode, CharacterNodeData, VideoNodeData, AudioNodeData, VideoGenHistoryEntry } from '@/store/useCanvasStore';
+import { selectNodesByUpdatedDesc } from '@/store/useCanvasStore';
 import RefTagInput, { type RefTagInputRef, type RefImage, type RefType } from './RefTagInput';
+import { NodePickerDropdown, type NodePickerItem } from './NodePickerDropdown';
 
 // ---------------------------------------------------------------------------
 // Provider logo mapping
@@ -363,17 +365,17 @@ export default function VideoGeneratePanel({
   // Picker mode based on current video mode
   const pickerMode: PickerMode = PICKER_MODE_MAP[videoMode] || 'none';
 
-  // Available nodes from canvas
+  // Available nodes from canvas（按 updatedAt 倒序）
   const imageNodes = useMemo(
-    () => canvasNodes.filter((n) => n.type === 'image' && getImageNodeUrl(n)),
+    () => selectNodesByUpdatedDesc(canvasNodes.filter((n) => n.type === 'image' && getImageNodeUrl(n))),
     [canvasNodes],
   );
   const videoNodes = useMemo(
-    () => canvasNodes.filter((n) => n.type === 'video' && getVideoNodeUrl(n)),
+    () => selectNodesByUpdatedDesc(canvasNodes.filter((n) => n.type === 'video' && getVideoNodeUrl(n))),
     [canvasNodes],
   );
   const audioNodes = useMemo(
-    () => canvasNodes.filter((n) => n.type === 'audio' && getAudioNodeUrl(n)),
+    () => selectNodesByUpdatedDesc(canvasNodes.filter((n) => n.type === 'audio' && getAudioNodeUrl(n))),
     [canvasNodes],
   );
 
@@ -390,7 +392,7 @@ export default function VideoGeneratePanel({
   const videoRefCount = referenceImages.filter(r => r.refType === 'video').length;
   const audioRefCount = referenceImages.filter(r => r.refType === 'audio').length;
 
-  // Nodes to show in picker — multi_image shows mixed types for Seedance
+  // Nodes to show in picker — multi_image shows mixed types for Seedance（按 updatedAt 统一倒序）
   const pickerNodes = useMemo(() => {
     const isMulti = pickerMode === 'multi_image';
     const isVid = pickerMode === 'video';
@@ -399,7 +401,7 @@ export default function VideoGeneratePanel({
       ...(supportsRefVideos ? videoNodes : []),
       ...(supportsRefAudios ? audioNodes : []),
     ] : imageNodes;
-    return nodes;
+    return isMulti ? selectNodesByUpdatedDesc(nodes) : nodes;
   }, [pickerMode, imageNodes, videoNodes, audioNodes, supportsRefVideos, supportsRefAudios]);
 
   const hasPickerSelection =
@@ -652,7 +654,7 @@ export default function VideoGeneratePanel({
         {pickerMode === 'single_image' && imageUrl && (
           <div className="px-3 pt-2.5 pb-0">
             <div className="relative inline-block group/imgpreview">
-              <img src={imageUrl} alt="Reference" draggable={false} className="h-16 w-16 rounded-lg object-cover border border-border/50" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
+              <img src={imageUrl} alt="Reference" draggable={false} className="h-16 w-16 rounded-lg object-cover" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
               <button type="button" onClick={() => { unlinkNode(imageNodeIdRef.current); imageNodeIdRef.current = null; setImageUrl(''); }} className="absolute -top-1.5 -right-1.5 h-4 w-4 rounded-full bg-background border border-border/50 shadow-sm flex items-center justify-center opacity-0 group-hover/imgpreview:opacity-100 transition-opacity hover:bg-destructive hover:text-destructive-foreground">
                 <X className="h-2.5 w-2.5" />
               </button>
@@ -668,7 +670,7 @@ export default function VideoGeneratePanel({
           <div className="px-3 pt-2.5 pb-0 flex items-center gap-1.5">
             {/* First frame */}
             <div className="relative inline-block group/firstframe">
-              <img src={imageUrl} alt="First frame" draggable={false} className="h-16 w-16 rounded-lg object-cover border border-border/50" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
+              <img src={imageUrl} alt="First frame" draggable={false} className="h-16 w-16 rounded-lg object-cover" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
               <button type="button" onClick={() => { unlinkNode(imageNodeIdRef.current); unlinkNode(lastFrameNodeIdRef.current); imageNodeIdRef.current = null; lastFrameNodeIdRef.current = null; setImageUrl(''); setLastFrameImageUrl(''); }} className="absolute -top-1.5 -right-1.5 h-4 w-4 rounded-full bg-background border border-border/50 shadow-sm flex items-center justify-center opacity-0 group-hover/firstframe:opacity-100 transition-opacity hover:bg-destructive hover:text-destructive-foreground">
                 <X className="h-2.5 w-2.5" />
               </button>
@@ -681,7 +683,7 @@ export default function VideoGeneratePanel({
             {/* Last frame or placeholder */}
             {lastFrameImageUrl ? (
               <div className="relative inline-block group/lastframe">
-                <img src={lastFrameImageUrl} alt="Last frame" draggable={false} className="h-16 w-16 rounded-lg object-cover border border-border/50" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
+                <img src={lastFrameImageUrl} alt="Last frame" draggable={false} className="h-16 w-16 rounded-lg object-cover" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
                 <button type="button" onClick={() => { unlinkNode(lastFrameNodeIdRef.current); lastFrameNodeIdRef.current = null; setLastFrameImageUrl(''); }} className="absolute -top-1.5 -right-1.5 h-4 w-4 rounded-full bg-background border border-border/50 shadow-sm flex items-center justify-center opacity-0 group-hover/lastframe:opacity-100 transition-opacity hover:bg-destructive hover:text-destructive-foreground">
                   <X className="h-2.5 w-2.5" />
                 </button>
@@ -751,7 +753,7 @@ export default function VideoGeneratePanel({
                       <Music className="w-6 h-6 text-teal-400/60" />
                     </div>
                   ) : (ref.previewUrl || ref.url) && !(ref.url.startsWith('asset://') && !ref.previewUrl) ? (
-                    <img src={ref.previewUrl || ref.url} alt={ref.name} draggable={false} className="h-14 w-14 rounded-lg object-cover border border-border/50" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; (e.target as HTMLImageElement).nextElementSibling?.classList.remove('hidden'); }} />
+                    <img src={ref.previewUrl || ref.url} alt={ref.name} draggable={false} className="h-14 w-14 rounded-lg object-cover" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; (e.target as HTMLImageElement).nextElementSibling?.classList.remove('hidden'); }} />
                   ) : null}
                   {isImg && (
                     <div className={cn('h-14 w-14 rounded-lg border border-border/50 bg-muted flex items-center justify-center', (ref.previewUrl || (!ref.url.startsWith('asset://') && ref.url)) ? 'hidden absolute inset-0' : '')}>
@@ -950,60 +952,35 @@ export default function VideoGeneratePanel({
 
                 {/* Dropdown */}
                 {showNodePicker && (
-                  <div className="absolute bottom-full right-0 mb-1 w-56 max-h-60 overflow-y-auto rounded-lg border border-border/50 bg-popover shadow-lg z-50 animate-in fade-in zoom-in-95 duration-100">
-                    <div className="px-2 py-1.5 text-[10px] font-medium text-muted-foreground border-b border-border/50">
-                      {pickerMode === 'video'
-                        ? t('canvas.node.video.selectVideoNode')
-                        : pickerMode === 'multi_image'
-                          ? t('canvas.node.video.selectRefImages', { max: maxTotalRefs })
-                          : t('canvas.node.video.selectImageNode')}
-                    </div>
-                    {pickerNodes.map((node) => {
+                  <NodePickerDropdown
+                    open={showNodePicker}
+                    anchor="bottom"
+                    align="right"
+                    title={pickerMode === 'video'
+                      ? t('canvas.node.video.selectVideoNode')
+                      : pickerMode === 'multi_image'
+                        ? t('canvas.node.video.selectRefImages', { max: maxTotalRefs })
+                        : t('canvas.node.video.selectImageNode')}
+                    emptyText={pickerMode === 'video' ? t('canvas.node.video.noVideoNodes') : t('canvas.node.video.noImageNodes')}
+                    items={pickerNodes.map<NodePickerItem>((node) => {
                       const nt = node.type as string;
                       const isVideo = pickerMode === 'video' || nt === 'video';
                       const isAudio = nt === 'audio';
                       const data = node.data as Record<string, unknown>;
                       const label = ((data.name || node.id.slice(0, 8)) as string);
                       const thumbUrl = isVideo ? getVideoNodeUrl(node) : isAudio ? null : getImageNodeUrl(node);
-                      const NodeIcon = isVideo ? Film : isAudio ? Music : ImageIcon;
-                      const iconColor = isVideo ? 'text-amber-400' : isAudio ? 'text-teal-400' : 'text-node-green';
-                      // Check per-type limit
                       const atLimit = isVideo ? videoRefCount >= maxRefVideos
                         : isAudio ? audioRefCount >= maxRefAudios
                         : imageRefCount >= maxRefImages;
-                      return (
-                        <button
-                          key={node.id}
-                          type="button"
-                          onClick={() => handleSelectNode(node)}
-                          disabled={pickerMode === 'multi_image' && atLimit}
-                          className={cn(
-                            'w-full flex items-center gap-2 px-2 py-1.5 text-xs hover:bg-accent transition-colors cursor-pointer',
-                            pickerMode === 'multi_image' && atLimit && 'opacity-40 cursor-not-allowed',
-                          )}
-                        >
-                          {isAudio ? (
-                            <div className="h-8 w-8 rounded bg-muted border border-border/30 shrink-0 flex items-center justify-center">
-                              <Music className="w-4 h-4 text-teal-400/60" />
-                            </div>
-                          ) : thumbUrl && (
-                            isVideo
-                              ? <div className="h-8 w-12 rounded bg-muted border border-border/30 shrink-0 overflow-hidden"><video src={thumbUrl} className="w-full h-full object-cover" preload="metadata" muted /></div>
-                              : <img src={thumbUrl} alt="" className="h-8 w-8 rounded object-cover shrink-0 border border-border/30" />
-                          )}
-                          <div className="flex flex-col min-w-0 flex-1 text-left">
-                            <span className="font-medium truncate text-foreground">{label}</span>
-                          </div>
-                          <NodeIcon className={cn('w-3 h-3 shrink-0', iconColor)} />
-                        </button>
-                      );
+                      return {
+                        node,
+                        label,
+                        thumbUrl,
+                        disabled: pickerMode === 'multi_image' && atLimit,
+                      };
                     })}
-                    {pickerNodes.length === 0 && (
-                      <div className="p-3 text-[10px] text-muted-foreground text-center">
-                        {pickerMode === 'video' ? t('canvas.node.video.noVideoNodes') : t('canvas.node.video.noImageNodes')}
-                      </div>
-                    )}
-                  </div>
+                    onSelect={handleSelectNode}
+                  />
                 )}
               </div>
             )}
@@ -1028,37 +1005,22 @@ export default function VideoGeneratePanel({
                 </button>
 
                 {showNodePicker && (
-                  <div className="absolute bottom-full right-0 mb-1 w-56 max-h-60 overflow-y-auto rounded-lg border border-border/50 bg-popover shadow-lg z-50 animate-in fade-in zoom-in-95 duration-100">
-                    <div className="px-2 py-1.5 text-[10px] font-medium text-muted-foreground border-b border-border/50">
-                      {!imageUrl ? t('canvas.node.video.selectFirstFrame') : t('canvas.node.video.selectLastFrame')}
-                    </div>
-                    {imageNodes.map((node) => {
+                  <NodePickerDropdown
+                    open={showNodePicker}
+                    anchor="bottom"
+                    align="right"
+                    title={!imageUrl ? t('canvas.node.video.selectFirstFrame') : t('canvas.node.video.selectLastFrame')}
+                    emptyText={t('canvas.node.video.noImageNodes')}
+                    items={imageNodes.map<NodePickerItem>((node) => {
                       const data = node.data as Record<string, unknown>;
-                      const label = ((data.name || node.id.slice(0, 8)) as string);
-                      const thumbUrl = getImageNodeUrl(node);
-                      return (
-                        <button
-                          key={node.id}
-                          type="button"
-                          onClick={() => handleSelectNode(node)}
-                          className="w-full flex items-center gap-2 px-2 py-1.5 text-xs hover:bg-accent transition-colors cursor-pointer"
-                        >
-                          {thumbUrl && (
-                            <img src={thumbUrl} alt="" className="h-8 w-8 rounded object-cover shrink-0 border border-border/30" />
-                          )}
-                          <div className="flex flex-col min-w-0 flex-1 text-left">
-                            <span className="font-medium truncate text-foreground">{label}</span>
-                          </div>
-                          <ImageIcon className={cn('w-3 h-3 shrink-0 text-node-green')} />
-                        </button>
-                      );
+                      return {
+                        node,
+                        label: ((data.name || node.id.slice(0, 8)) as string),
+                        thumbUrl: getImageNodeUrl(node),
+                      };
                     })}
-                    {imageNodes.length === 0 && (
-                      <div className="p-3 text-[10px] text-muted-foreground text-center">
-                        {t('canvas.node.video.noImageNodes')}
-                      </div>
-                    )}
-                  </div>
+                    onSelect={handleSelectNode}
+                  />
                 )}
               </div>
             )}

--- a/frontend/src/components/canvas/VideoNode.tsx
+++ b/frontend/src/components/canvas/VideoNode.tsx
@@ -510,7 +510,7 @@ const VideoNode = ({ id, data, selected }: NodeProps<Node<VideoNodeData>>) => {
                   setEditTitle(e.target.value);
                   updateNodeData(id, { name: e.target.value });
                 }}
-                className="font-bold text-sm h-7 bg-transparent border-0 focus-visible:ring-0 focus-visible:ring-offset-0 focus:border-0 focus:outline-none px-0 shadow-none cursor-text select-text rounded-none leading-none"
+                className="font-bold text-sm h-7 bg-transparent border-0 focus-visible:ring-0 focus-visible:ring-offset-0 focus:border-0 focus:outline-none px-0 cursor-text select-text rounded-none leading-none"
                 placeholder={t('canvas.node.unnamedVideoCard')}
                 onClick={(e) => e.stopPropagation()}
                 onPointerDown={(e) => e.stopPropagation()}
@@ -531,7 +531,7 @@ const VideoNode = ({ id, data, selected }: NodeProps<Node<VideoNodeData>>) => {
           </div>
         </div>
 
-        <Card className={`w-full h-full flex flex-col bg-card ${selected ? 'ring-2 ring-primary' : 'border border-border/50'} overflow-hidden relative z-[2]`}>
+        <Card className={`w-full h-full flex flex-col bg-card ${selected ? 'ring-2 ring-primary' : ''} overflow-hidden relative z-[2]`}>
           <CardContent 
             className="flex flex-col items-center justify-center relative custom-scrollbar flex-1 p-0 overflow-hidden" 
           >
@@ -672,7 +672,7 @@ const VideoNode = ({ id, data, selected }: NodeProps<Node<VideoNodeData>>) => {
         {showAddMenu && (
           <div
             ref={addMenuRef}
-            className="absolute left-1/2 -translate-x-1/2 -top-[108px] flex items-center bg-background/95 backdrop-blur-md border border-border/60 rounded-full px-1 py-1 shadow-lg pointer-events-auto nodrag animate-in fade-in zoom-in-95 duration-150 z-30"
+            className="absolute left-1/2 -translate-x-1/2 -top-[108px] flex items-center bg-background/95 backdrop-blur-md border border-border/60 rounded-full px-1 py-1 pointer-events-auto nodrag animate-in fade-in zoom-in-95 duration-150 z-30"
           >
             <button
               className="w-7 h-7 flex items-center justify-center rounded-full text-muted-foreground hover:text-foreground hover:bg-secondary transition-all"
@@ -853,7 +853,7 @@ function VideoAssetPickerDialog({ currentUrl, onSelect, onClose, t }: VideoAsset
       onClick={onClose}
     >
       <div
-        className="bg-background border border-border/50 rounded-xl w-full max-w-lg max-h-[70vh] flex flex-col overflow-hidden shadow-xl animate-in zoom-in-95 duration-200"
+        className="bg-background border border-border/50 rounded-xl w-full max-w-lg max-h-[70vh] flex flex-col overflow-hidden animate-in zoom-in-95 duration-200"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between px-4 py-3 border-b border-border/50">

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      "rounded-lg border bg-card text-card-foreground",
       className
     )}
     {...props}

--- a/frontend/src/lib/nodeAttachmentUtils.ts
+++ b/frontend/src/lib/nodeAttachmentUtils.ts
@@ -21,6 +21,10 @@ export function extractPlainTextFromTiptap(json: unknown, maxLength = 150): stri
   return text.length > maxLength ? text.slice(0, maxLength) + '...' : text;
 }
 
+/** 读取节点 data.updatedAt（源自 useCanvasStore 的 addNode/updateNodeData 注入） */
+const readUpdatedAt = (node: CanvasNode): string | undefined =>
+  (node.data as { updatedAt?: string })?.updatedAt;
+
 /**
  * 节点 → 附件数据映射表（按节点类型提取）
  */
@@ -36,6 +40,7 @@ const NODE_ATTACHMENT_EXTRACTORS: Record<string, (node: CanvasNode) => NodeAttac
       excerpt: raw.length > 150 ? raw.slice(0, 150) + '...' : raw,
       thumbnailUrl: null,
       meta: { tags: data.tags, fullText },
+      updatedAt: readUpdatedAt(node),
     };
   },
   image: (node) => {
@@ -52,6 +57,7 @@ const NODE_ATTACHMENT_EXTRACTORS: Record<string, (node: CanvasNode) => NodeAttac
       excerpt: data.description || '',
       thumbnailUrl,
       meta: { uploading: data.uploading },
+      updatedAt: readUpdatedAt(node),
     };
   },
   video: (node) => {
@@ -69,6 +75,7 @@ const NODE_ATTACHMENT_EXTRACTORS: Record<string, (node: CanvasNode) => NodeAttac
       excerpt: data.description || '',
       thumbnailUrl,
       meta: { fitMode: data.fitMode, uploading: data.uploading },
+      updatedAt: readUpdatedAt(node),
     };
   },
   storyboard: (node) => {
@@ -145,6 +152,7 @@ const NODE_ATTACHMENT_EXTRACTORS: Record<string, (node: CanvasNode) => NodeAttac
         tableColumns,
         tableData,
       },
+      updatedAt: readUpdatedAt(node),
     };
   },
 };
@@ -161,5 +169,6 @@ export function extractNodeAttachment(node: CanvasNode): NodeAttachment {
     excerpt: '',
     thumbnailUrl: null,
     meta: {},
+    updatedAt: readUpdatedAt(node),
   };
 }

--- a/frontend/src/store/useAIAssistantStore.ts
+++ b/frontend/src/store/useAIAssistantStore.ts
@@ -118,7 +118,14 @@ export interface NodeAttachment {
   excerpt: string;        // 文本摘要或描述
   thumbnailUrl: string | null;  // 图片/视频缩略图URL
   meta: Record<string, unknown>; // 额外元数据
+  updatedAt?: string;     // 源节点修改时间（用于排序）
 }
+
+// 按 updatedAt 倒序（最新在前）并裁剪到最多 5 条
+const sortAttachmentsByUpdatedDesc = (attachments: NodeAttachment[]): NodeAttachment[] =>
+  [...attachments]
+    .sort((a, b) => (b.updatedAt ?? '').localeCompare(a.updatedAt ?? ''))
+    .slice(0, 5);
 
 // 用户上传的文件
 export interface UploadedFile {
@@ -425,12 +432,17 @@ export const useAIAssistantStore = create<AIAssistantState>()(
       clearImageEditContext: () => set({ imageEditContext: null }),
 
       // Node attachments (多图支持，最多5个，互斥：清除 imageEditContext)
-      setNodeAttachments: (nodeAttachments: NodeAttachment[]) => set({ nodeAttachments: nodeAttachments.slice(0, 5), imageEditContext: null }),
+      setNodeAttachments: (nodeAttachments: NodeAttachment[]) => set({
+        nodeAttachments: sortAttachmentsByUpdatedDesc(nodeAttachments),
+        imageEditContext: null,
+      }),
       addNodeAttachment: (attachment: NodeAttachment) => set((state) => {
         const exists = state.nodeAttachments.some(a => a.nodeId === attachment.nodeId);
         if (exists) return state;
-        const newAttachments = [...state.nodeAttachments, attachment].slice(0, 5);
-        return { nodeAttachments: newAttachments, imageEditContext: null };
+        return {
+          nodeAttachments: sortAttachmentsByUpdatedDesc([...state.nodeAttachments, attachment]),
+          imageEditContext: null,
+        };
       }),
       removeNodeAttachment: (nodeId: string) => set((state) => ({
         nodeAttachments: state.nodeAttachments.filter(a => a.nodeId !== nodeId)

--- a/frontend/src/store/useCanvasStore.ts
+++ b/frontend/src/store/useCanvasStore.ts
@@ -30,6 +30,8 @@ export type ScriptNodeData = {
   tags: string[];
   characters?: string[];
   scenes?: string;
+  /** 最后修改时间（ISO 字符串），用于节点选择器排序 */
+  updatedAt?: string;
 };
 
 export type ImageGenHistoryEntry = {
@@ -57,6 +59,8 @@ export type CharacterNodeData = {
   initialGenConfig?: Partial<ImageGenHistoryEntry>;
   /** 为 true 时 ImageGeneratePanel 始终显示 */
   pinPanel?: boolean;
+  /** 最后修改时间（ISO 字符串），用于节点选择器排序 */
+  updatedAt?: string;
 };
 
 export type StoryboardNodeData = {
@@ -69,6 +73,8 @@ export type StoryboardNodeData = {
   tableData?: Record<string, unknown>[]; // Raw table rows provided by Agent
   tableColumns?: { key: string; label: string; type?: 'text' | 'number' | 'image' | 'video' | 'audio' }[]; // Column definitions from Agent
   _streaming?: boolean; // Transient flag: node is being streamed from LLM deltas
+  /** 最后修改时间（ISO 字符串），用于节点选择器排序 */
+  updatedAt?: string;
 };
 
 export type VideoGenHistoryEntry = {
@@ -94,6 +100,8 @@ export type VideoNodeData = {
   initialGenConfig?: Partial<VideoGenHistoryEntry>;
   /** When true, keep VideoGeneratePanel always visible regardless of selection */
   pinPanel?: boolean;
+  /** 最后修改时间（ISO 字符串），用于节点选择器排序 */
+  updatedAt?: string;
 };
 
 export type AudioNodeData = {
@@ -102,6 +110,8 @@ export type AudioNodeData = {
   audioUrl?: string | null;
   uploading?: boolean;
   lyrics?: string;
+  /** 最后修改时间（ISO 字符串），用于节点选择器排序 */
+  updatedAt?: string;
 };
 
 export type GhostNodeData = {
@@ -332,7 +342,12 @@ export const useCanvasStore = create<CanvasState>()(
         if (nodes.some((n) => n.id === node.id)) {
           return;
         }
-        set({ nodes: [...nodes, node], isDirty: true });
+        // 自动写入 updatedAt（若未提供）
+        const existingUpdatedAt = (node.data as { updatedAt?: string })?.updatedAt;
+        const stamped: CanvasNode = existingUpdatedAt
+          ? node
+          : { ...node, data: { ...node.data, updatedAt: new Date().toISOString() } };
+        set({ nodes: [...nodes, stamped], isDirty: true });
         get().takeSnapshot();
       },
 
@@ -381,9 +396,10 @@ export const useCanvasStore = create<CanvasState>()(
       },
 
       updateNodeData: (id: string, data: Partial<ScriptNodeData | CharacterNodeData | StoryboardNodeData | VideoNodeData | AudioNodeData>) => {
+        const now = new Date().toISOString();
         set({
           nodes: get().nodes.map((node) =>
-            node.id === id ? { ...node, data: { ...node.data, ...data } } : node
+            node.id === id ? { ...node, data: { ...node.data, ...data, updatedAt: now } } : node
           ),
           isDirty: true,
         });
@@ -797,3 +813,15 @@ export const useCanvasStore = create<CanvasState>()(
     }
   )
 );
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+/**
+ * 按 node.data.updatedAt 倒序排序（最新修改的在前）。
+ * 缺失 updatedAt 的节点会排到最后。
+ */
+export const selectNodesByUpdatedDesc = <T extends CanvasNode>(nodes: T[]): T[] =>
+  [...nodes].sort((a, b) => {
+    const ta = (a.data as { updatedAt?: string })?.updatedAt ?? '';
+    const tb = (b.data as { updatedAt?: string })?.updatedAt ?? '';
+    return tb.localeCompare(ta);
+  });


### PR DESCRIPTION
- 添加 DashScope 适配器，支持多个 HappyHorse 模型
- 实现本地媒体文件上传 OSS 策略，替代 base64 编码
- 后端视频提交和轮询接口支持 base_url 覆盖
- 更新视频服务注册表，支持 DashScope 供应商识别
- 修改本地媒体文件处理逻辑，适应 DashScope 需求
- 修改前端相关组件，优化节点选择器 UX 和排序逻辑
- 移除部分冗余图标及样式调整，提高界面简洁度
- 增强适配器日志和错误处理，提升鲁棒性