### PR TITLE
feat(admin): 将仪表盘及管理页面国际化支持接入 i18next

### DIFF
--- a/backend/admin/next-env.d.ts
+++ b/backend/admin/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/backend/admin/src/app/admin/agents/[id]/page.tsx
+++ b/backend/admin/src/app/admin/agents/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
 import { ArrowLeft, Save, Settings } from 'lucide-react';
 import AgentForm from '@/components/admin/agents/AgentForm';
 import { useAgent, useCreateAgent, useUpdateAgent } from '@/hooks/useAgents';
@@ -19,6 +20,7 @@ const ChatInterface = dynamic(() => import('@/components/admin/agents/ChatInterf
 export default function AgentDetailPage() {
   const router = useRouter();
   const params = useParams();
+  const { t } = useTranslation();
   const id = params?.id as string;
   const isNew = id === 'new';
 
@@ -37,13 +39,13 @@ export default function AgentDetailPage() {
         ? createAgent(values).then(res => router.replace(`/admin/agents/${res.data.id}`))
         : updateAgent(id, values).then(() => mutate());
       await action;
-      toast({ title: isNew ? '创建成功' : '更新成功' });
+      toast({ title: isNew ? t('agents.toast.createSuccess') : t('agents.toast.updateSuccess') });
     } catch (err: any) {
       console.error(err);
       toast({ 
         variant: "destructive",
-        title: '操作失败',
-        description: err.response?.data?.detail || '未知错误'
+        title: t('agents.toast.submitFailed'),
+        description: err.response?.data?.detail || t('agents.toast.unknownError')
       });
     } finally {
       setSaving(false);
@@ -56,15 +58,15 @@ export default function AgentDetailPage() {
 
   // Loading state
   if (isLoading && !isNew) {
-    return <div className="h-full flex items-center justify-center">Loading...</div>;
+    return <div className="h-full flex items-center justify-center">{t('agents.header.loading')}</div>;
   }
 
   // Error state
   if (error && !isNew) {
     return (
       <div className="h-full flex flex-col items-center justify-center gap-4">
-        <h1 className="text-2xl font-bold">Agent Not Found</h1>
-        <Button onClick={() => router.push('/admin/agents')}>Back Home</Button>
+        <h1 className="text-2xl font-bold">{t('agents.header.notFound')}</h1>
+        <Button onClick={() => router.push('/admin/agents')}>{t('agents.header.backHome')}</Button>
       </div>
     );
   }
@@ -73,7 +75,7 @@ export default function AgentDetailPage() {
   if (isNew) {
     return (
       <div className="h-full flex flex-col">
-        <Header title="创建新智能体" saving={saving} onSave={handleSave} onBack={() => router.push('/admin/agents')} />
+        <Header title={t('agents.header.newAgent')} saving={saving} onSave={handleSave} onBack={() => router.push('/admin/agents')} />
         <div className="flex-1 overflow-y-auto bg-muted/20">
           <div className="max-w-7xl mx-auto py-12 px-6">
             <div className="bg-card rounded-xl border shadow-sm p-8">
@@ -96,7 +98,7 @@ export default function AgentDetailPage() {
             <div className="p-6  max-w-3xl mx-auto">
               <div className="flex items-center gap-2 mb-6 font-medium">
                 <Settings className="h-5 w-5" />
-                <span>配置</span>
+                <span>{t('agents.header.config')}</span>
               </div>
               <AgentForm initialValues={agent} onSubmit={handleSubmit} onFormInstanceReady={setFormInstance} />
             </div>
@@ -121,6 +123,7 @@ function Header({ title, subtitle, saving, onSave, onBack }: {
   onSave: () => void; 
   onBack: () => void;
 }) {
+  const { t } = useTranslation();
   return (
     <div className="h-16 border-b flex items-center justify-between px-6 shrink-0">
       <div className="flex items-center gap-4">
@@ -129,14 +132,14 @@ function Header({ title, subtitle, saving, onSave, onBack }: {
         </Button>
         <div className="h-6 w-[1px] bg-border mx-1" />
         <div className="flex flex-col">
-          <span className="font-semibold text-lg leading-tight">{title || 'Loading...'}</span>
+          <span className="font-semibold text-lg leading-tight">{title || t('agents.header.loading')}</span>
           {subtitle && <span className="text-xs text-muted-foreground">{subtitle}</span>}
         </div>
       </div>
       <div className="flex gap-3">
-        <Button variant="outline" onClick={onBack}>取消</Button>
+        <Button variant="outline" onClick={onBack}>{t('agents.header.cancel')}</Button>
         <Button onClick={onSave} disabled={saving}>
-          {saving ? '保存中...' : <><Save className="mr-2 h-4 w-4" /> 保存</>}
+          {saving ? t('agents.header.saving') : <><Save className="mr-2 h-4 w-4" /> {t('agents.header.save')}</>}
         </Button>
       </div>
     </div>

--- a/backend/admin/src/app/admin/agents/page.tsx
+++ b/backend/admin/src/app/admin/agents/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
 import { useAgents, useDeleteAgent } from '@/hooks/useAgents';
 import { useLLMProviders } from '@/hooks/useLLMProviders';
 import { Agent } from '@/types';
@@ -38,6 +39,7 @@ import { Plus, Pencil, Trash2, Search, Bot } from 'lucide-react';
 
 export default function AgentsPage() {
   const router = useRouter();
+  const { t } = useTranslation();
   const [searchText, setSearchText] = useState('');
   const [pagination, setPagination] = useState({ current: 1, pageSize: 20 });
   const { toast } = useToast();
@@ -50,14 +52,14 @@ export default function AgentsPage() {
     try {
       await deleteAgent(id);
       toast({
-        title: "智能体删除成功",
+        title: t('agents.toast.deleteSuccess'),
       });
       mutate();
     } catch (err: any) {
       toast({
         variant: "destructive",
-        title: "删除失败",
-        description: err.response?.data?.detail || '未知错误',
+        title: t('agents.toast.deleteFailed'),
+        description: err.response?.data?.detail || t('agents.toast.unknownError'),
       });
     }
   };
@@ -66,15 +68,15 @@ export default function AgentsPage() {
     <div className="max-w-[1200px] mx-auto w-full space-y-6 animate-in fade-in duration-500">
       <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
         <div>
-          <h2 className="text-3xl font-bold tracking-tight">智能体管理</h2>
-          <p className="text-muted-foreground">创建、配置和管理您的 AI 智能体</p>
+          <h2 className="text-3xl font-bold tracking-tight">{t('agents.title')}</h2>
+          <p className="text-muted-foreground">{t('agents.subtitle')}</p>
         </div>
         
         <div className="flex items-center gap-2">
            <div className="relative">
              <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
              <Input 
-               placeholder="搜索智能体..." 
+               placeholder={t('agents.searchPlaceholder')}
                className="pl-9 w-[200px]"
                onChange={(e) => setSearchText(e.target.value)}
              />
@@ -82,7 +84,7 @@ export default function AgentsPage() {
 
                       
            <Button onClick={() => router.push('/admin/agents/new')}>
-             <Plus className="mr-2 h-4 w-4" /> 创建智能体
+             <Plus className="mr-2 h-4 w-4" /> {t('agents.create')}
            </Button>
         </div>
       </div>
@@ -92,19 +94,19 @@ export default function AgentsPage() {
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead>名称</TableHead>
-                  <TableHead>模型配置</TableHead>
-                  <TableHead>参数</TableHead>
-                  <TableHead>能力</TableHead>
-                  <TableHead>创建时间</TableHead>
-                  <TableHead className="text-right">操作</TableHead>
+                  <TableHead>{t('agents.table.name')}</TableHead>
+                  <TableHead>{t('agents.table.model')}</TableHead>
+                  <TableHead>{t('agents.table.params')}</TableHead>
+                  <TableHead>{t('agents.table.capabilities')}</TableHead>
+                  <TableHead>{t('agents.table.createdAt')}</TableHead>
+                  <TableHead className="text-right">{t('agents.table.actions')}</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
                 {isLoading ? (
                   <TableRow>
                     <TableCell colSpan={6} className="h-24 text-center">
-                      加载中...
+                      {t('agents.loading')}
                     </TableCell>
                   </TableRow>
                 ) : agents?.map((agent: Agent) => {
@@ -129,11 +131,11 @@ export default function AgentsPage() {
                       <TableCell>
                         <div className="flex flex-col gap-1">
                           <div className="flex items-center gap-2">
-                            <span className="text-xs text-muted-foreground">供应商</span>
+                            <span className="text-xs text-muted-foreground">{t('agents.table.provider')}</span>
                             <Badge variant="outline" className="font-normal">{provider?.name || 'Unknown'}</Badge>
                           </div>
                           <div className="flex items-center gap-2">
-                            <span className="text-xs text-muted-foreground">模型</span>
+                            <span className="text-xs text-muted-foreground">{t('agents.table.modelLabel')}</span>
                             <span className="text-sm font-medium">{agent.model}</span>
                           </div>
                         </div>
@@ -141,11 +143,11 @@ export default function AgentsPage() {
                       <TableCell>
                         <div className="space-y-1">
                            <div className="flex justify-between text-xs w-32">
-                             <span className="text-muted-foreground">温度</span>
+                             <span className="text-muted-foreground">{t('agents.table.temperature')}</span>
                              <span className="font-mono">{agent.temperature}</span>
                            </div>
                            <div className="flex justify-between text-xs w-32">
-                             <span className="text-muted-foreground">上下文</span>
+                             <span className="text-muted-foreground">{t('agents.table.contextWindow')}</span>
                              <span className="font-mono">{agent.context_window / 1024}k</span>
                            </div>
                         </div>
@@ -153,13 +155,13 @@ export default function AgentsPage() {
                       <TableCell>
                         <div className="flex flex-wrap gap-1 max-w-[200px]">
                           {agent.tools && agent.tools.length > 0 ? (
-                             agent.tools.map(t => (
-                              <Badge key={t} variant="secondary" className="text-xs">
-                                 {t}
+                             agent.tools.map(tn => (
+                              <Badge key={tn} variant="secondary" className="text-xs">
+                                 {tn}
                                </Badge>
                              ))
                           ) : (
-                             <span className="text-muted-foreground text-xs">无工具</span>
+                             <span className="text-muted-foreground text-xs">{t('agents.noTools')}</span>
                           )}
                         </div>
                       </TableCell>
@@ -175,7 +177,7 @@ export default function AgentsPage() {
                                   <Pencil className="h-4 w-4" />
                                 </Button>
                               </TooltipTrigger>
-                              <TooltipContent>编辑</TooltipContent>
+                              <TooltipContent>{t('agents.table.editTooltip')}</TooltipContent>
                             </Tooltip>
                           </TooltipProvider>
                           
@@ -187,14 +189,14 @@ export default function AgentsPage() {
                             </AlertDialogTrigger>
                             <AlertDialogContent>
                               <AlertDialogHeader>
-                                <AlertDialogTitle>确认删除？</AlertDialogTitle>
+                                <AlertDialogTitle>{t('agents.delete.title')}</AlertDialogTitle>
                                 <AlertDialogDescription>
-                                  此操作不可撤销。
+                                  {t('agents.delete.description', { name: agent.name })}
                                 </AlertDialogDescription>
                               </AlertDialogHeader>
                               <AlertDialogFooter>
-                                <AlertDialogCancel>取消</AlertDialogCancel>
-                                <AlertDialogAction onClick={() => agent.id && handleDelete(agent.id)}>确认删除</AlertDialogAction>
+                                <AlertDialogCancel>{t('agents.delete.cancel')}</AlertDialogCancel>
+                                <AlertDialogAction onClick={() => agent.id && handleDelete(agent.id)}>{t('agents.delete.confirm')}</AlertDialogAction>
                               </AlertDialogFooter>
                             </AlertDialogContent>
                           </AlertDialog>

--- a/backend/admin/src/app/admin/llm/[id]/page.tsx
+++ b/backend/admin/src/app/admin/llm/[id]/page.tsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import useSWR from 'swr';
 import { useParams } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
 import api from '@/lib/axios';
 import { ProviderForm } from '../components/provider-form';
 import { Loader2 } from 'lucide-react';
@@ -14,10 +15,8 @@ const fetcher = (url: string) => api.get(url).then((res) => res.data);
 export default function EditLLMProviderPage() {
   const params = useParams();
   const id = params?.id as string;
-  
-  // 尝试获取列表并在前端查找，以兼容可能不支持单条查询的后端
-  // 如果后端支持 /admin/llm-providers/:id，可以直接用那个接口
-  // 为了保险起见，这里先用列表接口
+  const { t } = useTranslation();
+
   const { data: providers, error, isLoading } = useSWR('/admin/llm-providers/', fetcher);
 
   if (isLoading) {
@@ -31,7 +30,7 @@ export default function EditLLMProviderPage() {
   if (error) {
     return (
       <div className="flex min-h-[60vh] w-full items-center justify-center text-destructive">
-        加载失败，请刷新重试
+        {t('llm.edit.loadFailed')}
       </div>
     );
   }
@@ -41,7 +40,7 @@ export default function EditLLMProviderPage() {
   if (!provider) {
     return (
       <div className="flex min-h-[60vh] w-full items-center justify-center text-muted-foreground">
-        未找到该供应商
+        {t('llm.edit.notFound')}
       </div>
     );
   }

--- a/backend/admin/src/app/admin/llm/components/provider-form.tsx
+++ b/backend/admin/src/app/admin/llm/components/provider-form.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useForm, useFieldArray } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
+import { useTranslation } from 'react-i18next';
 import api from '@/lib/axios';
 import { mutate } from 'swr';
 import { Button } from '@/components/ui/button';
@@ -31,7 +32,7 @@ import { Badge } from "@/components/ui/badge";
 import { useToast } from '@/components/ui/use-toast';
 import { Plus, Trash2, Plug, X, ChevronDown, ChevronRight, Save, ArrowLeft } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { PRESET_COST_DIMENSIONS, MODEL_TYPE_OPTIONS, PROVIDER_OPTIONS, formSchema, LLMProvider } from '../schema';
+import { PRESET_COST_DIMENSIONS, MODEL_TYPE_OPTIONS, PROVIDER_OPTIONS, createFormSchema, FormValues, LLMProvider } from '../schema';
 
 interface ProviderFormProps {
   initialData?: LLMProvider;
@@ -40,14 +41,17 @@ interface ProviderFormProps {
 export function ProviderForm({ initialData }: ProviderFormProps) {
   const router = useRouter();
   const { toast } = useToast();
+  const { t } = useTranslation();
   const [isTesting, setIsTesting] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [tagInput, setTagInput] = useState("");
   const [modelCosts, setModelCosts] = useState<Record<string, Record<string, number>>>(initialData?.model_costs || {});
   const [expandedModels, setExpandedModels] = useState<Record<string, boolean>>({});
 
-  const form = useForm<z.infer<typeof formSchema>>({
-    resolver: zodResolver(formSchema),
+  const formSchema = useMemo(() => createFormSchema(t), [t]);
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema) as any,
     defaultValues: {
       name: initialData?.name || "",
       provider_type: initialData?.provider_type || "",
@@ -71,19 +75,19 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
     try {
       const values = await form.trigger();
       if (!values) return;
-      
+
       const data = form.getValues();
       if (!data.models || data.models.length === 0 || !data.models[0].value) {
         toast({
           variant: "destructive",
-          title: "请至少添加一个模型进行测试",
+          title: t('llm.form.toast.selectModelForTest'),
         });
         return;
       }
-      
+
       setIsTesting(true);
       const testModel = data.models[0].value;
-      
+
       const payload = {
         provider_type: data.provider_type,
         api_key: data.api_key,
@@ -93,24 +97,24 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
       };
 
       const res = await api.post('/admin/llm-providers/test-connection', payload);
-      
+
       if (res.data.success) {
         toast({
-          title: "连接成功",
-          description: `回复：${res.data.response}`,
+          title: t('llm.form.toast.testSuccess'),
+          description: t('llm.form.toast.testSuccessDesc', { response: res.data.response }),
         });
       } else {
         toast({
           variant: "destructive",
-          title: "连接失败",
+          title: t('llm.form.toast.testFailed'),
           description: res.data.message,
         });
       }
     } catch (err: any) {
       toast({
         variant: "destructive",
-        title: "测试失败",
-        description: err.message || '未知错误',
+        title: t('llm.form.toast.testError'),
+        description: err.message || t('llm.form.toast.unknownError'),
       });
     } finally {
       setIsTesting(false);
@@ -152,17 +156,17 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
 
       if (initialData) {
         await api.put(`/admin/llm-providers/${initialData.id}`, submitValues);
-        toast({ title: "供应商更新成功" });
+        toast({ title: t('llm.form.toast.updateSuccess') });
       } else {
         await api.post('/admin/llm-providers', submitValues);
-        toast({ title: "供应商创建成功" });
+        toast({ title: t('llm.form.toast.createSuccess') });
       }
       mutate('/admin/llm-providers/');
       router.push('/admin/llm');
-    } catch (err) {
+    } catch {
       toast({
         variant: "destructive",
-        title: "操作失败",
+        title: t('llm.form.toast.submitFailed'),
       });
     } finally {
       setIsSaving(false);
@@ -170,7 +174,7 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
   };
 
   const handleSave = () => {
-    form.handleSubmit(onSubmit)();
+    form.handleSubmit(onSubmit as any)();
   };
 
   return (
@@ -178,35 +182,35 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-3xl font-bold tracking-tight">{initialData ? "编辑供应商" : "创建供应商"}</h2>
-          <p className="text-muted-foreground mt-1">配置 LLM 供应商的基础信息、模型参数及连接认证。</p>
+          <h2 className="text-3xl font-bold tracking-tight">{initialData ? t('llm.form.editTitle') : t('llm.form.createTitle')}</h2>
+          <p className="text-muted-foreground mt-1">{t('llm.form.subtitle')}</p>
         </div>
         <div className="flex gap-3 items-center">
-          {initialData && <span className="text-xs text-muted-foreground mr-2">ID: {initialData.id}</span>}
+          {initialData && <span className="text-xs text-muted-foreground mr-2">{t('llm.form.idLabel', { id: initialData.id })}</span>}
           <Button type="button" variant="outline" onClick={handleTestConnection} disabled={isTesting}>
             {isTesting ? <div className="animate-spin mr-2 h-4 w-4 border-2 border-current border-t-transparent rounded-full" /> : <Plug className="mr-2 h-4 w-4" />}
-            测试连接
+            {t('llm.form.testConnection')}
           </Button>
           <Button variant="outline" onClick={() => router.back()}>
-            <ArrowLeft className="mr-2 h-4 w-4" /> 返回
+            <ArrowLeft className="mr-2 h-4 w-4" /> {t('llm.form.back')}
           </Button>
           <Button onClick={handleSave} disabled={isSaving}>
-            {isSaving ? '保存中...' : <><Save className="mr-2 h-4 w-4" /> 保存</>}
+            {isSaving ? t('llm.form.saving') : <><Save className="mr-2 h-4 w-4" /> {t('llm.form.save')}</>}
           </Button>
         </div>
       </div>
 
       {/* Content: Left-Right layout */}
       <Form {...form}>
-        <form onSubmit={form.handleSubmit(onSubmit)}>
+        <form onSubmit={form.handleSubmit(onSubmit as any)}>
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             {/* ==================== Left Column ==================== */}
             <div className="space-y-6">
               {/* 基本信息 */}
               <Card>
                 <CardHeader>
-                  <CardTitle>基本信息</CardTitle>
-                  <CardDescription>配置供应商的名称、品牌和标签。</CardDescription>
+                  <CardTitle>{t('llm.form.basic.title')}</CardTitle>
+                  <CardDescription>{t('llm.form.basic.description')}</CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-4">
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -215,9 +219,9 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
                       name="name"
                       render={({ field }) => (
                         <FormItem>
-                          <FormLabel>名称</FormLabel>
+                          <FormLabel>{t('llm.form.basic.name')}</FormLabel>
                           <FormControl>
-                            <Input placeholder="输入名称 (如 OpenAI)" {...field} />
+                            <Input placeholder={t('llm.form.basic.namePlaceholder')} {...field} />
                           </FormControl>
                           <FormMessage />
                         </FormItem>
@@ -228,11 +232,11 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
                       name="provider_type"
                       render={({ field }) => (
                         <FormItem>
-                          <FormLabel>品牌</FormLabel>
+                          <FormLabel>{t('llm.form.basic.brand')}</FormLabel>
                           <Select onValueChange={field.onChange} defaultValue={field.value} value={field.value}>
                             <FormControl>
                               <SelectTrigger>
-                                <SelectValue placeholder="选择品牌" />
+                                <SelectValue placeholder={t('llm.form.basic.brandPlaceholder')} />
                               </SelectTrigger>
                             </FormControl>
                             <SelectContent>
@@ -259,7 +263,7 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
                     name="tags"
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel>标签</FormLabel>
+                        <FormLabel>{t('llm.form.basic.tags')}</FormLabel>
                         <FormControl>
                           <div className="flex flex-wrap items-center gap-2 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 min-h-[2.5rem]">
                             {field.value?.map((tag, index) => (
@@ -277,7 +281,7 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
                             ))}
                             <input
                               className="flex-1 bg-transparent outline-none placeholder:text-muted-foreground min-w-[120px]"
-                              placeholder={field.value?.length ? "" : "输入标签后按回车添加"}
+                              placeholder={field.value?.length ? "" : t('llm.form.basic.tagsPlaceholder')}
                               value={tagInput}
                               onChange={(e) => setTagInput(e.target.value)}
                               onKeyDown={(e) => {
@@ -300,7 +304,7 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
                             />
                           </div>
                         </FormControl>
-                        <FormDescription>用于分类和筛选，支持多个标签。</FormDescription>
+                        <FormDescription>{t('llm.form.basic.tagsDescription')}</FormDescription>
                         <FormMessage />
                       </FormItem>
                     )}
@@ -311,8 +315,8 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
               {/* 连接与认证 */}
               <Card>
                 <CardHeader>
-                  <CardTitle>连接与认证</CardTitle>
-                  <CardDescription>配置 API 密钥和高级选项。</CardDescription>
+                  <CardTitle>{t('llm.form.connection.title')}</CardTitle>
+                  <CardDescription>{t('llm.form.connection.description')}</CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-4">
                   <FormField
@@ -320,11 +324,11 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
                     name="base_url"
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel>基础 URL (选填)</FormLabel>
+                        <FormLabel>{t('llm.form.connection.baseUrl')}</FormLabel>
                         <FormControl>
-                          <Input placeholder="例如 https://api.openai.com/v1" {...field} />
+                          <Input placeholder={t('llm.form.connection.baseUrlPlaceholder')} {...field} />
                         </FormControl>
-                        <FormDescription>如果使用代理或自定义端点，请填写此项。</FormDescription>
+                        <FormDescription>{t('llm.form.connection.baseUrlDescription')}</FormDescription>
                         <FormMessage />
                       </FormItem>
                     )}
@@ -335,9 +339,9 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
                     name="api_key"
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel>API 密钥</FormLabel>
+                        <FormLabel>{t('llm.form.connection.apiKey')}</FormLabel>
                         <FormControl>
-                          <Input type="password" placeholder="sk-..." {...field} />
+                          <Input type="password" placeholder={t('llm.form.connection.apiKeyPlaceholder')} {...field} />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -349,11 +353,11 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
                     name="config_json"
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel>高级配置 (JSON)</FormLabel>
+                        <FormLabel>{t('llm.form.connection.advancedConfig')}</FormLabel>
                         <FormControl>
                           <Textarea
                             rows={5}
-                            placeholder='{"timeout": 30, "max_retries": 3}'
+                            placeholder={t('llm.form.connection.advancedConfigPlaceholder')}
                             className="font-mono text-sm"
                             {...field}
                           />
@@ -370,8 +374,8 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
             <div className="space-y-6">
               <Card>
                 <CardHeader>
-                  <CardTitle>模型配置</CardTitle>
-                  <CardDescription>添加支持的模型及其成本信息。</CardDescription>
+                  <CardTitle>{t('llm.form.models.title')}</CardTitle>
+                  <CardDescription>{t('llm.form.models.description')}</CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-6">
                   <div className="space-y-4">
@@ -383,7 +387,7 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
                           render={({ field }) => (
                             <FormItem className="flex-1">
                               <FormControl>
-                                <Input placeholder="模型名称 (例如 gpt-4)" {...field} />
+                                <Input placeholder={t('llm.form.models.modelNamePlaceholder')} {...field} />
                               </FormControl>
                               <FormMessage />
                             </FormItem>
@@ -395,7 +399,7 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
                           render={({ field }) => (
                             <FormItem className="w-[140px]">
                               <FormControl>
-                                <Input placeholder="别称（选填）" {...field} />
+                                <Input placeholder={t('llm.form.models.aliasPlaceholder')} {...field} />
                               </FormControl>
                               <FormMessage />
                             </FormItem>
@@ -409,12 +413,12 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
                               <Select onValueChange={field.onChange} defaultValue={field.value} value={field.value}>
                                 <FormControl>
                                   <SelectTrigger>
-                                    <SelectValue placeholder="类型" />
+                                    <SelectValue placeholder={t('llm.form.models.typePlaceholder')} />
                                   </SelectTrigger>
                                 </FormControl>
                                 <SelectContent>
                                   {MODEL_TYPE_OPTIONS.map((opt) => (
-                                    <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+                                    <SelectItem key={opt.value} value={opt.value}>{t(opt.labelKey)}</SelectItem>
                                   ))}
                                 </SelectContent>
                               </Select>
@@ -434,7 +438,7 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
                         </Button>
                       </div>
                     ))}
-                    
+
                     <Button
                       type="button"
                       variant="outline"
@@ -442,7 +446,7 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
                       onClick={() => append({ value: "", type: "", display_name: "" })}
                       className="w-full border-dashed"
                     >
-                      <Plus className="mr-2 h-4 w-4" /> 添加模型
+                      <Plus className="mr-2 h-4 w-4" /> {t('llm.form.models.addModel')}
                     </Button>
                     {form.formState.errors.models?.message && (
                       <p className="text-sm font-medium text-destructive">{String(form.formState.errors.models.message)}</p>
@@ -453,10 +457,10 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
                   {fields.length > 0 && fields.some(f => form.getValues(`models.${fields.indexOf(f)}.value`)) && (
                     <div className="space-y-4 pt-4 border-t">
                       <div className="flex items-center justify-between">
-                        <h4 className="text-sm font-medium">模型成本配置 (选填)</h4>
-                        <span className="text-xs text-muted-foreground">USD / Unit</span>
+                        <h4 className="text-sm font-medium">{t('llm.form.models.costsTitle')}</h4>
+                        <span className="text-xs text-muted-foreground">{t('llm.form.models.costsUnit')}</span>
                       </div>
-                      
+
                       <div className="space-y-3">
                         {fields.map((field, index) => {
                           const modelName = form.watch(`models.${index}.value`);
@@ -476,18 +480,18 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
                                 <span className="font-mono text-sm font-medium">{modelName}</span>
                                 {Object.keys(costs).length > 0 && (
                                   <Badge variant="secondary" className="ml-auto text-xs font-normal">
-                                    {Object.keys(costs).length} 项配置
+                                    {t('llm.form.models.configCount', { count: Object.keys(costs).length })}
                                   </Badge>
                                 )}
                               </button>
-                              
+
                               {isExpanded && (
                                 <div className="p-4 pt-0 space-y-4 border-t bg-muted/10">
                                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
                                     {Object.entries(PRESET_COST_DIMENSIONS).map(([dimKey, dimConfig]) => (
                                       <div key={dimKey} className="space-y-1.5">
                                         <label className="text-xs font-medium text-muted-foreground flex justify-between">
-                                          {dimConfig.label}
+                                          {t(dimConfig.labelKey)}
                                           <span className="opacity-70">{dimConfig.unit}</span>
                                         </label>
                                         <Input
@@ -519,15 +523,15 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
                                   {/* 自定义参数 */}
                                   {customKeys.length > 0 && (
                                     <div className="space-y-3 pt-2">
-                                      <h5 className="text-xs font-semibold text-muted-foreground">自定义参数</h5>
+                                      <h5 className="text-xs font-semibold text-muted-foreground">{t('llm.form.models.customParamsTitle')}</h5>
                                       {customKeys.map((customKey) => (
                                         <div key={customKey} className="flex gap-3 items-end p-2 bg-background rounded-md border">
                                           <div className="flex-1 space-y-1">
-                                            <label className="text-xs text-muted-foreground">参数名</label>
+                                            <label className="text-xs text-muted-foreground">{t('llm.form.models.customParamName')}</label>
                                             <div className="font-mono text-sm px-2 py-1 bg-muted rounded">{customKey}</div>
                                           </div>
                                           <div className="flex-1 space-y-1">
-                                            <label className="text-xs text-muted-foreground">成本 (USD)</label>
+                                            <label className="text-xs text-muted-foreground">{t('llm.form.models.customParamCost')}</label>
                                             <Input
                                               type="number"
                                               step="0.000001"
@@ -578,14 +582,14 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
                                     size="sm"
                                     className="w-full border-dashed text-xs"
                                     onClick={() => {
-                                      const name = prompt('输入自定义参数名 (英文, 如 reasoning_output)');
+                                      const name = prompt(t('llm.form.models.customParamPrompt'));
                                       if (!name) return;
                                       if (!name.match(/^[a-z_][a-z0-9_]*$/)) {
-                                        toast({ variant: "destructive", title: "参数名格式错误", description: "仅支持小写字母、数字和下划线" });
+                                        toast({ variant: "destructive", title: t('llm.form.models.customParamFormatError'), description: t('llm.form.models.customParamFormatErrorDesc') });
                                         return;
                                       }
                                       if (name in PRESET_COST_DIMENSIONS || (costs[name] !== undefined)) {
-                                        toast({ variant: "destructive", title: "参数名已存在" });
+                                        toast({ variant: "destructive", title: t('llm.form.models.customParamExists') });
                                         return;
                                       }
                                       setModelCosts(prev => {
@@ -595,7 +599,7 @@ export function ProviderForm({ initialData }: ProviderFormProps) {
                                       });
                                     }}
                                   >
-                                    <Plus className="mr-1 h-3 w-3" /> 添加自定义成本参数
+                                    <Plus className="mr-1 h-3 w-3" /> {t('llm.form.models.addCustomParam')}
                                   </Button>
                                 </div>
                               )}

--- a/backend/admin/src/app/admin/llm/components/provider-list.tsx
+++ b/backend/admin/src/app/admin/llm/components/provider-list.tsx
@@ -4,6 +4,7 @@
 import useSWR, { mutate } from 'swr';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
+import { useTranslation } from 'react-i18next';
 import api from '@/lib/axios';
 import { Button } from '@/components/ui/button';
 import { Badge } from "@/components/ui/badge";
@@ -36,19 +37,20 @@ const fetcher = (url: string) => api.get(url).then((res) => res.data);
 export function ProviderList() {
   const router = useRouter();
   const { toast } = useToast();
+  const { t } = useTranslation();
   const { data: providers, error, isLoading } = useSWR('/admin/llm-providers/', fetcher);
 
   const handleDelete = async (id: string) => {
     try {
       await api.delete(`/admin/llm-providers/${id}`);
       toast({
-        title: "供应商删除成功",
+        title: t('llm.list.toast.deleteSuccess'),
       });
       mutate('/admin/llm-providers/');
-    } catch (err) {
+    } catch {
       toast({
         variant: "destructive",
-        title: "删除失败",
+        title: t('llm.list.toast.deleteFailed'),
       });
     }
   };
@@ -64,7 +66,7 @@ export function ProviderList() {
   if (error) {
     return (
       <div className="flex h-[400px] w-full items-center justify-center text-destructive">
-        加载失败，请刷新重试
+        {t('llm.list.loadFailed')}
       </div>
     );
   }
@@ -72,10 +74,10 @@ export function ProviderList() {
   if (!providers || providers.length === 0) {
     return (
       <div className="flex h-[400px] w-full flex-col items-center justify-center space-y-4 rounded-lg border border-dashed bg-muted/50">
-        <div className="text-xl font-medium text-muted-foreground">暂无 AI 供应商</div>
+        <div className="text-xl font-medium text-muted-foreground">{t('llm.list.empty')}</div>
         <Button onClick={() => router.push('/admin/llm/create')}>
           <Plus className="mr-2 h-4 w-4" />
-          添加第一个 AI 供应商
+          {t('llm.list.emptyAction')}
         </Button>
       </div>
     );
@@ -87,11 +89,11 @@ export function ProviderList() {
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead className="w-[200px]">名称</TableHead>
-              <TableHead className="w-[120px]">品牌</TableHead>
-              <TableHead>标签</TableHead>
-              <TableHead>模型</TableHead>
-              <TableHead className="w-[120px] text-right">操作</TableHead>
+              <TableHead className="w-[200px]">{t('llm.list.table.name')}</TableHead>
+              <TableHead className="w-[120px]">{t('llm.list.table.brand')}</TableHead>
+              <TableHead>{t('llm.list.table.tags')}</TableHead>
+              <TableHead>{t('llm.list.table.models')}</TableHead>
+              <TableHead className="w-[120px] text-right">{t('llm.list.table.actions')}</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -115,7 +117,7 @@ export function ProviderList() {
                     )}
                     <div className="flex flex-col">
                       <span>{provider.name}</span>
-                      <span className="text-xs text-muted-foreground truncate max-w-[180px]">{provider.base_url || '默认URL'}</span>
+                      <span className="text-xs text-muted-foreground truncate max-w-[180px]">{provider.base_url || t('llm.list.defaultUrl')}</span>
                     </div>
                   </div>
                 </TableCell>
@@ -147,31 +149,31 @@ export function ProviderList() {
                 </TableCell>
                 <TableCell className="text-right">
                   <div className="flex justify-end gap-2">
-                    <Button 
-                      variant="ghost" 
-                      size="icon" 
+                    <Button
+                      variant="ghost"
+                      size="icon"
                       onClick={() => router.push(`/admin/llm/${provider.id}`)}
-                      title="编辑"
+                      title={t('llm.list.editTooltip')}
                     >
                       <Pencil className="h-4 w-4" />
                     </Button>
                     <AlertDialog>
                       <AlertDialogTrigger asChild>
-                        <Button variant="ghost" size="icon" className="text-destructive hover:text-destructive hover:bg-destructive/10" title="删除">
+                        <Button variant="ghost" size="icon" className="text-destructive hover:text-destructive hover:bg-destructive/10" title={t('llm.list.deleteTooltip')}>
                           <Trash2 className="h-4 w-4" />
                         </Button>
                       </AlertDialogTrigger>
                       <AlertDialogContent>
                         <AlertDialogHeader>
-                          <AlertDialogTitle>确认删除供应商？</AlertDialogTitle>
+                          <AlertDialogTitle>{t('llm.list.delete.title')}</AlertDialogTitle>
                           <AlertDialogDescription>
-                            此操作将永久删除该供应商配置 ({provider.name})，不可撤销。
+                            {t('llm.list.delete.description', { name: provider.name })}
                           </AlertDialogDescription>
                         </AlertDialogHeader>
                         <AlertDialogFooter>
-                          <AlertDialogCancel>取消</AlertDialogCancel>
+                          <AlertDialogCancel>{t('llm.list.delete.cancel')}</AlertDialogCancel>
                           <AlertDialogAction onClick={() => handleDelete(provider.id)} className="bg-destructive hover:bg-destructive/90">
-                            确认删除
+                            {t('llm.list.delete.confirm')}
                           </AlertDialogAction>
                         </AlertDialogFooter>
                       </AlertDialogContent>

--- a/backend/admin/src/app/admin/llm/page.tsx
+++ b/backend/admin/src/app/admin/llm/page.tsx
@@ -3,24 +3,26 @@
 
 import React from 'react';
 import { useRouter } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Plus } from 'lucide-react';
 import { ProviderList } from './components/provider-list';
 
 export default function LLMPage() {
   const router = useRouter();
+  const { t } = useTranslation();
 
   return (
     <>
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-3xl font-bold tracking-tight">AI 供应商</h2>
+          <h2 className="text-3xl font-bold tracking-tight">{t('llm.title')}</h2>
           <p className="text-muted-foreground mt-1">
-            管理和配置 AI 供应商及其模型参数
+            {t('llm.subtitle')}
           </p>
         </div>
         <Button onClick={() => router.push('/admin/llm/create')}>
-          <Plus className="mr-2 h-4 w-4" /> 添加供应商
+          <Plus className="mr-2 h-4 w-4" /> {t('llm.addProvider')}
         </Button>
       </div>
 

--- a/backend/admin/src/app/admin/llm/schema.ts
+++ b/backend/admin/src/app/admin/llm/schema.ts
@@ -1,16 +1,17 @@
 
 import * as z from 'zod';
+import type { TFunction } from 'i18next';
 
-export const PRESET_COST_DIMENSIONS: Record<string, { label: string; unit: string }> = {
-  input:              { label: '输入',         unit: 'USD/1M tokens' },
-  text_output:        { label: '文本输出',     unit: 'USD/1M tokens' },
-  image_output:       { label: '图片输出',     unit: 'USD/1M tokens' },
-  search:             { label: '搜索查询',     unit: 'USD/次' },
-  video_input_image:  { label: '视频输入图片', unit: 'USD/张' },
-  video_input_second: { label: '视频输入时长', unit: 'USD/秒' },
-  video_output_480p:  { label: '视频输出480p', unit: 'USD/秒' },
-  video_output_720p:  { label: '视频输出720p', unit: 'USD/秒' },
-  audio_generation:   { label: '音频生成',     unit: 'USD/次' },
+export const PRESET_COST_DIMENSIONS: Record<string, { labelKey: string; unit: string }> = {
+  input:              { labelKey: 'llm.costDimension.input',              unit: 'USD/1M tokens' },
+  text_output:        { labelKey: 'llm.costDimension.text_output',        unit: 'USD/1M tokens' },
+  image_output:       { labelKey: 'llm.costDimension.image_output',       unit: 'USD/1M tokens' },
+  search:             { labelKey: 'llm.costDimension.search',             unit: 'USD/次' },
+  video_input_image:  { labelKey: 'llm.costDimension.video_input_image',  unit: 'USD/张' },
+  video_input_second: { labelKey: 'llm.costDimension.video_input_second', unit: 'USD/秒' },
+  video_output_480p:  { labelKey: 'llm.costDimension.video_output_480p',  unit: 'USD/秒' },
+  video_output_720p:  { labelKey: 'llm.costDimension.video_output_720p',  unit: 'USD/秒' },
+  audio_generation:   { labelKey: 'llm.costDimension.audio_generation',   unit: 'USD/次' },
 };
 
 export const MODEL_TYPE_TAGS = [
@@ -22,11 +23,11 @@ export const MODEL_TYPE_TAGS = [
 ] as const;
 
 export const MODEL_TYPE_OPTIONS = [
-  { value: 'language', label: '语言模型' },
-  { value: 'image', label: '图像模型' },
-  { value: 'video', label: '视频模型' },
-  { value: 'audio', label: '音频模型' },
-  { value: 'multimodal', label: '多模态模型' },
+  { value: 'language', labelKey: 'llm.modelType.language' },
+  { value: 'image', labelKey: 'llm.modelType.image' },
+  { value: 'video', labelKey: 'llm.modelType.video' },
+  { value: 'audio', labelKey: 'llm.modelType.audio' },
+  { value: 'multimodal', labelKey: 'llm.modelType.multimodal' },
 ] as const;
 
 export const PROVIDER_ICONS: Record<string, string> = {
@@ -35,9 +36,7 @@ export const PROVIDER_ICONS: Record<string, string> = {
   dashscope: '/provider/qwen-color.svg',
   anthropic: '/provider/claude-color.svg',
   gemini: '/provider/gemini-color.svg',
-  deepseek: '/provider/deepseek-color.svg', // Assuming a fallback or standard icon if not present, user listed qwen-color but deepseek might use something else or generic. Wait, checking file list again.
-  // File list: azureai-color.svg, claude-color.svg, doubao-color.svg, gemini-color.svg, grok.svg, kling-color.svg, meta-color.svg, microsoft-color.svg, minimax-color.svg, openai.svg, openrouter.svg, qwen-color.svg, sora-color.svg
-  // Mapping based on available files:
+  deepseek: '/provider/deepseek-color.svg',
   minimax: '/provider/minimax-color.svg',
   xai: '/provider/grok.svg',
   doubao: '/provider/doubao-color.svg',
@@ -47,46 +46,52 @@ export const PROVIDER_ICONS: Record<string, string> = {
   openrouter: '/provider/openrouter.svg',
   sora: '/provider/sora-color.svg',
   ark: '/provider/volcengine-color.svg',
-  // Fallbacks or mappings for existing keys
-  // deepseek not in list, maybe use qwen or generic? Or maybe it's not provided yet. I'll omit or use a placeholder if needed, but for now I'll map what I can.
 };
 
+// Provider brand labels come from the vendor itself (proper nouns), not translated.
 export const PROVIDER_OPTIONS = [
   { value: 'openai', label: 'OpenAI', icon: PROVIDER_ICONS.openai },
   { value: 'azure', label: 'Azure OpenAI', icon: PROVIDER_ICONS.azure },
   { value: 'dashscope', label: 'Dashscope (Qwen)', icon: PROVIDER_ICONS.dashscope },
   { value: 'anthropic', label: 'Anthropic (Claude)', icon: PROVIDER_ICONS.anthropic },
   { value: 'gemini', label: 'Google Gemini', icon: PROVIDER_ICONS.gemini },
-  { value: 'deepseek', label: 'DeepSeek', icon: PROVIDER_ICONS.deepseek }, // Fallback to openai icon or generic for now as deepseek icon is missing
+  { value: 'deepseek', label: 'DeepSeek', icon: PROVIDER_ICONS.deepseek },
   { value: 'minimax', label: 'MiniMax', icon: PROVIDER_ICONS.minimax },
   { value: 'xai', label: 'xAI (Grok)', icon: PROVIDER_ICONS.xai },
   { value: 'ark', label: '火山方舟 (Ark)', icon: PROVIDER_ICONS.ark },
-  // { value: 'kling', label: 'Kling', icon: PROVIDER_ICONS.kling },
-  // { value: 'openrouter', label: 'OpenRouter', icon: PROVIDER_ICONS.openrouter },
 ];
 
-
-export const formSchema = z.object({
-  name: z.string().min(1, "请输入名称"),
-  provider_type: z.string().min(1, "请选择平台"),
+export const createFormSchema = (t: TFunction) => z.object({
+  name: z.string().min(1, t('llm.form.validation.nameRequired')),
+  provider_type: z.string().min(1, t('llm.form.validation.providerRequired')),
   tags: z.array(z.string()).optional(),
-  models: z.array(z.object({ 
-    value: z.string().min(1, "请输入模型名称"),
+  models: z.array(z.object({
+    value: z.string().min(1, t('llm.form.validation.modelNameRequired')),
     type: z.string().optional(),
     display_name: z.string().optional(),
-  })).min(1, "至少需要一个模型"),
+  })).min(1, t('llm.form.validation.modelsRequired')),
   base_url: z.string().optional(),
-  api_key: z.string().min(1, "请输入 API 密钥"),
+  api_key: z.string().min(1, t('llm.form.validation.apiKeyRequired')),
   config_json: z.string().refine((val) => {
     if (!val) return true;
     try {
       JSON.parse(val);
       return true;
-    } catch (e) {
+    } catch {
       return false;
     }
-  }, "请输入有效的 JSON 格式").optional(),
+  }, t('llm.form.validation.invalidJson')).optional(),
 });
+
+export type FormValues = {
+  name: string;
+  provider_type: string;
+  tags?: string[];
+  models: { value: string; type?: string; display_name?: string }[];
+  base_url?: string;
+  api_key: string;
+  config_json?: string;
+};
 
 export type LLMProvider = {
   id: string;

--- a/backend/admin/src/app/admin/page.tsx
+++ b/backend/admin/src/app/admin/page.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import React, { useState, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   Users,
   UserCheck,
   DollarSign,
   Wallet,
-  TrendingUp,
   Loader2,
   Crown,
   Percent,
@@ -48,58 +48,14 @@ const TOOLTIP_STYLE = {
   color: 'hsl(var(--card-foreground))',
 };
 
-const BUCKET_LABELS: Record<string, string> = {
-  today: '今日',
-  yesterday: '昨日',
-  this_week: '本周',
-  this_month: '本月',
-  older: '更早',
-};
+const BUCKET_KEYS = ['today', 'yesterday', 'this_week', 'this_month', 'older'] as const;
+
+const PERIOD_KEYS = ['today', 'yesterday', 'week', 'month', 'quarter', 'all'] as const;
+
+const LIMIT_OPTIONS = [10, 50, 100] as const;
 
 const fmt = (n?: number | null) => (n ?? 0).toLocaleString();
 const pct = (n?: number | null) => `${(n ?? 0).toFixed(2)}%`;
-
-// ---------------------------------------------------------------------------
-// Period / Limit options
-// ---------------------------------------------------------------------------
-
-const PERIOD_OPTIONS: Array<{ key: string; label: string }> = [
-  { key: 'today', label: '今日' },
-  { key: 'yesterday', label: '昨日' },
-  { key: 'week', label: '本周' },
-  { key: 'month', label: '本月' },
-  { key: 'quarter', label: '近三月' },
-  { key: 'all', label: '全部' },
-];
-
-const PERIOD_TITLE_REG: Record<string, string> = {
-  today: '注册趋势（今日）',
-  yesterday: '注册趋势（近 2 天）',
-  week: '注册趋势（本周）',
-  month: '注册趋势（近 30 天）',
-  quarter: '注册趋势（近 3 个月）',
-  all: '注册趋势（全部）',
-};
-
-const PERIOD_TITLE_ACTIVE: Record<string, string> = {
-  today: '活跃趋势（今日）',
-  yesterday: '活跃趋势（近 2 天）',
-  week: '活跃趋势（本周）',
-  month: '活跃趋势（近 30 天）',
-  quarter: '活跃趋势（近 3 个月）',
-  all: '活跃趋势（全部）',
-};
-
-const PERIOD_TITLE_CONV: Record<string, string> = {
-  today: '订阅转化（今日）',
-  yesterday: '订阅转化（近 2 天）',
-  week: '订阅转化（本周）',
-  month: '订阅转化（近 30 天）',
-  quarter: '订阅转化（近 3 个月）',
-  all: '订阅转化（全部）',
-};
-
-const LIMIT_OPTIONS = [10, 50, 100] as const;
 
 // ---------------------------------------------------------------------------
 // Stat Card config (4 cards)
@@ -107,17 +63,17 @@ const LIMIT_OPTIONS = [10, 50, 100] as const;
 
 interface StatCardDef {
   key: string;
-  label: string;
+  labelKey: string;
   icon: React.ElementType;
   color: string;
   getValue: (o: NonNullable<ReturnType<typeof useDashboardOverview>['overview']>) => string;
 }
 
 const STAT_CARDS: StatCardDef[] = [
-  { key: 'users', label: '用户总数', icon: Users, color: 'text-blue-500', getValue: (o) => fmt(o.total_users) },
-  { key: 'today_active', label: '今日活跃', icon: UserCheck, color: 'text-green-500', getValue: (o) => fmt(o.today_active_users) },
-  { key: 'today_revenue', label: '今日营收', icon: DollarSign, color: 'text-amber-500', getValue: (o) => `$${fmt(o.today_revenue)}` },
-  { key: 'total_revenue', label: '总营收', icon: Wallet, color: 'text-violet-500', getValue: (o) => `$${fmt(o.total_revenue)}` },
+  { key: 'users', labelKey: 'dashboard.stat.totalUsers', icon: Users, color: 'text-blue-500', getValue: (o) => fmt(o.total_users) },
+  { key: 'today_active', labelKey: 'dashboard.stat.todayActive', icon: UserCheck, color: 'text-green-500', getValue: (o) => fmt(o.today_active_users) },
+  { key: 'today_revenue', labelKey: 'dashboard.stat.todayRevenue', icon: DollarSign, color: 'text-amber-500', getValue: (o) => `$${fmt(o.today_revenue)}` },
+  { key: 'total_revenue', labelKey: 'dashboard.stat.totalRevenue', icon: Wallet, color: 'text-violet-500', getValue: (o) => `$${fmt(o.total_revenue)}` },
 ];
 
 // ---------------------------------------------------------------------------
@@ -133,16 +89,17 @@ function LoadingSpinner() {
 }
 
 function StatCardGrid() {
+  const { t } = useTranslation();
   const { overview, isLoading } = useDashboardOverview();
 
   if (isLoading) return <LoadingSpinner />;
 
   return (
     <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
-      {STAT_CARDS.map(({ key, label, icon: Icon, color, getValue }) => (
+      {STAT_CARDS.map(({ key, labelKey, icon: Icon, color, getValue }) => (
         <Card key={key} className="relative overflow-hidden">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-1">
-            <CardTitle className="text-xs font-medium text-muted-foreground">{label}</CardTitle>
+            <CardTitle className="text-xs font-medium text-muted-foreground">{t(labelKey)}</CardTitle>
             <Icon className={`h-4 w-4 ${color}`} />
           </CardHeader>
           <CardContent>
@@ -159,9 +116,10 @@ function StatCardGrid() {
 // ---------------------------------------------------------------------------
 
 function PeriodSelector({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  const { t } = useTranslation();
   return (
     <div className="flex gap-1">
-      {PERIOD_OPTIONS.map(({ key, label }) => (
+      {PERIOD_KEYS.map((key) => (
         <button
           key={key}
           onClick={() => onChange(key)}
@@ -171,7 +129,7 @@ function PeriodSelector({ value, onChange }: { value: string; onChange: (v: stri
               : 'text-muted-foreground hover:bg-muted'
           }`}
         >
-          {label}
+          {t(`dashboard.period.${key}`)}
         </button>
       ))}
     </div>
@@ -183,23 +141,29 @@ function PeriodSelector({ value, onChange }: { value: string; onChange: (v: stri
 // ---------------------------------------------------------------------------
 
 function RegistrationTrendChart() {
+  const { t } = useTranslation();
   const [period, setPeriod] = useState('month');
   const { trend, isLoading } = useRegistrationTrend(period);
 
   const buckets = trend?.buckets ?? {};
   const daily = trend?.daily ?? [];
 
+  const title = t('dashboard.trend.titleWithRange', {
+    name: t('dashboard.trend.registration'),
+    range: t(`dashboard.period.rangeLabel.${period}`),
+  });
+
   return (
     <Card className="flex flex-col">
       <CardHeader className="pb-2">
         <div className="flex items-center justify-between gap-2">
-          <CardTitle className="text-base">{PERIOD_TITLE_REG[period] ?? '注册趋势'}</CardTitle>
+          <CardTitle className="text-base">{title}</CardTitle>
           <PeriodSelector value={period} onChange={setPeriod} />
         </div>
         <div className="flex flex-wrap gap-2 pt-1">
-          {Object.entries(BUCKET_LABELS).map(([k, v]) => (
+          {BUCKET_KEYS.map((k) => (
             <Badge key={k} variant="secondary" className="text-xs font-normal">
-              {v}：{fmt(buckets[k])}
+              {t(`dashboard.bucket.${k}`)}：{fmt(buckets[k])}
             </Badge>
           ))}
         </div>
@@ -218,8 +182,8 @@ function RegistrationTrendChart() {
                 <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
                 <XAxis dataKey="date" tick={{ fontSize: 11 }} tickFormatter={(v: string) => v.slice(5)} className="fill-muted-foreground" />
                 <YAxis tick={{ fontSize: 11 }} className="fill-muted-foreground" allowDecimals={false} />
-                <Tooltip contentStyle={TOOLTIP_STYLE} labelFormatter={(l) => `日期：${l}`} />
-                <Area type="monotone" dataKey="count" name="注册数" stroke="hsl(var(--primary))" fill="url(#regGrad)" strokeWidth={2} />
+                <Tooltip contentStyle={TOOLTIP_STYLE} labelFormatter={(l) => t('dashboard.trend.dateLabel', { date: l })} />
+                <Area type="monotone" dataKey="count" name={t('dashboard.trend.registrationSeries')} stroke="hsl(var(--primary))" fill="url(#regGrad)" strokeWidth={2} />
               </AreaChart>
             </ResponsiveContainer>
           </div>
@@ -234,16 +198,22 @@ function RegistrationTrendChart() {
 // ---------------------------------------------------------------------------
 
 function ActiveTrendChart() {
+  const { t } = useTranslation();
   const [period, setPeriod] = useState('month');
   const { trend, isLoading } = useActiveTrend(period);
 
   const daily = trend?.daily ?? [];
 
+  const title = t('dashboard.trend.titleWithRange', {
+    name: t('dashboard.trend.active'),
+    range: t(`dashboard.period.rangeLabel.${period}`),
+  });
+
   return (
     <Card className="flex flex-col">
       <CardHeader className="pb-2">
         <div className="flex items-center justify-between gap-2">
-          <CardTitle className="text-base">{PERIOD_TITLE_ACTIVE[period] ?? '活跃趋势'}</CardTitle>
+          <CardTitle className="text-base">{title}</CardTitle>
           <PeriodSelector value={period} onChange={setPeriod} />
         </div>
       </CardHeader>
@@ -261,8 +231,8 @@ function ActiveTrendChart() {
                 <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
                 <XAxis dataKey="date" tick={{ fontSize: 11 }} tickFormatter={(v: string) => v.slice(5)} className="fill-muted-foreground" />
                 <YAxis tick={{ fontSize: 11 }} className="fill-muted-foreground" allowDecimals={false} />
-                <Tooltip contentStyle={TOOLTIP_STYLE} labelFormatter={(l) => `日期：${l}`} />
-                <Area type="monotone" dataKey="count" name="活跃用户" stroke="hsl(var(--chart-2, 160 60% 45%))" fill="url(#activeGrad)" strokeWidth={2} />
+                <Tooltip contentStyle={TOOLTIP_STYLE} labelFormatter={(l) => t('dashboard.trend.dateLabel', { date: l })} />
+                <Area type="monotone" dataKey="count" name={t('dashboard.trend.activeSeries')} stroke="hsl(var(--chart-2, 160 60% 45%))" fill="url(#activeGrad)" strokeWidth={2} />
               </AreaChart>
             </ResponsiveContainer>
           </div>
@@ -277,16 +247,22 @@ function ActiveTrendChart() {
 // ---------------------------------------------------------------------------
 
 function ConversionTrendChart() {
+  const { t } = useTranslation();
   const [period, setPeriod] = useState('month');
   const { trend, isLoading } = useConversionTrend(period);
 
   const daily = trend?.daily ?? [];
 
+  const title = t('dashboard.trend.titleWithRange', {
+    name: t('dashboard.trend.conversion'),
+    range: t(`dashboard.period.rangeLabel.${period}`),
+  });
+
   return (
     <Card className="flex flex-col">
       <CardHeader className="pb-2">
         <div className="flex items-center justify-between gap-2">
-          <CardTitle className="text-base">{PERIOD_TITLE_CONV[period] ?? '订阅转化'}</CardTitle>
+          <CardTitle className="text-base">{title}</CardTitle>
           <PeriodSelector value={period} onChange={setPeriod} />
         </div>
       </CardHeader>
@@ -298,8 +274,8 @@ function ConversionTrendChart() {
                 <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
                 <XAxis dataKey="date" tick={{ fontSize: 11 }} tickFormatter={(v: string) => v.slice(5)} className="fill-muted-foreground" />
                 <YAxis tick={{ fontSize: 11 }} className="fill-muted-foreground" allowDecimals={false} />
-                <Tooltip contentStyle={TOOLTIP_STYLE} labelFormatter={(l) => `日期：${l}`} />
-                <Bar dataKey="new_subscriptions" name="新增订阅" fill="hsl(var(--chart-3, 30 80% 55%))" radius={[4, 4, 0, 0]} />
+                <Tooltip contentStyle={TOOLTIP_STYLE} labelFormatter={(l) => t('dashboard.trend.dateLabel', { date: l })} />
+                <Bar dataKey="new_subscriptions" name={t('dashboard.trend.conversionSeries')} fill="hsl(var(--chart-3, 30 80% 55%))" radius={[4, 4, 0, 0]} />
               </BarChart>
             </ResponsiveContainer>
           </div>
@@ -322,6 +298,7 @@ const RANK_COLORS: Record<number, string> = {
 const ROW_HEIGHT = 56;
 
 function TokenLeaderboard() {
+  const { t } = useTranslation();
   const [limit, setLimit] = useState<number>(10);
   const { leaderboard, isLoading } = useTokenLeaderboard(limit);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -339,7 +316,7 @@ function TokenLeaderboard() {
         <div className="flex items-center justify-between gap-2">
           <div className="flex items-center gap-2">
             <Crown className="h-4 w-4 text-amber-500" />
-            <CardTitle className="text-base">Token 消耗排行榜</CardTitle>
+            <CardTitle className="text-base">{t('dashboard.leaderboard.title')}</CardTitle>
           </div>
           <div className="flex gap-1">
             {LIMIT_OPTIONS.map((n) => (
@@ -352,7 +329,7 @@ function TokenLeaderboard() {
                     : 'text-muted-foreground hover:bg-muted'
                 }`}
               >
-                Top {n}
+                {t('dashboard.leaderboard.top', { n })}
               </button>
             ))}
           </div>
@@ -360,15 +337,15 @@ function TokenLeaderboard() {
       </CardHeader>
       <CardContent className="flex flex-1 flex-col pt-0">
         {isLoading ? <LoadingSpinner /> : leaderboard.length === 0 ? (
-          <p className="py-8 text-center text-sm text-muted-foreground">暂无数据</p>
+          <p className="py-8 text-center text-sm text-muted-foreground">{t('dashboard.leaderboard.empty')}</p>
         ) : (
           <>
             {/* Table header */}
             <div className="grid grid-cols-[40px_1fr_100px_100px] gap-1 border-b px-1 pb-1.5 text-xs font-medium text-muted-foreground">
-              <span>#</span>
-              <span>用户</span>
-              <span className="text-right">总 Token</span>
-              <span className="text-right">积分</span>
+              <span>{t('dashboard.leaderboard.rank')}</span>
+              <span>{t('dashboard.leaderboard.user')}</span>
+              <span className="text-right">{t('dashboard.leaderboard.totalTokens')}</span>
+              <span className="text-right">{t('dashboard.leaderboard.credits')}</span>
             </div>
             {/* Virtual scroll area */}
             <div ref={scrollRef} className="flex-1 overflow-auto">
@@ -391,7 +368,7 @@ function TokenLeaderboard() {
                           </AvatarFallback>
                         </Avatar>
                         <div className="min-w-0">
-                          <p className="truncate text-sm font-medium leading-none">{entry.nickname || '—'}</p>
+                          <p className="truncate text-sm font-medium leading-none">{entry.nickname || t('dashboard.leaderboard.nicknamePlaceholder')}</p>
                           <p className="truncate text-xs text-muted-foreground">{entry.email}</p>
                         </div>
                       </div>
@@ -417,21 +394,22 @@ function TokenLeaderboard() {
 // ---------------------------------------------------------------------------
 
 function BusinessMetrics() {
+  const { t } = useTranslation();
   const { metrics, isLoading } = useOperationalMetrics();
 
   if (isLoading) return <LoadingSpinner />;
 
   const cards = [
-    { label: '付费用户占比 (PUR)', value: pct(metrics?.pur), icon: Percent, color: 'text-blue-500' },
-    { label: '活跃留存率', value: pct(metrics?.retention_rate), icon: ShieldCheck, color: 'text-green-500' },
-    { label: 'MRR (月经常性收入)', value: `$${fmt(metrics?.mrr)}`, icon: BadgeDollarSign, color: 'text-amber-500' },
-    { label: '退订率', value: pct(metrics?.churn_rate), icon: UserMinus, color: 'text-red-500' },
+    { label: t('dashboard.metrics.pur'), value: pct(metrics?.pur), icon: Percent, color: 'text-blue-500' },
+    { label: t('dashboard.metrics.retention'), value: pct(metrics?.retention_rate), icon: ShieldCheck, color: 'text-green-500' },
+    { label: t('dashboard.metrics.mrr'), value: `$${fmt(metrics?.mrr)}`, icon: BadgeDollarSign, color: 'text-amber-500' },
+    { label: t('dashboard.metrics.churn'), value: pct(metrics?.churn_rate), icon: UserMinus, color: 'text-red-500' },
   ];
 
   return (
     <Card>
       <CardHeader className="pb-2">
-        <CardTitle className="text-base">运营指标</CardTitle>
+        <CardTitle className="text-base">{t('dashboard.metrics.title')}</CardTitle>
       </CardHeader>
       <CardContent>
         <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
@@ -455,9 +433,10 @@ function BusinessMetrics() {
 // ---------------------------------------------------------------------------
 
 export default function AdminDashboard() {
+  const { t } = useTranslation();
   return (
     <div className="mx-auto w-full max-w-[1400px] space-y-4 p-4">
-      <h2 className="text-2xl font-bold tracking-tight">仪表盘</h2>
+      <h2 className="text-2xl font-bold tracking-tight">{t('dashboard.title')}</h2>
 
       {/* Row 1: Stat cards */}
       <StatCardGrid />

--- a/backend/admin/src/app/admin/subscriptions/page.tsx
+++ b/backend/admin/src/app/admin/subscriptions/page.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { useForm, useFieldArray } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import {
   Table,
@@ -61,47 +62,19 @@ import {
   useDeletePlan,
 } from '@/hooks/useSubscriptions';
 
-// 计费周期映射表（避免 if-else）
-const BILLING_PERIODS: Record<string, { label: string; short: string }> = {
-  monthly: { label: '月付', short: '月' },
-  yearly: { label: '年付', short: '年' },
-  lifetime: { label: '终身', short: '终身' },
-};
-
 // 基准积分成本（1 积分 = $0.01 USD）
 const CREDIT_BASE_COST_USD = 0.01;
 
-// 存储配额选项 (GB)
-const STORAGE_QUOTA_OPTIONS: { label: string; bytes: number }[] = [
-  { label: '1 GB', bytes: 1 * 1024 ** 3 },
-  { label: '2 GB', bytes: 2 * 1024 ** 3 },
-  { label: '5 GB', bytes: 5 * 1024 ** 3 },
-  { label: '10 GB', bytes: 10 * 1024 ** 3 },
-  { label: '20 GB', bytes: 20 * 1024 ** 3 },
-  { label: '50 GB', bytes: 50 * 1024 ** 3 },
-  { label: '100 GB', bytes: 100 * 1024 ** 3 },
-];
+const BILLING_CYCLE_KEYS = ['monthly', 'yearly', 'lifetime'] as const;
+type BillingCycleKey = typeof BILLING_CYCLE_KEYS[number];
 
 function formatStorageQuota(bytes: number): string {
   const gb = bytes / (1024 ** 3);
   return gb >= 1 ? `${gb} GB` : `${(bytes / (1024 ** 2)).toFixed(0)} MB`;
 }
 
-const formSchema = z.object({
-  name: z.string().min(1, '请输入套餐名称'),
-  description: z.string().optional(),
-  price_usd: z.number().positive('价格必须大于 0'),
-  credits: z.number().positive('积分数量必须大于 0'),
-  billing_period: z.enum(['monthly', 'yearly', 'lifetime']),
-  storage_quota_gb: z.number().min(0.1, '存储配额必须大于 0'),
-  features: z.array(z.object({ value: z.string().min(1, '请输入特性描述') })),
-  is_active: z.boolean(),
-  sort_order: z.number().int().min(0),
-});
-
-type FormValues = z.infer<typeof formSchema>;
-
 export default function SubscriptionsPage() {
+  const { t } = useTranslation();
   const { toast } = useToast();
   const { plans, isLoading, mutate } = useSubscriptions();
   const { createPlan } = useCreatePlan();
@@ -111,6 +84,20 @@ export default function SubscriptionsPage() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editing, setEditing] = useState<SubscriptionPlan | null>(null);
   const [submitting, setSubmitting] = useState(false);
+
+  const formSchema = useMemo(() => z.object({
+    name: z.string().min(1, t('subscriptions.validation.nameRequired')),
+    description: z.string().optional(),
+    price_usd: z.number().positive(t('subscriptions.validation.pricePositive')),
+    credits: z.number().positive(t('subscriptions.validation.creditsPositive')),
+    billing_period: z.enum(['monthly', 'yearly', 'lifetime']),
+    storage_quota_gb: z.number().min(0.1, t('subscriptions.validation.storagePositive')),
+    features: z.array(z.object({ value: z.string().min(1, t('subscriptions.validation.featureRequired')) })),
+    is_active: z.boolean(),
+    sort_order: z.number().int().min(0),
+  }), [t]);
+
+  type FormValues = z.infer<typeof formSchema>;
 
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
@@ -135,10 +122,12 @@ export default function SubscriptionsPage() {
   const watchPrice = form.watch('price_usd');
   const watchCredits = form.watch('credits');
 
-  // 自动计算指标
   const unitPrice = watchCredits > 0 ? watchPrice / watchCredits : 0;
   const baseCost = watchCredits * CREDIT_BASE_COST_USD;
   const profitMargin = baseCost > 0 ? ((watchPrice - baseCost) / baseCost * 100) : 0;
+
+  const getCycleLabel = (key: string) =>
+    BILLING_CYCLE_KEYS.includes(key as BillingCycleKey) ? t(`subscriptions.billingCycle.${key}`) : key;
 
   const handleAdd = () => {
     setEditing(null);
@@ -175,10 +164,10 @@ export default function SubscriptionsPage() {
   const handleDelete = async (plan: SubscriptionPlan) => {
     try {
       await deletePlan(plan.id);
-      toast({ title: '删除成功', description: `套餐 "${plan.name}" 已删除。` });
+      toast({ title: t('subscriptions.toast.deleteSuccess'), description: t('subscriptions.toast.deleteSuccessDesc', { name: plan.name }) });
       mutate();
     } catch {
-      toast({ title: '删除失败', variant: 'destructive' });
+      toast({ title: t('subscriptions.toast.deleteFailed'), variant: 'destructive' });
     }
   };
 
@@ -190,20 +179,19 @@ export default function SubscriptionsPage() {
         features: values.features.map(f => f.value),
         storage_quota_bytes: Math.round(values.storage_quota_gb * 1024 ** 3),
       };
-      // 移除临时字段
       delete (payload as any).storage_quota_gb;
 
       editing
         ? await updatePlan(editing.id, payload)
         : await createPlan(payload);
 
-      toast({ title: editing ? '更新成功' : '创建成功' });
+      toast({ title: editing ? t('subscriptions.toast.updateSuccess') : t('subscriptions.toast.createSuccess') });
       setDialogOpen(false);
       mutate();
     } catch (err: any) {
       toast({
-        title: editing ? '更新失败' : '创建失败',
-        description: err?.response?.data?.detail ?? '请稍后再试',
+        title: editing ? t('subscriptions.toast.updateFailed') : t('subscriptions.toast.createFailed'),
+        description: err?.response?.data?.detail ?? t('subscriptions.toast.retryLater'),
         variant: 'destructive',
       });
     } finally {
@@ -215,11 +203,11 @@ export default function SubscriptionsPage() {
     <div className="max-w-[1200px] mx-auto w-full space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h2 className="text-2xl font-bold tracking-tight">订阅套餐管理</h2>
-          <p className="text-muted-foreground text-sm mt-1">管理用户订阅套餐和定价策略</p>
+          <h2 className="text-2xl font-bold tracking-tight">{t('subscriptions.title')}</h2>
+          <p className="text-muted-foreground text-sm mt-1">{t('subscriptions.subtitle')}</p>
         </div>
         <Button onClick={handleAdd}>
-          <Plus className="mr-2 h-4 w-4" /> 新建套餐
+          <Plus className="mr-2 h-4 w-4" /> {t('subscriptions.newPlan')}
         </Button>
       </div>
 
@@ -227,27 +215,27 @@ export default function SubscriptionsPage() {
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead className="w-12">排序</TableHead>
-              <TableHead>套餐名称</TableHead>
-              <TableHead>计费周期</TableHead>
-              <TableHead className="text-right">价格 (USD)</TableHead>
-              <TableHead className="text-right">积分</TableHead>
-              <TableHead className="text-right">存储配额</TableHead>
-              <TableHead className="text-right">单价 ($/积分)</TableHead>
-              <TableHead className="text-right">利润率</TableHead>
-              <TableHead>状态</TableHead>
-              <TableHead className="w-24">操作</TableHead>
+              <TableHead className="w-12">{t('subscriptions.table.order')}</TableHead>
+              <TableHead>{t('subscriptions.table.name')}</TableHead>
+              <TableHead>{t('subscriptions.table.billingCycle')}</TableHead>
+              <TableHead className="text-right">{t('subscriptions.table.price')}</TableHead>
+              <TableHead className="text-right">{t('subscriptions.table.credits')}</TableHead>
+              <TableHead className="text-right">{t('subscriptions.table.storage')}</TableHead>
+              <TableHead className="text-right">{t('subscriptions.table.unitPrice')}</TableHead>
+              <TableHead className="text-right">{t('subscriptions.table.margin')}</TableHead>
+              <TableHead>{t('subscriptions.table.status')}</TableHead>
+              <TableHead className="w-24">{t('subscriptions.table.actions')}</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {isLoading && (
               <TableRow>
-                <TableCell colSpan={10} className="text-center text-muted-foreground py-8">加载中...</TableCell>
+                <TableCell colSpan={10} className="text-center text-muted-foreground py-8">{t('subscriptions.table.loading')}</TableCell>
               </TableRow>
             )}
             {!isLoading && (!plans || plans.length === 0) && (
               <TableRow>
-                <TableCell colSpan={10} className="text-center text-muted-foreground py-8">暂无套餐数据</TableCell>
+                <TableCell colSpan={10} className="text-center text-muted-foreground py-8">{t('subscriptions.table.empty')}</TableCell>
               </TableRow>
             )}
             {plans?.map((plan) => {
@@ -267,7 +255,7 @@ export default function SubscriptionsPage() {
                     </div>
                   </TableCell>
                   <TableCell>
-                    <Badge variant="outline">{BILLING_PERIODS[plan.billing_period]?.label ?? plan.billing_period}</Badge>
+                    <Badge variant="outline">{getCycleLabel(plan.billing_period)}</Badge>
                   </TableCell>
                   <TableCell className="text-right font-mono">${plan.price_usd.toFixed(2)}</TableCell>
                   <TableCell className="text-right font-mono">{plan.credits.toLocaleString()}</TableCell>
@@ -284,7 +272,7 @@ export default function SubscriptionsPage() {
                   </TableCell>
                   <TableCell>
                     <Badge variant={plan.is_active ? 'default' : 'secondary'}>
-                      {plan.is_active ? '启用' : '停用'}
+                      {plan.is_active ? t('subscriptions.status.active') : t('subscriptions.status.inactive')}
                     </Badge>
                   </TableCell>
                   <TableCell>
@@ -300,14 +288,14 @@ export default function SubscriptionsPage() {
                         </AlertDialogTrigger>
                         <AlertDialogContent>
                           <AlertDialogHeader>
-                            <AlertDialogTitle>确认删除</AlertDialogTitle>
+                            <AlertDialogTitle>{t('subscriptions.delete.title')}</AlertDialogTitle>
                             <AlertDialogDescription>
-                              确定要删除套餐 &quot;{plan.name}&quot; 吗？此操作不可撤销。
+                              {t('subscriptions.delete.description', { name: plan.name })}
                             </AlertDialogDescription>
                           </AlertDialogHeader>
                           <AlertDialogFooter>
-                            <AlertDialogCancel>取消</AlertDialogCancel>
-                            <AlertDialogAction onClick={() => handleDelete(plan)}>确认删除</AlertDialogAction>
+                            <AlertDialogCancel>{t('subscriptions.delete.cancel')}</AlertDialogCancel>
+                            <AlertDialogAction onClick={() => handleDelete(plan)}>{t('subscriptions.delete.confirm')}</AlertDialogAction>
                           </AlertDialogFooter>
                         </AlertDialogContent>
                       </AlertDialog>
@@ -324,9 +312,9 @@ export default function SubscriptionsPage() {
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
         <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
           <DialogHeader>
-            <DialogTitle>{editing ? '编辑套餐' : '新建套餐'}</DialogTitle>
+            <DialogTitle>{editing ? t('subscriptions.dialog.editTitle') : t('subscriptions.dialog.createTitle')}</DialogTitle>
             <DialogDescription>
-              {editing ? '修改订阅套餐信息' : '创建新的订阅套餐'}
+              {editing ? t('subscriptions.dialog.editDescription') : t('subscriptions.dialog.createDescription')}
             </DialogDescription>
           </DialogHeader>
 
@@ -337,9 +325,9 @@ export default function SubscriptionsPage() {
                 name="name"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>套餐名称</FormLabel>
+                    <FormLabel>{t('subscriptions.form.name')}</FormLabel>
                     <FormControl>
-                      <Input placeholder="例如：基础版" {...field} />
+                      <Input placeholder={t('subscriptions.form.namePlaceholder')} {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -351,9 +339,9 @@ export default function SubscriptionsPage() {
                 name="description"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>描述</FormLabel>
+                    <FormLabel>{t('subscriptions.form.description')}</FormLabel>
                     <FormControl>
-                      <Textarea placeholder="套餐描述（可选）" rows={2} {...field} />
+                      <Textarea placeholder={t('subscriptions.form.descriptionPlaceholder')} rows={2} {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -366,7 +354,7 @@ export default function SubscriptionsPage() {
                   name="price_usd"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>价格 (USD)</FormLabel>
+                      <FormLabel>{t('subscriptions.form.price')}</FormLabel>
                       <FormControl>
                         <Input
                           type="number"
@@ -386,7 +374,7 @@ export default function SubscriptionsPage() {
                   name="credits"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>积分数量</FormLabel>
+                      <FormLabel>{t('subscriptions.form.credits')}</FormLabel>
                       <FormControl>
                         <Input
                           type="number"
@@ -405,15 +393,15 @@ export default function SubscriptionsPage() {
               {/* 自动计算指标 */}
               <div className="rounded-lg border p-3 bg-muted/50 space-y-1.5">
                 <div className="flex justify-between text-xs">
-                  <span className="text-muted-foreground">单价</span>
-                  <span className="font-mono">${unitPrice.toFixed(4)} / 积分</span>
+                  <span className="text-muted-foreground">{t('subscriptions.metrics.unitPrice')}</span>
+                  <span className="font-mono">{t('subscriptions.metrics.unitPriceValue', { value: unitPrice.toFixed(4) })}</span>
                 </div>
                 <div className="flex justify-between text-xs">
-                  <span className="text-muted-foreground">基准成本 (1积分=$0.01)</span>
-                  <span className="font-mono">${baseCost.toFixed(2)}</span>
+                  <span className="text-muted-foreground">{t('subscriptions.metrics.baseCost')}</span>
+                  <span className="font-mono">{t('subscriptions.metrics.baseCostValue', { value: baseCost.toFixed(2) })}</span>
                 </div>
                 <div className="flex justify-between text-xs">
-                  <span className="text-muted-foreground">利润率</span>
+                  <span className="text-muted-foreground">{t('subscriptions.metrics.margin')}</span>
                   <span className={
                     profitMargin > 0 ? 'text-green-600 dark:text-green-400 font-medium font-mono' :
                     profitMargin < 0 ? 'text-red-600 dark:text-red-400 font-medium font-mono' :
@@ -430,15 +418,15 @@ export default function SubscriptionsPage() {
                   name="billing_period"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>计费周期</FormLabel>
+                      <FormLabel>{t('subscriptions.form.billingCycle')}</FormLabel>
                       <FormControl>
                         <Select onValueChange={field.onChange} value={field.value}>
                           <SelectTrigger>
                             <SelectValue />
                           </SelectTrigger>
                           <SelectContent>
-                            {Object.entries(BILLING_PERIODS).map(([key, val]) => (
-                              <SelectItem key={key} value={key}>{val.label}</SelectItem>
+                            {BILLING_CYCLE_KEYS.map((key) => (
+                              <SelectItem key={key} value={key}>{t(`subscriptions.billingCycle.${key}`)}</SelectItem>
                             ))}
                           </SelectContent>
                         </Select>
@@ -453,7 +441,7 @@ export default function SubscriptionsPage() {
                   name="sort_order"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>排序</FormLabel>
+                      <FormLabel>{t('subscriptions.form.sortOrder')}</FormLabel>
                       <FormControl>
                         <Input
                           type="number"
@@ -474,7 +462,7 @@ export default function SubscriptionsPage() {
                 name="storage_quota_gb"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>存储配额 (GB)</FormLabel>
+                    <FormLabel>{t('subscriptions.form.storageQuota')}</FormLabel>
                     <FormControl>
                       <Input
                         type="number"
@@ -492,7 +480,7 @@ export default function SubscriptionsPage() {
               {/* 特性列表 */}
               <div>
                 <div className="flex items-center justify-between mb-2">
-                  <FormLabel>套餐特性</FormLabel>
+                  <FormLabel>{t('subscriptions.form.features')}</FormLabel>
                   <Button
                     type="button"
                     variant="outline"
@@ -500,7 +488,7 @@ export default function SubscriptionsPage() {
                     className="text-xs h-7"
                     onClick={() => append({ value: '' })}
                   >
-                    <Plus className="mr-1 h-3 w-3" /> 添加
+                    <Plus className="mr-1 h-3 w-3" /> {t('subscriptions.form.featureAdd')}
                   </Button>
                 </div>
                 <div className="space-y-2">
@@ -513,7 +501,7 @@ export default function SubscriptionsPage() {
                         <FormItem>
                           <div className="flex items-center gap-2">
                             <FormControl>
-                              <Input placeholder="例如：每月 1000 积分" {...inputField} />
+                              <Input placeholder={t('subscriptions.form.featurePlaceholder')} {...inputField} />
                             </FormControl>
                             <Button
                               type="button"
@@ -531,7 +519,7 @@ export default function SubscriptionsPage() {
                     />
                   ))}
                   {fields.length === 0 && (
-                    <p className="text-xs text-muted-foreground text-center py-2">暂无特性，点击"添加"按钮</p>
+                    <p className="text-xs text-muted-foreground text-center py-2">{t('subscriptions.form.featuresEmpty')}</p>
                   )}
                 </div>
               </div>
@@ -542,7 +530,7 @@ export default function SubscriptionsPage() {
                 render={({ field }) => (
                   <FormItem>
                     <div className="flex items-center justify-between">
-                      <FormLabel>启用</FormLabel>
+                      <FormLabel>{t('subscriptions.form.isActive')}</FormLabel>
                       <FormControl>
                         <Switch checked={field.value} onCheckedChange={field.onChange} />
                       </FormControl>
@@ -553,9 +541,9 @@ export default function SubscriptionsPage() {
               />
 
               <DialogFooter>
-                <Button type="button" variant="outline" onClick={() => setDialogOpen(false)}>取消</Button>
+                <Button type="button" variant="outline" onClick={() => setDialogOpen(false)}>{t('subscriptions.form.cancel')}</Button>
                 <Button type="submit" disabled={submitting}>
-                  {submitting ? '提交中...' : (editing ? '保存' : '创建')}
+                  {submitting ? t('subscriptions.form.submitting') : (editing ? t('subscriptions.form.save') : t('subscriptions.form.create'))}
                 </Button>
               </DialogFooter>
             </form>

--- a/backend/admin/src/app/admin/users/[id]/credits/page.tsx
+++ b/backend/admin/src/app/admin/users/[id]/credits/page.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { useParams } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import {
   Table,
@@ -20,14 +21,14 @@ import type { CreditTransaction, User } from '@/types';
 
 const fetcher = (url: string) => api.get(url).then((res) => res.data);
 
-// 交易类型映射表
-const TRANSACTION_TYPE_MAP: Record<string, { label: string; variant: 'default' | 'secondary' | 'destructive' }> = {
-  recharge: { label: '充值', variant: 'default' },
-  deduction: { label: '消费', variant: 'destructive' },
-  admin_adjust: { label: '调整', variant: 'secondary' },
+const TYPE_VARIANT: Record<string, 'default' | 'secondary' | 'destructive'> = {
+  recharge: 'default',
+  deduction: 'destructive',
+  admin_adjust: 'secondary',
 };
 
 export default function CreditHistoryPage() {
+  const { t } = useTranslation();
   const params = useParams();
   const userId = params.id as string;
 
@@ -37,19 +38,23 @@ export default function CreditHistoryPage() {
     fetcher
   );
 
+  const getTypeLabel = (type: string) => t(`users.creditsPage.types.${type in TYPE_VARIANT ? type : 'admin_adjust'}`);
+  const getTypeVariant = (type: string) => TYPE_VARIANT[type] ?? TYPE_VARIANT.admin_adjust;
+
   return (
     <div className="space-y-4">
       <div className="flex items-center gap-4">
         <Link href="/admin/users">
-          <Button variant="ghost" size="icon">
+          <Button variant="ghost" size="icon" title={t('users.creditsPage.back')}>
             <ArrowLeft className="h-4 w-4" />
           </Button>
         </Link>
         <div>
-          <h2 className="text-2xl font-bold tracking-tight">积分历史</h2>
+          <h2 className="text-2xl font-bold tracking-tight">{t('users.creditsPage.title')}</h2>
           <p className="text-sm text-muted-foreground">
-            用户: {user?.nickname || '加载中...'} ({user?.email})
-            {user && ` - 当前余额: ${Number(user.credits || 0).toFixed(2)}`}
+            {t('users.creditsPage.userLabel', { nickname: user?.nickname || t('users.creditsPage.userLoading') })}
+            {user?.email && ` (${user.email})`}
+            {user && ` - ${t('users.creditsPage.balanceLabel', { balance: Number(user.credits || 0).toFixed(2) })}`}
           </p>
         </div>
       </div>
@@ -58,30 +63,29 @@ export default function CreditHistoryPage() {
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead>时间</TableHead>
-              <TableHead>类型</TableHead>
-              <TableHead className="text-right">金额</TableHead>
-              <TableHead className="text-right">变动前</TableHead>
-              <TableHead className="text-right">变动后</TableHead>
-              <TableHead className="text-right">Token</TableHead>
-              <TableHead>说明</TableHead>
+              <TableHead>{t('users.creditsPage.table.time')}</TableHead>
+              <TableHead>{t('users.creditsPage.table.type')}</TableHead>
+              <TableHead className="text-right">{t('users.creditsPage.table.amount')}</TableHead>
+              <TableHead className="text-right">{t('users.creditsPage.table.balanceBefore')}</TableHead>
+              <TableHead className="text-right">{t('users.creditsPage.table.balanceAfter')}</TableHead>
+              <TableHead className="text-right">{t('users.creditsPage.table.tokens')}</TableHead>
+              <TableHead>{t('users.creditsPage.table.description')}</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {isLoading ? (
               <TableRow>
                 <TableCell colSpan={7} className="h-24 text-center">
-                  加载中...
+                  {t('users.creditsPage.loading')}
                 </TableCell>
               </TableRow>
             ) : !transactions || transactions.length === 0 ? (
               <TableRow>
                 <TableCell colSpan={7} className="h-24 text-center text-muted-foreground">
-                  暂无积分变动记录
+                  {t('users.creditsPage.empty')}
                 </TableCell>
               </TableRow>
             ) : transactions.map((tx) => {
-              const typeInfo = TRANSACTION_TYPE_MAP[tx.transaction_type] || TRANSACTION_TYPE_MAP.admin_adjust;
               const isPositive = tx.amount > 0;
               return (
                 <TableRow key={tx.id}>
@@ -89,7 +93,7 @@ export default function CreditHistoryPage() {
                     {new Date(tx.created_at).toLocaleString()}
                   </TableCell>
                   <TableCell>
-                    <Badge variant={typeInfo.variant}>{typeInfo.label}</Badge>
+                    <Badge variant={getTypeVariant(tx.transaction_type)}>{getTypeLabel(tx.transaction_type)}</Badge>
                   </TableCell>
                   <TableCell className={`text-right tabular-nums font-mono ${isPositive ? 'text-green-600' : 'text-red-600'}`}>
                     {isPositive ? '+' : ''}{Number(tx.amount).toFixed(2)}

--- a/backend/admin/src/app/admin/users/page.tsx
+++ b/backend/admin/src/app/admin/users/page.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import {
   Table,
@@ -69,23 +70,6 @@ import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 
 const fetcher = (url: string) => api.get(url).then((res) => res.data);
 
-// 积分调整表单 Schema
-const creditAdjustSchema = z.object({
-  amount: z.number().refine(v => v !== 0, { message: '金额不能为 0' }),
-  description: z.string().min(1, '请输入操作说明'),
-});
-
-// 订阅设置表单 Schema
-const subscriptionSchema = z.object({
-  plan_id: z.string().min(1, '请选择套餐'),
-  start_at: z.string().min(1, '请选择开始时间'),
-  end_at: z.string().min(1, '请选择结束时间'),
-  auto_grant_credits: z.boolean(),
-});
-
-type CreditAdjustValues = z.infer<typeof creditAdjustSchema>;
-type SubscriptionValues = z.infer<typeof subscriptionSchema>;
-
 // 存储大小格式化
 const STORAGE_UNITS = ["B", "KB", "MB", "GB", "TB"];
 function formatBytes(bytes: number): string {
@@ -95,11 +79,10 @@ function formatBytes(bytes: number): string {
   return `${size.toFixed(i > 0 ? 1 : 0)} ${STORAGE_UNITS[i]}`;
 }
 
-// 订阅状态映射表
-const SUBSCRIPTION_STATUS_MAP: Record<string, { label: string; variant: 'default' | 'secondary' | 'destructive' }> = {
-  active: { label: '生效中', variant: 'default' },
-  inactive: { label: '未订阅', variant: 'secondary' },
-  expired: { label: '已过期', variant: 'destructive' },
+const STATUS_VARIANT: Record<string, 'default' | 'secondary' | 'destructive'> = {
+  active: 'default',
+  inactive: 'secondary',
+  expired: 'destructive',
 };
 
 // 详情行组件
@@ -115,9 +98,9 @@ function DetailRow({ label, value }: { label: string; value: React.ReactNode }) 
 // 注册来源标识组件
 function AuthSourceBadge({ user }: { user: User }) {
   const sources: { icon: string; label: string }[] = [];
-  if (user.google_id) sources.push({ icon: '/provider/gemini-color.svg', label: 'Google' });
-  if (user.github_id) sources.push({ icon: '/provider/meta-color.svg', label: 'GitHub' });
-  
+  user.google_id && sources.push({ icon: '/provider/gemini-color.svg', label: 'Google' });
+  user.github_id && sources.push({ icon: '/provider/meta-color.svg', label: 'GitHub' });
+
   return (
     <div className="flex items-center gap-1.5">
       {sources.length === 0 ? (
@@ -141,7 +124,8 @@ function AuthSourceBadge({ user }: { user: User }) {
 }
 
 export default function UsersPage() {
-  const { data: users, error, isLoading } = useSWR<User[]>('/admin/users', fetcher);
+  const { t } = useTranslation();
+  const { data: users, isLoading } = useSWR<User[]>('/admin/users', fetcher);
   const { data: plans } = useSWR<SubscriptionPlan[]>('/admin/subscriptions', fetcher);
   const { toast } = useToast();
 
@@ -150,6 +134,22 @@ export default function UsersPage() {
   const [detailDialogOpen, setDetailDialogOpen] = useState(false);
   const [selectedUser, setSelectedUser] = useState<User | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [recalcingAll, setRecalcingAll] = useState(false);
+
+  const creditAdjustSchema = useMemo(() => z.object({
+    amount: z.number().refine(v => v !== 0, { message: t('users.credit.validation.nonZero') }),
+    description: z.string().min(1, t('users.credit.validation.reasonRequired')),
+  }), [t]);
+
+  const subscriptionSchema = useMemo(() => z.object({
+    plan_id: z.string().min(1, t('users.subscription.validation.planRequired')),
+    start_at: z.string().min(1, t('users.subscription.validation.startRequired')),
+    end_at: z.string().min(1, t('users.subscription.validation.endRequired')),
+    auto_grant_credits: z.boolean(),
+  }), [t]);
+
+  type CreditAdjustValues = z.infer<typeof creditAdjustSchema>;
+  type SubscriptionValues = z.infer<typeof subscriptionSchema>;
 
   const creditForm = useForm<CreditAdjustValues>({
     resolver: zodResolver(creditAdjustSchema),
@@ -158,28 +158,24 @@ export default function UsersPage() {
 
   const subscriptionForm = useForm<SubscriptionValues>({
     resolver: zodResolver(subscriptionSchema),
-    defaultValues: { 
-      plan_id: '', 
+    defaultValues: {
+      plan_id: '',
       start_at: new Date().toISOString().slice(0, 16),
       end_at: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 16),
       auto_grant_credits: true,
     },
   });
 
+  const getStatusLabel = (status: string) => t(`users.subscriptionStatus.${status in STATUS_VARIANT ? status : 'inactive'}`);
+  const getStatusVariant = (status: string) => STATUS_VARIANT[status] ?? STATUS_VARIANT.inactive;
+
   const handleDelete = async (id: string) => {
     try {
       await api.delete(`/admin/users/${id}`);
-      toast({
-        title: "用户删除成功",
-        description: "用户已从系统中移除",
-      });
+      toast({ title: t('users.toast.deleteSuccess'), description: t('users.toast.deleteSuccessDesc') });
       mutate('/admin/users');
-    } catch (err) {
-      toast({
-        variant: "destructive",
-        title: "删除用户失败",
-        description: "请稍后重试",
-      });
+    } catch {
+      toast({ variant: 'destructive', title: t('users.toast.deleteFailed'), description: t('users.toast.retryLater') });
     }
   };
 
@@ -215,18 +211,17 @@ export default function UsersPage() {
         amount: values.amount,
         description: values.description,
       });
-      toast({ 
-        title: values.amount > 0 ? '充值成功' : '扣除成功',
-        description: `已${values.amount > 0 ? '充值' : '扣除'} ${Math.abs(values.amount)} 积分`,
+      const isRecharge = values.amount > 0;
+      toast({
+        title: isRecharge ? t('users.toast.rechargeSuccess') : t('users.toast.deductSuccess'),
+        description: isRecharge
+          ? t('users.toast.rechargeDesc', { amount: Math.abs(values.amount) })
+          : t('users.toast.deductDesc', { amount: Math.abs(values.amount) }),
       });
       setCreditDialogOpen(false);
       mutate('/admin/users');
     } catch (err: any) {
-      toast({
-        variant: 'destructive',
-        title: '操作失败',
-        description: err?.response?.data?.detail || '请稍后重试',
-      });
+      toast({ variant: 'destructive', title: t('users.toast.operationFailed'), description: err?.response?.data?.detail || t('users.toast.retryLater') });
     } finally {
       setSubmitting(false);
     }
@@ -242,15 +237,11 @@ export default function UsersPage() {
         end_at: new Date(values.end_at).toISOString(),
         auto_grant_credits: values.auto_grant_credits,
       });
-      toast({ title: '订阅设置成功' });
+      toast({ title: t('users.toast.subscriptionSetSuccess') });
       setSubscriptionDialogOpen(false);
       mutate('/admin/users');
     } catch (err: any) {
-      toast({
-        variant: 'destructive',
-        title: '设置失败',
-        description: err?.response?.data?.detail || '请稍后重试',
-      });
+      toast({ variant: 'destructive', title: t('users.toast.subscriptionSetFailed'), description: err?.response?.data?.detail || t('users.toast.retryLater') });
     } finally {
       setSubmitting(false);
     }
@@ -259,64 +250,64 @@ export default function UsersPage() {
   const cancelSubscription = async (userId: string) => {
     try {
       await api.delete(`/admin/users/${userId}/subscription`);
-      toast({ title: '订阅已取消' });
+      toast({ title: t('users.toast.subscriptionCanceled') });
       mutate('/admin/users');
     } catch (err: any) {
-      toast({
-        variant: 'destructive',
-        title: '取消失败',
-        description: err?.response?.data?.detail || '请稍后重试',
-      });
+      toast({ variant: 'destructive', title: t('users.toast.subscriptionCancelFailed'), description: err?.response?.data?.detail || t('users.toast.retryLater') });
     }
   };
-
-  const [recalcingAll, setRecalcingAll] = useState(false);
 
   const handleRecalcAll = async () => {
     setRecalcingAll(true);
     try {
       await api.post('/admin/users/recalc-all-storage');
-      toast({ title: '存储用量重算完成' });
+      toast({ title: t('users.toast.recalcSuccess') });
       mutate('/admin/users');
     } catch {
-      toast({ variant: 'destructive', title: '重算失败' });
+      toast({ variant: 'destructive', title: t('users.toast.recalcFailed') });
     } finally {
       setRecalcingAll(false);
     }
   };
 
+  const getAuthProviderLabel = (u: User) => {
+    if (u.google_id && u.github_id) return t('users.detail.providerGoogleGitHub');
+    if (u.google_id) return t('users.detail.providerGoogle');
+    if (u.github_id) return t('users.detail.providerGitHub');
+    return t('users.detail.providerLocal');
+  };
+
   return (
     <div className="max-w-[1200px] mx-auto w-full space-y-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-3xl font-bold tracking-tight">用户管理</h2>
+        <h2 className="text-3xl font-bold tracking-tight">{t('users.title')}</h2>
         <Button variant="outline" size="sm" onClick={handleRecalcAll} disabled={recalcingAll}>
           <RefreshCw className={`h-3.5 w-3.5 mr-1.5 ${recalcingAll ? 'animate-spin' : ''}`} />
-          {recalcingAll ? '重算中...' : '重算存储用量'}
+          {recalcingAll ? t('users.actions.recalcing') : t('users.actions.recalcStorage')}
         </Button>
       </div>
       <div className="rounded-md border bg-card">
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead>用户</TableHead>
-              <TableHead className="text-right">积分</TableHead>
-              <TableHead className="text-right">Token (输入/输出)</TableHead>
-              <TableHead>订阅状态</TableHead>
-              <TableHead>存储用量</TableHead>
-              <TableHead>注册来源</TableHead>
-              <TableHead>时间</TableHead>
-              <TableHead className="text-right">操作</TableHead>
+              <TableHead>{t('users.table.user')}</TableHead>
+              <TableHead className="text-right">{t('users.table.credits')}</TableHead>
+              <TableHead className="text-right">{t('users.table.tokenIO')}</TableHead>
+              <TableHead>{t('users.table.subscriptionStatus')}</TableHead>
+              <TableHead>{t('users.table.storage')}</TableHead>
+              <TableHead>{t('users.table.authSource')}</TableHead>
+              <TableHead>{t('users.table.time')}</TableHead>
+              <TableHead className="text-right">{t('users.table.actions')}</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {isLoading ? (
               <TableRow>
                 <TableCell colSpan={8} className="h-24 text-center">
-                  加载中...
+                  {t('users.table.loading')}
                 </TableCell>
               </TableRow>
             ) : users?.map((user) => {
-              const statusInfo = SUBSCRIPTION_STATUS_MAP[user.subscription_status] || SUBSCRIPTION_STATUS_MAP.inactive;
               const usedBytes = user.storage_used_bytes || 0;
               const quotaBytes = user.storage_quota_bytes || 2147483648;
               const usagePercent = Math.min(100, Math.round(usedBytes / quotaBytes * 100));
@@ -338,7 +329,7 @@ export default function UsersPage() {
                     </div>
                   </TableCell>
                   <TableCell>
-                    <Badge variant={statusInfo.variant}>{statusInfo.label}</Badge>
+                    <Badge variant={getStatusVariant(user.subscription_status)}>{getStatusLabel(user.subscription_status)}</Badge>
                   </TableCell>
                   <TableCell>
                     <TooltipProvider>
@@ -353,7 +344,7 @@ export default function UsersPage() {
                           </div>
                         </TooltipTrigger>
                         <TooltipContent>
-                          <p>使用率: {usagePercent}%</p>
+                          <p>{t('users.tooltip.usageRate', { percent: usagePercent })}</p>
                         </TooltipContent>
                       </Tooltip>
                     </TooltipProvider>
@@ -369,17 +360,17 @@ export default function UsersPage() {
                   </TableCell>
                   <TableCell className="text-right">
                     <div className="flex items-center justify-end gap-1">
-                      <Button variant="ghost" size="icon" title="查看详情" onClick={() => openDetailDialog(user)}>
+                      <Button variant="ghost" size="icon" title={t('users.tooltip.viewDetail')} onClick={() => openDetailDialog(user)}>
                         <Eye className="h-4 w-4" />
                       </Button>
-                      <Button variant="ghost" size="icon" title="积分管理" onClick={() => openCreditDialog(user)}>
+                      <Button variant="ghost" size="icon" title={t('users.tooltip.manageCredits')} onClick={() => openCreditDialog(user)}>
                         <Coins className="h-4 w-4" />
                       </Button>
-                      <Button variant="ghost" size="icon" title="订阅管理" onClick={() => openSubscriptionDialog(user)}>
+                      <Button variant="ghost" size="icon" title={t('users.tooltip.manageSubscription')} onClick={() => openSubscriptionDialog(user)}>
                         <CreditCard className="h-4 w-4" />
                       </Button>
                       <Link href={`/admin/users/${user.id}/credits`}>
-                        <Button variant="ghost" size="icon" title="积分历史">
+                        <Button variant="ghost" size="icon" title={t('users.tooltip.creditHistory')}>
                           <History className="h-4 w-4" />
                         </Button>
                       </Link>
@@ -391,14 +382,12 @@ export default function UsersPage() {
                         </AlertDialogTrigger>
                         <AlertDialogContent>
                           <AlertDialogHeader>
-                            <AlertDialogTitle>确认删除？</AlertDialogTitle>
-                            <AlertDialogDescription>
-                              此操作不可撤销。这将永久删除该用户及其相关数据。
-                            </AlertDialogDescription>
+                            <AlertDialogTitle>{t('users.delete.title')}</AlertDialogTitle>
+                            <AlertDialogDescription>{t('users.delete.description')}</AlertDialogDescription>
                           </AlertDialogHeader>
                           <AlertDialogFooter>
-                            <AlertDialogCancel>取消</AlertDialogCancel>
-                            <AlertDialogAction onClick={() => handleDelete(user.id)}>确认删除</AlertDialogAction>
+                            <AlertDialogCancel>{t('users.delete.cancel')}</AlertDialogCancel>
+                            <AlertDialogAction onClick={() => handleDelete(user.id)}>{t('users.delete.confirm')}</AlertDialogAction>
                           </AlertDialogFooter>
                         </AlertDialogContent>
                       </AlertDialog>
@@ -414,10 +403,9 @@ export default function UsersPage() {
       {/* 用户详情 Dialog */}
       <Dialog open={detailDialogOpen} onOpenChange={setDetailDialogOpen}>
         <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto p-0">
-          <VisuallyHidden><DialogTitle>用户详情</DialogTitle></VisuallyHidden>
+          <VisuallyHidden><DialogTitle>{t('users.detail.title')}</DialogTitle></VisuallyHidden>
           {selectedUser && (() => {
             const u = selectedUser;
-            const statusInfo = SUBSCRIPTION_STATUS_MAP[u.subscription_status] || SUBSCRIPTION_STATUS_MAP.inactive;
             const usedBytes = u.storage_used_bytes || 0;
             const quotaBytes = u.storage_quota_bytes || 2147483648;
             const usagePercent = Math.min(100, Math.round(usedBytes / quotaBytes * 100));
@@ -435,8 +423,8 @@ export default function UsersPage() {
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2 mb-1">
                         <h3 className="text-lg font-semibold truncate">{u.nickname}</h3>
-                        <Badge variant={u.is_active ? 'default' : 'destructive'} className="text-[10px] px-1.5 py-0">{u.is_active ? '活跃' : '禁用'}</Badge>
-                        {u.is_balance_frozen && <Badge variant="destructive" className="text-[10px] px-1.5 py-0">余额冻结</Badge>}
+                        <Badge variant={u.is_active ? 'default' : 'destructive'} className="text-[10px] px-1.5 py-0">{u.is_active ? t('users.detail.active') : t('users.detail.disabled')}</Badge>
+                        {u.is_balance_frozen && <Badge variant="destructive" className="text-[10px] px-1.5 py-0">{t('users.detail.frozen')}</Badge>}
                       </div>
                       <p className="text-sm text-muted-foreground">{u.email}</p>
                       <p className="text-xs text-muted-foreground mt-1 font-mono">{u.id}</p>
@@ -448,30 +436,25 @@ export default function UsersPage() {
                 <div className="px-6 py-5 space-y-5">
                   {/* 注册来源 */}
                   <div className="rounded-lg border p-4">
-                    <h4 className="text-sm font-medium mb-3 flex items-center gap-1.5"><Mail className="h-3.5 w-3.5 text-muted-foreground" />注册来源</h4>
+                    <h4 className="text-sm font-medium mb-3 flex items-center gap-1.5"><Mail className="h-3.5 w-3.5 text-muted-foreground" />{t('users.detail.authSource')}</h4>
                     <div className="flex items-center gap-2">
                       <AuthSourceBadge user={u} />
-                      <span className="text-sm text-muted-foreground">
-                        {u.google_id && u.github_id ? 'Google + GitHub 联合登录'
-                          : u.google_id ? 'Google 联合登录'
-                          : u.github_id ? 'GitHub 联合登录'
-                          : '本地注册'}
-                      </span>
+                      <span className="text-sm text-muted-foreground">{getAuthProviderLabel(u)}</span>
                     </div>
                   </div>
 
                   {/* 账户数据统计卡片 */}
                   <div className="grid grid-cols-3 gap-3">
                     <div className="rounded-lg border p-3 text-center">
-                      <p className="text-xs text-muted-foreground mb-1">积分余额</p>
+                      <p className="text-xs text-muted-foreground mb-1">{t('users.detail.stats.creditBalance')}</p>
                       <p className="text-lg font-semibold font-mono">{Number(u.credits || 0).toFixed(2)}</p>
                     </div>
                     <div className="rounded-lg border p-3 text-center">
-                      <p className="text-xs text-muted-foreground mb-1">输入 Token</p>
+                      <p className="text-xs text-muted-foreground mb-1">{t('users.detail.stats.inputToken')}</p>
                       <p className="text-lg font-semibold font-mono">{(u.total_input_tokens || 0).toLocaleString()}</p>
                     </div>
                     <div className="rounded-lg border p-3 text-center">
-                      <p className="text-xs text-muted-foreground mb-1">输出 Token</p>
+                      <p className="text-xs text-muted-foreground mb-1">{t('users.detail.stats.outputToken')}</p>
                       <p className="text-lg font-semibold font-mono">{(u.total_output_tokens || 0).toLocaleString()}</p>
                     </div>
                   </div>
@@ -479,7 +462,7 @@ export default function UsersPage() {
                   {/* 存储空间 */}
                   <div className="rounded-lg border p-4">
                     <div className="flex items-center justify-between mb-2">
-                      <span className="text-sm font-medium flex items-center gap-1.5"><HardDrive className="h-3.5 w-3.5 text-muted-foreground" />存储空间</span>
+                      <span className="text-sm font-medium flex items-center gap-1.5"><HardDrive className="h-3.5 w-3.5 text-muted-foreground" />{t('users.detail.storage.title')}</span>
                       <span className="text-xs text-muted-foreground">{formatBytes(usedBytes)} / {formatBytes(quotaBytes)} ({usagePercent}%)</span>
                     </div>
                     <Progress value={usagePercent} className="h-1.5" />
@@ -487,26 +470,26 @@ export default function UsersPage() {
 
                   {/* 订阅信息 */}
                   <div className="rounded-lg border p-4">
-                    <h4 className="text-sm font-medium mb-3 flex items-center gap-1.5"><CreditCard className="h-3.5 w-3.5 text-muted-foreground" />订阅信息</h4>
+                    <h4 className="text-sm font-medium mb-3 flex items-center gap-1.5"><CreditCard className="h-3.5 w-3.5 text-muted-foreground" />{t('users.detail.subscription.title')}</h4>
                     <div className="grid grid-cols-2 gap-3 text-sm">
-                      <DetailRow label="订阅状态" value={<Badge variant={statusInfo.variant}>{statusInfo.label}</Badge>} />
-                      <DetailRow label="当前套餐" value={planName || '-'} />
-                      <DetailRow label="开始时间" value={formatDateTime(u.subscription_start_at)} />
-                      <DetailRow label="到期时间" value={formatDateTime(u.subscription_end_at)} />
+                      <DetailRow label={t('users.detail.subscription.status')} value={<Badge variant={getStatusVariant(u.subscription_status)}>{getStatusLabel(u.subscription_status)}</Badge>} />
+                      <DetailRow label={t('users.detail.subscription.plan')} value={planName || t('users.detail.subscription.empty')} />
+                      <DetailRow label={t('users.detail.subscription.startTime')} value={formatDateTime(u.subscription_start_at)} />
+                      <DetailRow label={t('users.detail.subscription.endTime')} value={formatDateTime(u.subscription_end_at)} />
                     </div>
                   </div>
 
                   {/* 登录与设备 */}
                   <div className="rounded-lg border p-4">
-                    <h4 className="text-sm font-medium mb-3 flex items-center gap-1.5"><Globe className="h-3.5 w-3.5 text-muted-foreground" />登录与设备</h4>
+                    <h4 className="text-sm font-medium mb-3 flex items-center gap-1.5"><Globe className="h-3.5 w-3.5 text-muted-foreground" />{t('users.detail.login.title')}</h4>
                     <div className="grid grid-cols-2 gap-3 text-sm">
-                      <DetailRow label="注册时间" value={formatDateTime(u.created_at)} />
-                      <DetailRow label="最后登录" value={formatDateTime(u.last_login_at)} />
-                      <DetailRow label="注册IP" value={<span className="font-mono text-xs">{u.register_ip || '-'}</span>} />
-                      <DetailRow label="登录IP" value={<span className="font-mono text-xs">{u.last_login_ip || '-'}</span>} />
-                      <DetailRow label="设备类型" value={<span className="flex items-center gap-1"><DeviceIcon className="h-3.5 w-3.5" />{u.last_device_type || '-'}</span>} />
-                      <DetailRow label="操作系统" value={u.last_os || '-'} />
-                      <DetailRow label="浏览器" value={u.last_browser || '-'} />
+                      <DetailRow label={t('users.detail.login.registerTime')} value={formatDateTime(u.created_at)} />
+                      <DetailRow label={t('users.detail.login.lastLogin')} value={formatDateTime(u.last_login_at)} />
+                      <DetailRow label={t('users.detail.login.registerIp')} value={<span className="font-mono text-xs">{u.register_ip || '-'}</span>} />
+                      <DetailRow label={t('users.detail.login.loginIp')} value={<span className="font-mono text-xs">{u.last_login_ip || '-'}</span>} />
+                      <DetailRow label={t('users.detail.login.deviceType')} value={<span className="flex items-center gap-1"><DeviceIcon className="h-3.5 w-3.5" />{u.last_device_type || '-'}</span>} />
+                      <DetailRow label={t('users.detail.login.os')} value={u.last_os || '-'} />
+                      <DetailRow label={t('users.detail.login.browser')} value={u.last_browser || '-'} />
                     </div>
                   </div>
                 </div>
@@ -520,9 +503,9 @@ export default function UsersPage() {
       <Dialog open={creditDialogOpen} onOpenChange={setCreditDialogOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>积分管理</DialogTitle>
+            <DialogTitle>{t('users.credit.dialogTitle')}</DialogTitle>
             <DialogDescription>
-              为用户 {selectedUser?.nickname} 调整积分（当前余额: {Number(selectedUser?.credits || 0).toFixed(2)}）
+              {t('users.credit.description', { nickname: selectedUser?.nickname ?? '', balance: Number(selectedUser?.credits || 0).toFixed(2) })}
             </DialogDescription>
           </DialogHeader>
           <Form {...creditForm}>
@@ -532,12 +515,12 @@ export default function UsersPage() {
                 name="amount"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>调整金额</FormLabel>
+                    <FormLabel>{t('users.credit.amount')}</FormLabel>
                     <FormControl>
                       <Input
                         type="number"
                         step="0.01"
-                        placeholder="正数=充值，负数=扣除"
+                        placeholder={t('users.credit.amountPlaceholder')}
                         value={field.value}
                         onChange={e => field.onChange(Number(e.target.value))}
                       />
@@ -551,18 +534,18 @@ export default function UsersPage() {
                 name="description"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>操作说明</FormLabel>
+                    <FormLabel>{t('users.credit.reason')}</FormLabel>
                     <FormControl>
-                      <Textarea placeholder="请输入操作原因" rows={2} {...field} />
+                      <Textarea placeholder={t('users.credit.reasonPlaceholder')} rows={2} {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
                 )}
               />
               <DialogFooter>
-                <Button type="button" variant="outline" onClick={() => setCreditDialogOpen(false)}>取消</Button>
+                <Button type="button" variant="outline" onClick={() => setCreditDialogOpen(false)}>{t('users.credit.cancel')}</Button>
                 <Button type="submit" disabled={submitting}>
-                  {submitting ? '提交中...' : '确认'}
+                  {submitting ? t('users.credit.submitting') : t('users.credit.confirm')}
                 </Button>
               </DialogFooter>
             </form>
@@ -574,9 +557,9 @@ export default function UsersPage() {
       <Dialog open={subscriptionDialogOpen} onOpenChange={setSubscriptionDialogOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>订阅管理</DialogTitle>
+            <DialogTitle>{t('users.subscription.dialogTitle')}</DialogTitle>
             <DialogDescription>
-              为用户 {selectedUser?.nickname} 设置订阅套餐
+              {t('users.subscription.description', { nickname: selectedUser?.nickname ?? '' })}
             </DialogDescription>
           </DialogHeader>
           <Form {...subscriptionForm}>
@@ -586,16 +569,16 @@ export default function UsersPage() {
                 name="plan_id"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>订阅套餐</FormLabel>
+                    <FormLabel>{t('users.subscription.plan')}</FormLabel>
                     <FormControl>
                       <Select onValueChange={field.onChange} value={field.value}>
                         <SelectTrigger>
-                          <SelectValue placeholder="选择套餐" />
+                          <SelectValue placeholder={t('users.subscription.planPlaceholder')} />
                         </SelectTrigger>
                         <SelectContent>
                           {plans?.filter(p => p.is_active).map(plan => (
                             <SelectItem key={plan.id} value={plan.id}>
-                              {plan.name} - ${plan.price_usd} ({plan.credits} 积分)
+                              {t('users.subscription.planItem', { name: plan.name, price: plan.price_usd, credits: plan.credits })}
                             </SelectItem>
                           ))}
                         </SelectContent>
@@ -611,7 +594,7 @@ export default function UsersPage() {
                   name="start_at"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>开始时间</FormLabel>
+                      <FormLabel>{t('users.subscription.startTime')}</FormLabel>
                       <FormControl>
                         <Input type="datetime-local" {...field} />
                       </FormControl>
@@ -624,7 +607,7 @@ export default function UsersPage() {
                   name="end_at"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>结束时间</FormLabel>
+                      <FormLabel>{t('users.subscription.endTime')}</FormLabel>
                       <FormControl>
                         <Input type="datetime-local" {...field} />
                       </FormControl>
@@ -639,7 +622,7 @@ export default function UsersPage() {
                 render={({ field }) => (
                   <FormItem>
                     <div className="flex items-center justify-between">
-                      <FormLabel>自动发放套餐积分</FormLabel>
+                      <FormLabel>{t('users.subscription.autoGrant')}</FormLabel>
                       <FormControl>
                         <Switch checked={field.value} onCheckedChange={field.onChange} />
                       </FormControl>
@@ -658,12 +641,12 @@ export default function UsersPage() {
                       setSubscriptionDialogOpen(false);
                     }}
                   >
-                    取消订阅
+                    {t('users.subscription.cancelSub')}
                   </Button>
                 )}
-                <Button type="button" variant="outline" onClick={() => setSubscriptionDialogOpen(false)}>取消</Button>
+                <Button type="button" variant="outline" onClick={() => setSubscriptionDialogOpen(false)}>{t('users.subscription.cancel')}</Button>
                 <Button type="submit" disabled={submitting}>
-                  {submitting ? '提交中...' : '设置订阅'}
+                  {submitting ? t('users.subscription.submitting') : t('users.subscription.submit')}
                 </Button>
               </DialogFooter>
             </form>

--- a/backend/admin/src/components/admin/AdminLayout.tsx
+++ b/backend/admin/src/components/admin/AdminLayout.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 import { usePathname } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/context/AuthContext';
 import { Toaster } from '@/components/ui/toaster';
 import { cn } from '@/lib/utils';
@@ -10,7 +11,6 @@ import {
   Bot,
   Zap,
   Users,
-  BookOpen,
   CreditCard,
   Shield,
   ChevronLeft,
@@ -23,6 +23,8 @@ import {
   ServerCog,
   Wrench,
   UserCircle,
+  Languages,
+  Check,
 } from 'lucide-react';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
@@ -32,14 +34,23 @@ import {
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+
+const LANGUAGES = [
+  { code: 'zh-CN', labelKey: 'layout.language.zhCN' },
+  { code: 'en-US', labelKey: 'layout.language.enUS' },
+] as const;
 
 const AdminLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [collapsed, setCollapsed] = useState(false);
   const pathname = usePathname();
   const { logout, user } = useAuth();
+  const { t, i18n } = useTranslation();
 
   // If login page, don't show layout
   if (pathname === '/admin/login') {
@@ -48,66 +59,18 @@ const AdminLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
 
 
   const items = [
-    {
-      title: '仪表盘',
-      href: '/admin',
-      icon: LayoutDashboard,
-    },
-    {
-      title: 'AI 供应商',
-      href: '/admin/llm',
-      icon: Bot,
-    },
-    {
-      title: '智能体管理',
-      href: '/admin/agents',
-      icon: Zap,
-    },
-    {
-      title: '技能管理 (Skills)',
-      href: '/admin/skills',
-      icon: Blocks,
-    },
-    {
-      title: 'MCP 客户端',
-      href: '/admin/mcp',
-      icon: ServerCog,
-    },
-    {
-      title: '工具管理',
-      href: '/admin/tools',
-      icon: Wrench,
-    },
-    {
-      title: '视频生成',
-      href: '/admin/videos',
-      icon: Film,
-    },
-    {
-      title: '虚拟人像',
-      href: '/admin/virtual-humans',
-      icon: UserCircle,
-    },
-    {
-      title: '提示词模板',
-      href: '/admin/prompt-templates',
-      icon: FileCode2,
-    },
-    {
-      title: '用户管理',
-      href: '/admin/users',
-      icon: Users,
-    },
-    {
-      title: '订阅套餐',
-      href: '/admin/subscriptions',
-      icon: CreditCard,
-    },
-    {
-      title: '管理员',
-      href: '/admin/admins',
-      icon: Shield,
-    },
+    { title: t('layout.sidebar.dashboard'), href: '/admin', icon: LayoutDashboard },
+    { title: t('layout.sidebar.llm'), href: '/admin/llm', icon: Bot },
+    { title: t('layout.sidebar.agents'), href: '/admin/agents', icon: Zap },
+    { title: t('layout.sidebar.skills'), href: '/admin/skills', icon: Blocks },
+    { title: t('layout.sidebar.mcp'), href: '/admin/mcp', icon: ServerCog },
+    { title: t('layout.sidebar.tools'), href: '/admin/tools', icon: Wrench },
+    { title: t('layout.sidebar.videos'), href: '/admin/videos', icon: Film },
+    { title: t('layout.sidebar.virtualHumans'), href: '/admin/virtual-humans', icon: UserCircle },
+    { title: t('layout.sidebar.promptTemplates'), href: '/admin/prompt-templates', icon: FileCode2 },
+    { title: t('layout.sidebar.users'), href: '/admin/users', icon: Users },
+    { title: t('layout.sidebar.subscriptions'), href: '/admin/subscriptions', icon: CreditCard },
+    { title: t('layout.sidebar.admins'), href: '/admin/admins', icon: Shield },
   ];
 
   // 某些子页面需要全屏/无内边距布局（如：创建/编辑智能体页面有自己的滚动和分栏机制）
@@ -135,7 +98,7 @@ const AdminLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
             onClick={() => setCollapsed(!collapsed)}
           >
             {collapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
-            <span className="sr-only">Toggle Menu</span>
+            <span className="sr-only">{t('layout.sidebar.toggleMenu')}</span>
           </Button>
         </div>
         
@@ -175,7 +138,7 @@ const AdminLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
                    </Avatar>
                    {!collapsed && (
                      <div className="flex flex-col items-start text-xs flex-1 min-w-0">
-                       <span className="font-medium truncate w-full text-left">{user?.nickname || '管理员'}</span>
+                       <span className="font-medium truncate w-full text-left">{user?.nickname || t('layout.account.admin')}</span>
                        <span className="text-muted-foreground truncate w-full text-left">{user?.email || 'admin@infinitetheater.com'}</span>
                      </div>
                    )}
@@ -184,11 +147,34 @@ const AdminLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start" side="right" className="w-56" sideOffset={10}>
-                <DropdownMenuLabel>{user?.nickname || '我的账户'}</DropdownMenuLabel>
+                <DropdownMenuLabel>{user?.nickname || t('layout.account.myAccount')}</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuSub>
+                  <DropdownMenuSubTrigger>
+                    <Languages className="mr-2 h-4 w-4" />
+                    <span>{t('layout.language.label')}</span>
+                  </DropdownMenuSubTrigger>
+                  <DropdownMenuSubContent>
+                    {LANGUAGES.map((lang) => (
+                      <DropdownMenuItem
+                        key={lang.code}
+                        onClick={() => i18n.changeLanguage(lang.code)}
+                      >
+                        <Check
+                          className={cn(
+                            "mr-2 h-4 w-4",
+                            i18n.language === lang.code ? "opacity-100" : "opacity-0"
+                          )}
+                        />
+                        <span>{t(lang.labelKey)}</span>
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuSubContent>
+                </DropdownMenuSub>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem onClick={logout}>
                     <LogOut className="mr-2 h-4 w-4" />
-                    <span>退出登录</span>
+                    <span>{t('layout.account.logout')}</span>
                 </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>

--- a/backend/admin/src/components/admin/agents/AgentForm/BasicInfo.tsx
+++ b/backend/admin/src/components/admin/agents/AgentForm/BasicInfo.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 import Image from 'next/image';
 import {
   FormControl,
@@ -51,6 +52,7 @@ const BasicInfo: React.FC<BasicInfoProps> = ({
   isFormInitialized
 }) => {
   const { control, watch, setValue } = useFormContext();
+  const { t } = useTranslation();
   const selectedProviderId = watch('provider_id');
   const selectedModel = watch('model');
 
@@ -67,9 +69,9 @@ const BasicInfo: React.FC<BasicInfoProps> = ({
         name="name"
         render={({ field }) => (
           <FormItem>
-            <FormLabel>名称 <span className="text-destructive">*</span></FormLabel>
+            <FormLabel>{t('agents.form.fieldLabels.name')} <span className="text-destructive">*</span></FormLabel>
             <FormControl>
-              <Input placeholder="给智能体起个名字，例如: 故事导演" disabled={loading} {...field} />
+              <Input placeholder={t('agents.form.basicInfo.namePlaceholder')} disabled={loading} {...field} />
             </FormControl>
             <FormMessage />
           </FormItem>
@@ -81,10 +83,10 @@ const BasicInfo: React.FC<BasicInfoProps> = ({
         name="description"
         render={({ field }) => (
           <FormItem>
-            <FormLabel>描述 <span className="text-destructive">*</span></FormLabel>
+            <FormLabel>{t('agents.form.fieldLabels.description')} <span className="text-destructive">*</span></FormLabel>
             <FormControl>
               <Textarea 
-                placeholder="简要描述智能体的职责和功能..." 
+                placeholder={t('agents.form.basicInfo.descPlaceholder')} 
                 disabled={loading} 
                 className="resize-none" 
                 rows={3}
@@ -97,14 +99,14 @@ const BasicInfo: React.FC<BasicInfoProps> = ({
       />
 
       <div className="p-4 bg-muted/50 rounded-xl border">
-        <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground mb-3">模型配置</div>
+        <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground mb-3">{t('agents.form.basicInfo.modelConfig')}</div>
         <div className="grid grid-cols-2 gap-4">
           <FormField
             control={control}
             name="provider_id"
             render={({ field }) => (
               <FormItem>
-                <FormLabel className="text-xs">供应商 <span className="text-destructive">*</span></FormLabel>
+                <FormLabel className="text-xs">{t('agents.form.fieldLabels.provider_id')} <span className="text-destructive">*</span></FormLabel>
                 <Select 
                   onValueChange={(value) => {
                     field.onChange(value);
@@ -118,7 +120,7 @@ const BasicInfo: React.FC<BasicInfoProps> = ({
                 >
                   <FormControl>
                     <SelectTrigger className="bg-background">
-                      <SelectValue placeholder="选择供应商" />
+                      <SelectValue placeholder={t('agents.form.basicInfo.selectProvider')} />
                     </SelectTrigger>
                   </FormControl>
                   <SelectContent>
@@ -149,7 +151,7 @@ const BasicInfo: React.FC<BasicInfoProps> = ({
             name="model"
             render={({ field }) => (
               <FormItem>
-                <FormLabel className="text-xs">模型 <span className="text-destructive">*</span></FormLabel>
+                <FormLabel className="text-xs">{t('agents.form.fieldLabels.model')} <span className="text-destructive">*</span></FormLabel>
                 <Select 
                   onValueChange={(value) => {
                     // 防止意外清空：只有当新值非空或用户主动选择时才更新
@@ -162,7 +164,7 @@ const BasicInfo: React.FC<BasicInfoProps> = ({
                 >
                   <FormControl>
                     <SelectTrigger className="bg-background">
-                      <SelectValue placeholder={selectedProviderId ? "选择模型" : "先选择供应商"} />
+                      <SelectValue placeholder={selectedProviderId ? t('agents.form.basicInfo.selectModel') : t('agents.form.basicInfo.selectProviderFirst')} />
                     </SelectTrigger>
                   </FormControl>
                   <SelectContent>

--- a/backend/admin/src/components/admin/agents/AgentForm/LeaderConfig.tsx
+++ b/backend/admin/src/components/admin/agents/AgentForm/LeaderConfig.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 import {
   FormControl,
   FormField,
@@ -21,6 +22,7 @@ interface LeaderConfigProps {
 
 const LeaderConfig: React.FC<LeaderConfigProps> = ({ disabled, availableAgents = [] }) => {
   const { control, watch } = useFormContext();
+  const { t } = useTranslation();
   const isLeader = watch('is_leader');
   const currentAgentId = watch('id');
 
@@ -32,9 +34,9 @@ const LeaderConfig: React.FC<LeaderConfigProps> = ({ disabled, availableAgents =
       {/* Enable Leader Mode */}
       <div className="flex justify-between items-center">
         <div>
-          <span className="text-sm font-medium">Leader 模式</span>
+          <span className="text-sm font-medium">{t('agents.form.leader.leaderMode')}</span>
           <p className="text-xs text-muted-foreground mt-1">
-            启用后可智能协调其他智能体完成复杂任务，简单任务直接回复
+            {t('agents.form.leader.leaderModeDesc')}
           </p>
         </div>
         <FormField
@@ -62,8 +64,8 @@ const LeaderConfig: React.FC<LeaderConfigProps> = ({ disabled, availableAgents =
             name="member_agent_ids"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>成员智能体</FormLabel>
-                <FormDescription>选择可调度的智能体</FormDescription>
+                <FormLabel>{t('agents.form.leader.memberAgents')}</FormLabel>
+                <FormDescription>{t('agents.form.leader.memberAgentsDesc')}</FormDescription>
                 <div className="grid grid-cols-1 gap-2 mt-2 max-h-48 overflow-y-auto">
                   {memberOptions.length > 0 ? (
                     memberOptions.map((agent) => (
@@ -98,7 +100,7 @@ const LeaderConfig: React.FC<LeaderConfigProps> = ({ disabled, availableAgents =
                     ))
                   ) : (
                     <p className="text-xs text-muted-foreground p-2">
-                      暂无可用的成员智能体，请先创建其他智能体
+                      {t('agents.form.leader.noMembers')}
                     </p>
                   )}
                 </div>
@@ -114,7 +116,7 @@ const LeaderConfig: React.FC<LeaderConfigProps> = ({ disabled, availableAgents =
             render={({ field }) => (
               <FormItem>
                 <div className="flex justify-between">
-                  <FormLabel>最大子任务数</FormLabel>
+                  <FormLabel>{t('agents.form.leader.maxSubtasks')}</FormLabel>
                   <span className="text-sm text-muted-foreground">{field.value}</span>
                 </div>
                 <FormControl>
@@ -128,7 +130,7 @@ const LeaderConfig: React.FC<LeaderConfigProps> = ({ disabled, availableAgents =
                   />
                 </FormControl>
                 <FormDescription>
-                  限制单次任务可拆解的最大子任务数量
+                  {t('agents.form.leader.maxSubtasksDesc')}
                 </FormDescription>
               </FormItem>
             )}
@@ -137,9 +139,9 @@ const LeaderConfig: React.FC<LeaderConfigProps> = ({ disabled, availableAgents =
           {/* Auto Review */}
           <div className="flex justify-between items-center">
             <div>
-              <span className="text-sm font-medium">自动审查</span>
+              <span className="text-sm font-medium">{t('agents.form.leader.autoReview')}</span>
               <p className="text-xs text-muted-foreground mt-1">
-                子任务完成后由 Leader 自动审查结果
+                {t('agents.form.leader.autoReviewDesc')}
               </p>
             </div>
             <FormField

--- a/backend/admin/src/components/admin/agents/AgentForm/Parameters.tsx
+++ b/backend/admin/src/components/admin/agents/AgentForm/Parameters.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 import {
   FormControl,
   FormField,
@@ -22,17 +23,17 @@ import {
 import { LLMProvider } from '@/types';
 import { getModelDisplayName } from '@/lib/api-utils';
 
-// 积分定价维度映射表（避免 if-else）
+// 积分定价维度映射表（避免 if-else），label/unit 改为 i18n key
 const COST_DIMENSIONS = [
-  { key: 'input', label: '输入价格', unit: '积分/1M tokens', costUnit: '/1M tokens', formField: 'input_credit_per_1m', step: 0.01, group: 'base' },
-  { key: 'text_output', label: '输出价格', unit: '积分/1M tokens', costUnit: '/1M tokens', formField: 'output_credit_per_1m', step: 0.01, group: 'base' },
-  { key: 'image_output', label: '图片输出价格', unit: '积分/1M tokens', costUnit: '/1M tokens', formField: 'image_output_credit_per_1m', step: 0.01, group: 'gemini' },
-  { key: 'search', label: '搜索查询价格', unit: '积分/次', costUnit: '/次', formField: 'search_credit_per_query', step: 0.1, group: 'gemini_search' },
-  { key: 'image_generation', label: '图片生成价格', unit: '积分/张', costUnit: '/张', formField: 'image_credit_per_image', step: 0.1, group: 'image_gen' },
-  { key: 'video_input_image', label: '视频-输入图片', unit: '积分/张', costUnit: '/张', formField: 'video_input_image_credit', step: 0.001, group: 'video' },
-  { key: 'video_input_second', label: '视频-输入时长', unit: '积分/秒', costUnit: '/秒', formField: 'video_input_second_credit', step: 0.001, group: 'video' },
-  { key: 'video_output_480p', label: '视频输出(480p)', unit: '积分/秒', costUnit: '/秒', formField: 'video_output_480p_credit', step: 0.001, group: 'video' },
-  { key: 'video_output_720p', label: '视频输出(720p)', unit: '积分/秒', costUnit: '/秒', formField: 'video_output_720p_credit', step: 0.001, group: 'video' },
+  { key: 'input', labelKey: 'agents.form.parameters.costDimensions.input', unitKey: 'agents.form.parameters.units.per_1m', costUnitKey: 'agents.form.parameters.costUnits.per_1m', formField: 'input_credit_per_1m', step: 0.01, group: 'base' },
+  { key: 'text_output', labelKey: 'agents.form.parameters.costDimensions.text_output', unitKey: 'agents.form.parameters.units.per_1m', costUnitKey: 'agents.form.parameters.costUnits.per_1m', formField: 'output_credit_per_1m', step: 0.01, group: 'base' },
+  { key: 'image_output', labelKey: 'agents.form.parameters.costDimensions.image_output', unitKey: 'agents.form.parameters.units.per_1m', costUnitKey: 'agents.form.parameters.costUnits.per_1m', formField: 'image_output_credit_per_1m', step: 0.01, group: 'gemini' },
+  { key: 'search', labelKey: 'agents.form.parameters.costDimensions.search', unitKey: 'agents.form.parameters.units.per_query', costUnitKey: 'agents.form.parameters.costUnits.per_query', formField: 'search_credit_per_query', step: 0.1, group: 'gemini_search' },
+  { key: 'image_generation', labelKey: 'agents.form.parameters.costDimensions.image_generation', unitKey: 'agents.form.parameters.units.per_image', costUnitKey: 'agents.form.parameters.costUnits.per_image', formField: 'image_credit_per_image', step: 0.1, group: 'image_gen' },
+  { key: 'video_input_image', labelKey: 'agents.form.parameters.costDimensions.video_input_image', unitKey: 'agents.form.parameters.units.per_image', costUnitKey: 'agents.form.parameters.costUnits.per_image', formField: 'video_input_image_credit', step: 0.001, group: 'video' },
+  { key: 'video_input_second', labelKey: 'agents.form.parameters.costDimensions.video_input_second', unitKey: 'agents.form.parameters.units.per_second', costUnitKey: 'agents.form.parameters.costUnits.per_second', formField: 'video_input_second_credit', step: 0.001, group: 'video' },
+  { key: 'video_output_480p', labelKey: 'agents.form.parameters.costDimensions.video_output_480p', unitKey: 'agents.form.parameters.units.per_second', costUnitKey: 'agents.form.parameters.costUnits.per_second', formField: 'video_output_480p_credit', step: 0.001, group: 'video' },
+  { key: 'video_output_720p', labelKey: 'agents.form.parameters.costDimensions.video_output_720p', unitKey: 'agents.form.parameters.units.per_second', costUnitKey: 'agents.form.parameters.costUnits.per_second', formField: 'video_output_720p_credit', step: 0.001, group: 'video' },
 ] as const;
 
 // 维度组可见性规则映射（避免 if-else 分支）
@@ -51,6 +52,7 @@ interface ParametersProps {
 
 const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
   const { control, watch, setValue } = useFormContext();
+  const { t } = useTranslation();
   const temperature = watch('temperature');
   const contextWindow = watch('context_window');
   const providerId = watch('provider_id');
@@ -102,7 +104,7 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
     <div className="space-y-6">
       <div className="rounded-xl border bg-card p-5">
          <div className="flex justify-between items-center mb-4">
-           <Label className="text-sm font-medium">思考模式</Label>
+           <Label className="text-sm font-medium">{t('agents.form.parameters.thinkingMode')}</Label>
            <FormField
               control={control}
               name="thinking_mode"
@@ -115,22 +117,22 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
                         onCheckedChange={field.onChange}
                         disabled={disabled}
                       />
-                      <span className="text-xs text-muted-foreground">{field.value ? '开启' : '关闭'}</span>
+                      <span className="text-xs text-muted-foreground">{field.value ? t('agents.form.parameters.on') : t('agents.form.parameters.off')}</span>
                     </div>
                   </FormControl>
                 </FormItem>
               )}
             />
          </div>
-         <p className="text-xs text-muted-foreground">开启后，模型会在回答前进行思考过程（Chain of Thought）。</p>
+         <p className="text-xs text-muted-foreground">{t('agents.form.parameters.thinkingModeDesc')}</p>
       </div>
 
       <div className="rounded-xl border bg-card p-5">
          <div className="mb-4">
            <div className="flex justify-between items-center mb-2">
-             <Label className="text-sm font-medium">上下文窗口</Label>
+             <Label className="text-sm font-medium">{t('agents.form.parameters.contextWindow')}</Label>
              <span className="text-xs font-mono bg-muted px-2 py-0.5 rounded text-muted-foreground">
-               {formatContextWindow(contextWindow || 4096)} ({contextWindow || 4096} tokens)
+               {t('agents.form.parameters.contextWindowValue', { display: formatContextWindow(contextWindow || 4096), tokens: contextWindow || 4096 })}
              </span>
            </div>
            <FormField
@@ -169,8 +171,8 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
               )}
             />
            <div className="flex justify-between text-xs text-muted-foreground mt-2">
-             <span>4K</span>
-             <span>1M</span>
+             <span>{t('agents.form.parameters.contextWindowMin')}</span>
+             <span>{t('agents.form.parameters.contextWindowMax')}</span>
            </div>
          </div>
       </div>
@@ -179,8 +181,8 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
       <div className="rounded-xl border bg-card p-5">
         <div className="flex justify-between items-center mb-2">
           <div>
-            <Label className="text-sm font-medium">上下文压缩</Label>
-            <p className="text-xs text-muted-foreground mt-1">对话过长时自动摘要压缩旧消息</p>
+            <Label className="text-sm font-medium">{t('agents.form.parameters.compaction.title')}</Label>
+            <p className="text-xs text-muted-foreground mt-1">{t('agents.form.parameters.compaction.desc')}</p>
           </div>
           <FormField
             control={control}
@@ -194,7 +196,7 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
                       onCheckedChange={field.onChange}
                       disabled={disabled}
                     />
-                    <span className="text-xs text-muted-foreground">{field.value ? '开启' : '关闭'}</span>
+                    <span className="text-xs text-muted-foreground">{field.value ? t('agents.form.parameters.compaction.on') : t('agents.form.parameters.compaction.off')}</span>
                   </div>
                 </FormControl>
               </FormItem>
@@ -206,7 +208,7 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
           <div className="space-y-4 pt-3 border-t mt-3">
             {/* 压缩供应商 */}
             <div className="space-y-1.5">
-              <Label className="text-xs text-muted-foreground">摘要生成供应商</Label>
+              <Label className="text-xs text-muted-foreground">{t('agents.form.parameters.compaction.compactionProvider')}</Label>
               <FormField
                 control={control}
                 name="compaction_config.provider_id"
@@ -222,10 +224,10 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
                         disabled={disabled}
                       >
                         <SelectTrigger className="bg-background">
-                          <SelectValue placeholder="选择供应商" />
+                          <SelectValue placeholder={t('agents.form.parameters.compaction.selectProvider')} />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value="_fallback">使用当前智能体的供应商（默认）</SelectItem>
+                          <SelectItem value="_fallback">{t('agents.form.parameters.compaction.useDefault')}</SelectItem>
                           {providers?.filter(p => p.is_active).map(p => (
                             <SelectItem key={p.id} value={p.id}>{p.name} ({p.provider_type})</SelectItem>
                           ))}
@@ -240,7 +242,7 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
             {/* 压缩模型 */}
             {compactionProviderId && (
               <div className="space-y-1.5">
-                <Label className="text-xs text-muted-foreground">摘要生成模型</Label>
+                <Label className="text-xs text-muted-foreground">{t('agents.form.parameters.compaction.compactionModel')}</Label>
                 <FormField
                   control={control}
                   name="compaction_config.model"
@@ -249,7 +251,7 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
                       <FormControl>
                         <Select value={field.value || ''} onValueChange={field.onChange} disabled={disabled}>
                           <SelectTrigger className="bg-background">
-                            <SelectValue placeholder="选择模型" />
+                            <SelectValue placeholder={t('agents.form.parameters.compaction.selectModel')} />
                           </SelectTrigger>
                           <SelectContent>
                             {compactionModelList.map((m) => (
@@ -272,7 +274,7 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel className="text-xs text-muted-foreground">
-                      压缩触发阈值 ({Math.round((field.value ?? 0.75) * 100)}%)
+                      {t('agents.form.parameters.compaction.compactRatio', { percent: Math.round((field.value ?? 0.75) * 100) })}
                     </FormLabel>
                     <FormControl>
                       <Input
@@ -293,7 +295,7 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel className="text-xs text-muted-foreground">
-                      保留比例 ({Math.round((field.value ?? 0.15) * 100)}%)
+                      {t('agents.form.parameters.compaction.reserveRatio', { percent: Math.round((field.value ?? 0.15) * 100) })}
                     </FormLabel>
                     <FormControl>
                       <Input
@@ -316,7 +318,7 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
                 name="compaction_config.tool_old_threshold"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel className="text-xs text-muted-foreground">旧工具截断字符数</FormLabel>
+                    <FormLabel className="text-xs text-muted-foreground">{t('agents.form.parameters.compaction.toolOldThreshold')}</FormLabel>
                     <FormControl>
                       <Input
                         type="number"
@@ -335,7 +337,7 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
                 name="compaction_config.tool_recent_n"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel className="text-xs text-muted-foreground">最近完整保留条数</FormLabel>
+                    <FormLabel className="text-xs text-muted-foreground">{t('agents.form.parameters.compaction.toolRecentN')}</FormLabel>
                     <FormControl>
                       <Input
                         type="number"
@@ -356,7 +358,7 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
               name="compaction_config.max_summary_tokens"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel className="text-xs text-muted-foreground">最大摘要 Token 数</FormLabel>
+                  <FormLabel className="text-xs text-muted-foreground">{t('agents.form.parameters.compaction.maxSummaryTokens')}</FormLabel>
                   <FormControl>
                     <Input
                       type="number"
@@ -367,7 +369,7 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
                       disabled={disabled}
                     />
                   </FormControl>
-                  <p className="text-[11px] text-muted-foreground">LLM 生成摘要时的 max_tokens 限制</p>
+                  <p className="text-[11px] text-muted-foreground">{t('agents.form.parameters.compaction.maxSummaryTokensDesc')}</p>
                 </FormItem>
               )}
             />
@@ -380,11 +382,11 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
         <div className="mb-4">
           <div className="flex justify-between items-center mb-2">
             <div>
-              <Label className="text-sm font-medium">工具调用轮次限制</Label>
-              <p className="text-xs text-muted-foreground mt-1">单轮对话中最大工具调用次数</p>
+              <Label className="text-sm font-medium">{t('agents.form.parameters.maxToolRounds.title')}</Label>
+              <p className="text-xs text-muted-foreground mt-1">{t('agents.form.parameters.maxToolRounds.desc')}</p>
             </div>
             <span className="text-xs font-mono bg-muted px-2 py-0.5 rounded text-muted-foreground">
-              {watch('max_tool_rounds') ?? 100} 次
+              {watch('max_tool_rounds') ?? 100} {t('agents.form.parameters.maxToolRounds.times')}
             </span>
           </div>
           <FormField
@@ -424,15 +426,15 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
             )}
           />
           <div className="flex justify-between text-xs text-muted-foreground mt-2">
-            <span>10次</span>
-            <span>200次</span>
+            <span>{t('agents.form.parameters.maxToolRounds.min')}</span>
+            <span>{t('agents.form.parameters.maxToolRounds.max')}</span>
           </div>
         </div>
       </div>
 
       <div className="rounded-xl border bg-card p-5">
         <div className="flex justify-between items-center mb-4">
-          <Label className="text-sm font-medium">温度 (Temperature)</Label>
+          <Label className="text-sm font-medium">{t('agents.form.parameters.temperature')}</Label>
           <span className="text-xs font-mono bg-muted px-2 py-0.5 rounded text-muted-foreground">
              {temperature}
           </span>
@@ -471,18 +473,18 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
           )}
         />
         <div className="flex justify-between text-xs text-muted-foreground mt-2">
-          <span>0 (精确)</span>
-          <span>1 (创造性)</span>
+          <span>{t('agents.form.parameters.temperatureLow')}</span>
+          <span>{t('agents.form.parameters.temperatureHigh')}</span>
         </div>
       </div>
 
       <div className="rounded-xl border bg-card p-5">
-        <Label className="text-sm font-medium mb-2 block">积分定价</Label>
+        <Label className="text-sm font-medium mb-2 block">{t('agents.form.parameters.pricing.title')}</Label>
 
         {/* 成本倍率 - 仅在有 API 成本数据时显示 */}
         {hasAnyCost && (
           <div className="flex items-center gap-3 mb-4 p-3 rounded-lg bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800">
-            <Label className="text-xs text-blue-700 dark:text-blue-300 whitespace-nowrap">成本倍率</Label>
+            <Label className="text-xs text-blue-700 dark:text-blue-300 whitespace-nowrap">{t('agents.form.parameters.pricing.markupMultiplier')}</Label>
             <Input
               type="number"
               value={markupMultiplier}
@@ -506,7 +508,7 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
                 });
               }}
             >
-              应用全部建议
+              {t('agents.form.parameters.pricing.applyAll')}
             </Button>
           </div>
         )}
@@ -524,7 +526,7 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
                 render={({ field }) => (
                   <FormItem>
                     <div className="flex items-center justify-between">
-                      <FormLabel className="text-xs text-muted-foreground">{dim.label} ({dim.unit})</FormLabel>
+                      <FormLabel className="text-xs text-muted-foreground">{t(dim.labelKey)} ({t(dim.unitKey)})</FormLabel>
                       <FormControl>
                         <Input
                           type="number"
@@ -540,7 +542,7 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
                     {apiCost != null && (
                       <div className="flex items-center justify-between mt-1 px-1">
                         <span className="text-xs text-blue-600 dark:text-blue-400">
-                          API 成本: ${apiCost}{dim.costUnit}
+                          {t('agents.form.parameters.pricing.apiCost', { cost: apiCost, unit: t(dim.costUnitKey) })}
                         </span>
                         <button
                           type="button"
@@ -548,7 +550,7 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
                           onClick={() => setValue(dim.formField, suggestedCredit!)}
                           disabled={disabled}
                         >
-                          建议: {suggestedCredit} 积分
+                          {t('agents.form.parameters.pricing.suggestion', { value: suggestedCredit })}
                         </button>
                       </div>
                     )}
@@ -560,12 +562,12 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
           })}
         </div>
 
-        <p className="text-xs text-muted-foreground mt-3">设置为 0 表示免费，不消耗用户积分。</p>
+        <p className="text-xs text-muted-foreground mt-3">{t('agents.form.parameters.pricing.freeDesc')}</p>
 
         {/* 利润概览 */}
         {hasAnyCost && (
           <div className="mt-4 pt-4 border-t">
-            <Label className="text-xs font-medium mb-2 block text-muted-foreground">利润概览</Label>
+            <Label className="text-xs font-medium mb-2 block text-muted-foreground">{t('agents.form.parameters.pricing.profitOverview')}</Label>
             <div className="space-y-1.5">
               {visibleDimensions.map(dim => {
                 const apiCost = modelCosts[dim.key] as number | undefined;
@@ -574,16 +576,16 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
                 const margin = apiCost && apiCost > 0 ? ((revenueUsd - apiCost) / apiCost * 100) : null;
                 return apiCost != null ? (
                   <div key={dim.key} className="flex justify-between items-center text-xs">
-                    <span className="text-muted-foreground">{dim.label}</span>
+                    <span className="text-muted-foreground">{t(dim.labelKey)}</span>
                     <div className="flex items-center gap-2">
-                      <span className="text-muted-foreground font-mono">${apiCost} → {creditRate}积分 → ${revenueUsd.toFixed(2)}</span>
+                      <span className="text-muted-foreground font-mono">${apiCost} → {creditRate}{t('agents.form.parameters.pricing.credits')} → ${revenueUsd.toFixed(2)}</span>
                       <span className={
                         margin == null ? 'text-muted-foreground' :
                         margin > 0 ? 'text-green-600 dark:text-green-400 font-medium' :
                         margin < 0 ? 'text-red-600 dark:text-red-400 font-medium' :
                         'text-yellow-600 dark:text-yellow-400'
                       }>
-                        {margin != null ? `${margin > 0 ? '+' : ''}${margin.toFixed(1)}%` : 'N/A'}
+                        {margin != null ? `${margin > 0 ? '+' : ''}${margin.toFixed(1)}%` : t('agents.form.parameters.pricing.naLabel')}
                       </span>
                     </div>
                   </div>

--- a/backend/admin/src/components/admin/agents/AgentForm/SystemPrompt.tsx
+++ b/backend/admin/src/components/admin/agents/AgentForm/SystemPrompt.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 import {
   FormControl,
   FormField,
@@ -34,6 +35,7 @@ interface SystemPromptProps {
 
 const SystemPrompt: React.FC<SystemPromptProps> = ({ disabled }) => {
   const { control, setValue } = useFormContext();
+  const { t: tr } = useTranslation();
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState('');
   const [filterType, setFilterType] = useState('__all__');
@@ -61,7 +63,7 @@ const SystemPrompt: React.FC<SystemPromptProps> = ({ disabled }) => {
         render={({ field }) => (
           <FormItem>
             <div className="flex items-center justify-between mb-1">
-              <FormLabel>系统提示词 <span className="text-destructive">*</span></FormLabel>
+              <FormLabel>{tr('agents.form.systemPrompt.label')} <span className="text-destructive">*</span></FormLabel>
               <Button
                 type="button"
                 variant="outline"
@@ -71,12 +73,12 @@ const SystemPrompt: React.FC<SystemPromptProps> = ({ disabled }) => {
                 disabled={disabled}
               >
                 <FileCode2 className="h-3.5 w-3.5" />
-                从模板导入
+                {tr('agents.form.systemPrompt.importTemplate')}
               </Button>
             </div>
             <FormControl>
               <Textarea
-                placeholder="你是一个专业的助手..."
+                placeholder={tr('agents.form.systemPrompt.placeholder')}
                 disabled={disabled}
                 className="font-mono text-sm min-h-[300px] resize-y"
                 {...field}
@@ -90,7 +92,7 @@ const SystemPrompt: React.FC<SystemPromptProps> = ({ disabled }) => {
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent className="max-w-2xl max-h-[80vh] flex flex-col p-0 overflow-hidden">
           <DialogHeader className="px-6 pt-6 pb-4 border-b shrink-0">
-            <DialogTitle>选择提示词模板</DialogTitle>
+            <DialogTitle>{tr('agents.form.systemPrompt.dialogTitle')}</DialogTitle>
           </DialogHeader>
 
           {/* 搜索 & 筛选 */}
@@ -98,7 +100,7 @@ const SystemPrompt: React.FC<SystemPromptProps> = ({ disabled }) => {
             <div className="relative flex-1">
               <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
               <Input
-                placeholder="搜索模板名称..."
+                placeholder={tr('agents.form.systemPrompt.searchPlaceholder')}
                 className="pl-8 h-9"
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
@@ -109,7 +111,7 @@ const SystemPrompt: React.FC<SystemPromptProps> = ({ disabled }) => {
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="__all__">全部分类</SelectItem>
+                <SelectItem value="__all__">{tr('agents.form.systemPrompt.allCategories')}</SelectItem>
                 {templateTypes.map((t) => (
                   <SelectItem key={t} value={t}>
                     {t}
@@ -122,7 +124,7 @@ const SystemPrompt: React.FC<SystemPromptProps> = ({ disabled }) => {
           <ScrollArea className="flex-1 min-h-0 overflow-y-auto">
             <div className="px-6 py-4 space-y-2">
               {filtered.length === 0 && (
-                <p className="text-sm text-muted-foreground text-center py-8">没有匹配的模板</p>
+                <p className="text-sm text-muted-foreground text-center py-8">{tr('agents.form.systemPrompt.noMatch')}</p>
               )}
               {filtered.map((t) => (
                 <button
@@ -135,7 +137,7 @@ const SystemPrompt: React.FC<SystemPromptProps> = ({ disabled }) => {
                     <span className="font-medium text-sm truncate">{t.name}</span>
                     <div className="flex items-center gap-1.5 shrink-0">
                       {t.is_default && (
-                        <span className="text-xs px-1.5 py-0.5 rounded bg-primary/10 text-primary">默认</span>
+                        <span className="text-xs px-1.5 py-0.5 rounded bg-primary/10 text-primary">{tr('agents.form.systemPrompt.default')}</span>
                       )}
                       <span className="text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
                         {t.template_type}

--- a/backend/admin/src/components/admin/agents/AgentForm/Tools/MCPClients.tsx
+++ b/backend/admin/src/components/admin/agents/AgentForm/Tools/MCPClients.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Server } from 'lucide-react';
 
 const MCPClients: React.FC<{ disabled?: boolean }> = () => {
+  const { t } = useTranslation();
   return (
     <div className="mt-6 border-t pt-4">
       <h4 className="text-sm font-medium mb-3 flex items-center">
         <Server className="w-4 h-4 mr-2 text-muted-foreground" />
-        MCP 客户端 (Model Context Protocol)
+        {t('agents.form.tools.mcp.title')}
       </h4>
       <div className="rounded-lg border border-dashed p-6 text-center">
-        <p className="text-sm text-muted-foreground">功能开发中，敬请期待</p>
+        <p className="text-sm text-muted-foreground">{t('agents.form.tools.mcp.inDevelopment')}</p>
       </div>
     </div>
   );

--- a/backend/admin/src/components/admin/agents/AgentForm/Tools/Skills.tsx
+++ b/backend/admin/src/components/admin/agents/AgentForm/Tools/Skills.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 import { FormField, FormItem, FormMessage } from '@/components/ui/form';
 import api from '@/lib/axios';
 
@@ -10,6 +11,7 @@ interface SkillOption {
 
 const Skills: React.FC<{ disabled?: boolean }> = ({ disabled }) => {
   const { control, getValues, setValue } = useFormContext();
+  const { t } = useTranslation();
   const [skills, setSkills] = useState<SkillOption[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -36,17 +38,17 @@ const Skills: React.FC<{ disabled?: boolean }> = ({ disabled }) => {
 
   return (
     <div>
-      <h4 className="text-sm font-medium mb-3">技能 (Skills)</h4>
+      <h4 className="text-sm font-medium mb-3">{t('agents.form.tools.skills.title')}</h4>
       <FormField
         control={control}
         name="tools"
         render={({ field }) => (
           <FormItem>
             {loading ? (
-              <p className="text-xs text-muted-foreground">正在加载技能列表…</p>
+              <p className="text-xs text-muted-foreground">{t('agents.form.tools.skills.loading')}</p>
             ) : skills.length === 0 ? (
               <p className="text-xs text-muted-foreground">
-                暂无可用技能，请先在技能管理页面创建并启用技能。
+                {t('agents.form.tools.skills.empty')}
               </p>
             ) : (
               <div className="grid grid-cols-1 gap-2">

--- a/backend/admin/src/components/admin/agents/AgentForm/Tools/ToolCapabilities.tsx
+++ b/backend/admin/src/components/admin/agents/AgentForm/Tools/ToolCapabilities.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 import {
   FormControl,
   FormField,
@@ -13,10 +14,10 @@ import { useToolConfig } from '@/hooks/useToolRegistry';
 
 // 画布节点类型选项
 const NODE_TYPE_OPTIONS = [
-  { value: 'script', label: '文本节点', description: '富文本内容', icon: FileText },
-  { value: 'character', label: '图像节点', description: '图片生成与管理', icon: Image },
-  { value: 'video', label: '视频节点', description: '视频生成与管理', icon: Video },
-  { value: 'storyboard', label: '多维表格', description: '数据表格与分析', icon: Table2 },
+  { value: 'script', labelKey: 'agents.form.tools.capabilities.nodeTypes.script', descKey: 'agents.form.tools.capabilities.nodeTypes.scriptDesc', icon: FileText },
+  { value: 'character', labelKey: 'agents.form.tools.capabilities.nodeTypes.character', descKey: 'agents.form.tools.capabilities.nodeTypes.characterDesc', icon: Image },
+  { value: 'video', labelKey: 'agents.form.tools.capabilities.nodeTypes.video', descKey: 'agents.form.tools.capabilities.nodeTypes.videoDesc', icon: Video },
+  { value: 'storyboard', labelKey: 'agents.form.tools.capabilities.nodeTypes.storyboard', descKey: 'agents.form.tools.capabilities.nodeTypes.storyboardDesc', icon: Table2 },
 ] as const;
 
 const ALL_NODE_TYPES = NODE_TYPE_OPTIONS.map(o => o.value);
@@ -27,6 +28,7 @@ interface ToolCapabilitiesProps {
 
 const ToolCapabilities: React.FC<ToolCapabilitiesProps> = ({ disabled }) => {
   const { control, watch, setValue } = useFormContext();
+  const { t } = useTranslation();
 
   // 获取全局图像工具配置
   const { config: imageToolConfig } = useToolConfig('generate_image');
@@ -48,14 +50,14 @@ const ToolCapabilities: React.FC<ToolCapabilitiesProps> = ({ disabled }) => {
 
   return (
     <div className="mt-4 pt-4 border-t space-y-3">
-      <h4 className="text-sm font-medium">工具开关</h4>
+      <h4 className="text-sm font-medium">{t('agents.form.tools.capabilities.title')}</h4>
 
       {/* ── 图像工具（generate_image + edit_image）── */}
       <div className="rounded-lg border p-3">
         <div className="flex justify-between items-center">
           <div className="flex items-center gap-2">
             <Paintbrush className="h-4 w-4 text-emerald-500" />
-            <span className="text-sm font-medium">图像工具</span>
+            <span className="text-sm font-medium">{t('agents.form.tools.capabilities.image.title')}</span>
           </div>
           <FormField
             control={control}
@@ -74,17 +76,17 @@ const ToolCapabilities: React.FC<ToolCapabilitiesProps> = ({ disabled }) => {
           />
         </div>
         <p className="text-xs text-muted-foreground mt-1">
-          图像生成 (generate_image) 和图像编辑 (edit_image) 工具。
+          {t('agents.form.tools.capabilities.image.desc')}
         </p>
-        
+
         {/* 全局配置状态提示 */}
         {!globalImageEnabled && (
           <div className="mt-2 flex items-center gap-1.5 text-xs text-amber-600 dark:text-amber-500">
             <AlertCircle className="h-3 w-3" />
-            <span>全局配置未启用，请在「工具管理」中先启用图像生成</span>
+            <span>{t('agents.form.tools.capabilities.image.globalDisabled')}</span>
           </div>
         )}
-        
+
         {globalImageEnabled && agentImageEnabled && (
           <div className="mt-2 flex flex-wrap items-center gap-2">
             {imageToolConfig?.config?.image_model && (
@@ -93,7 +95,7 @@ const ToolCapabilities: React.FC<ToolCapabilitiesProps> = ({ disabled }) => {
               </Badge>
             )}
             <span className="text-xs text-muted-foreground">
-              参数配置请在「工具管理」中设置
+              {t('agents.form.tools.capabilities.image.params')}
             </span>
           </div>
         )}
@@ -104,7 +106,7 @@ const ToolCapabilities: React.FC<ToolCapabilitiesProps> = ({ disabled }) => {
         <div className="flex justify-between items-center">
           <div className="flex items-center gap-2">
             <Film className="h-4 w-4 text-violet-500" />
-            <span className="text-sm font-medium">视频工具</span>
+            <span className="text-sm font-medium">{t('agents.form.tools.capabilities.video.title')}</span>
           </div>
           <FormField
             control={control}
@@ -123,17 +125,17 @@ const ToolCapabilities: React.FC<ToolCapabilitiesProps> = ({ disabled }) => {
           />
         </div>
         <p className="text-xs text-muted-foreground mt-1">
-          视频生成 (generate_video) 和视频编辑 (edit_video) 工具。
+          {t('agents.form.tools.capabilities.video.desc')}
         </p>
-        
+
         {/* 全局配置状态提示 */}
         {!globalVideoEnabled && (
           <div className="mt-2 flex items-center gap-1.5 text-xs text-amber-600 dark:text-amber-500">
             <AlertCircle className="h-3 w-3" />
-            <span>全局配置未启用，请在「工具管理」中先启用视频生成</span>
+            <span>{t('agents.form.tools.capabilities.video.globalDisabled')}</span>
           </div>
         )}
-        
+
         {globalVideoEnabled && agentVideoEnabled && (
           <div className="mt-2 flex flex-wrap items-center gap-2">
             {videoToolConfig?.config?.video_model && (
@@ -142,7 +144,7 @@ const ToolCapabilities: React.FC<ToolCapabilitiesProps> = ({ disabled }) => {
               </Badge>
             )}
             <span className="text-xs text-muted-foreground">
-              参数配置请在「工具管理」中设置
+              {t('agents.form.tools.capabilities.video.params')}
             </span>
           </div>
         )}
@@ -153,7 +155,7 @@ const ToolCapabilities: React.FC<ToolCapabilitiesProps> = ({ disabled }) => {
         <div className="flex justify-between items-center">
           <div className="flex items-center gap-2">
             <LayoutGrid className="h-4 w-4 text-blue-500" />
-            <span className="text-sm font-medium">画布工具</span>
+            <span className="text-sm font-medium">{t('agents.form.tools.capabilities.canvas.title')}</span>
           </div>
           <Switch
             checked={canvasEnabled}
@@ -164,7 +166,7 @@ const ToolCapabilities: React.FC<ToolCapabilitiesProps> = ({ disabled }) => {
           />
         </div>
         <p className="text-xs text-muted-foreground mt-1">
-          开启后，智能体可以控制画布节点内容。
+          {t('agents.form.tools.capabilities.canvas.desc')}
         </p>
 
         {canvasEnabled && (
@@ -195,9 +197,9 @@ const ToolCapabilities: React.FC<ToolCapabilitiesProps> = ({ disabled }) => {
                           <Icon className={`h-3.5 w-3.5 ${isSelected ? 'text-foreground' : 'text-muted-foreground'}`} />
                           <div>
                             <span className={`text-xs font-medium block ${isSelected ? 'text-foreground' : 'text-muted-foreground'}`}>
-                              {option.label}
+                              {t(option.labelKey)}
                             </span>
-                            <span className="text-[10px] text-muted-foreground">{option.description}</span>
+                            <span className="text-[10px] text-muted-foreground">{t(option.descKey)}</span>
                           </div>
                         </div>
                       );

--- a/backend/admin/src/components/admin/agents/AgentForm/Tools/index.tsx
+++ b/backend/admin/src/components/admin/agents/AgentForm/Tools/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 import {
   FormControl,
   FormField,
@@ -12,15 +13,16 @@ import ToolCapabilities from './ToolCapabilities';
 
 const Tools: React.FC<{ disabled?: boolean }> = ({ disabled }) => {
   const { control, watch } = useFormContext();
+  const { t } = useTranslation();
   const toolsEnabled = watch('tools_enabled');
 
   return (
     <div className="rounded-xl border bg-card p-5">
       <div className="flex justify-between items-center mb-4">
         <div>
-          <span className="text-sm font-medium">能力</span>
+          <span className="text-sm font-medium">{t('agents.form.tools.title')}</span>
           <p className="text-xs text-muted-foreground mt-1">
-            启用以允许智能体访问外部技能、工具或连接 MCP 客户端。
+            {t('agents.form.tools.desc')}
           </p>
         </div>
         <FormField
@@ -48,7 +50,7 @@ const Tools: React.FC<{ disabled?: boolean }> = ({ disabled }) => {
         </div>
       ) : (
         <p className="text-xs text-muted-foreground border-t pt-4">
-          当前未启用能力。启用能力以允许智能体访问外部数据或执行操作。
+          {t('agents.form.tools.noToolsEnabled')}
         </p>
       )}
     </div>

--- a/backend/admin/src/components/admin/agents/AgentForm/index.tsx
+++ b/backend/admin/src/components/admin/agents/AgentForm/index.tsx
@@ -1,13 +1,14 @@
 'use client';
 
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useTranslation } from 'react-i18next';
 import { useToast } from '@/components/ui/use-toast';
 import { Agent } from '@/types';
 import { useLLMProviders } from '@/hooks/useLLMProviders';
 import { useAgents } from '@/hooks/useAgents';
-import { agentFormSchema, AgentFormValues } from './schema';
+import { createAgentFormSchema, AgentFormValues } from './schema';
 import BasicInfo from './BasicInfo';
 import SystemPrompt from './SystemPrompt';
 import Parameters from './Parameters';
@@ -74,7 +75,10 @@ export default function AgentForm({
   const { activeProviders, isLoading: providersLoading } = useLLMProviders();
   const { agents: availableAgents } = useAgents();
   const { toast } = useToast();
+  const { t } = useTranslation();
   const isFormInitialized = useRef(false);
+
+  const agentFormSchema = useMemo(() => createAgentFormSchema(t), [t]);
 
   const form = useForm<AgentFormValues>({
     resolver: zodResolver(agentFormSchema) as unknown as any,
@@ -208,11 +212,18 @@ export default function AgentForm({
 
   const agentType = form.watch('agent_type') as 'text' | 'image' | 'multimodal' | 'video';
 
-  // 字段名映射表（避免 if-else，直接查表显示中文名）
+  // 字段名映射表（避免 if-else，直接查表显示字段名）
   const FIELD_LABELS: Record<string, string> = {
-    name: '名称', description: '描述', provider_id: '供应商', model: '模型',
-    system_prompt: '系统提示词', temperature: '温度', context_window: '上下文窗口',
-    tools: '工具', coordination_modes: '协作方式', gemini_config: 'Gemini 配置',
+    name: t('agents.form.fieldLabels.name'),
+    description: t('agents.form.fieldLabels.description'),
+    provider_id: t('agents.form.fieldLabels.provider_id'),
+    model: t('agents.form.fieldLabels.model'),
+    system_prompt: t('agents.form.fieldLabels.system_prompt'),
+    temperature: t('agents.form.fieldLabels.temperature'),
+    context_window: t('agents.form.fieldLabels.context_window'),
+    tools: t('agents.form.fieldLabels.tools'),
+    coordination_modes: t('agents.form.fieldLabels.coordination_modes'),
+    gemini_config: t('agents.form.fieldLabels.gemini_config'),
   };
 
   const handleInvalid = (errors: Record<string, any>) => {
@@ -220,8 +231,8 @@ export default function AgentForm({
     const fields = Object.keys(errors).map(k => FIELD_LABELS[k] || k);
     toast({
       variant: "destructive",
-      title: "请检查以下字段",
-      description: fields.join('、'),
+      title: t('agents.form.invalidToastTitle'),
+      description: fields.join(t('agents.form.invalidToastJoiner')),
     });
   };
 
@@ -288,8 +299,8 @@ export default function AgentForm({
       }
       toast({
         variant: "destructive",
-        title: "提交失败",
-        description: error.response?.data?.detail ? JSON.stringify(error.response.data.detail) : "请重试",
+        title: t('agents.form.submitFailedTitle'),
+        description: error.response?.data?.detail ? JSON.stringify(error.response.data.detail) : t('agents.form.submitFailedDesc'),
       });
     }
   };
@@ -299,7 +310,7 @@ export default function AgentForm({
       {twoColumn ? (
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
           <div className="lg:col-span-6 xl:col-span-7">
-            <Section title="基础信息">
+            <Section title={t('agents.form.sections.basic')}>
               <BasicInfo 
                 providers={activeProviders || []} 
                 loading={providersLoading || loading}
@@ -307,19 +318,19 @@ export default function AgentForm({
               />
             </Section>
             <div className="h-px bg-border my-8"></div>
-            <Section title="系统设定">
+            <Section title={t('agents.form.sections.system')}>
                <SystemPrompt disabled={loading} />
             </Section>
           </div>
           <div className="lg:col-span-6 xl:col-span-5">
             <div className="space-y-6 pb-4">
-              <Section title="参数设置">
+              <Section title={t('agents.form.sections.params')}>
                 <Parameters disabled={loading} providers={activeProviders || []} />
               </Section>
-              <Section title="能力">
+              <Section title={t('agents.form.sections.capabilities')}>
                 <Tools disabled={loading} />
               </Section>
-              <Section title="协作配置" className="mb-0">
+              <Section title={t('agents.form.sections.leader')} className="mb-0">
                 <LeaderConfig disabled={loading} availableAgents={availableAgents || []} />
               </Section>
             </div>

--- a/backend/admin/src/components/admin/agents/AgentForm/schema.ts
+++ b/backend/admin/src/components/admin/agents/AgentForm/schema.ts
@@ -1,4 +1,5 @@
 import * as z from 'zod';
+import type { TFunction } from 'i18next';
 
 const emptyStringToNull = (val: unknown) => {
   if (val === "" || val === "undefined") return null;
@@ -45,27 +46,27 @@ const compactionConfigSchema = z.object({
   max_summary_tokens: z.number().min(4096).max(131072).optional().default(4096),
 }).optional().nullable();
 
-export const agentFormSchema = z.object({
-  name: z.string().min(1, "请输入智能体名称").max(50, "最大长度50字符"),
-  description: z.string().min(1, "请输入描述").max(500, "最大长度500字符"),
-  provider_id: z.string().min(1, "请选择供应商"),
-  model: z.string().min(1, "请选择模型"),
+export const createAgentFormSchema = (t: TFunction) => z.object({
+  name: z.string().min(1, t('agents.form.validation.nameRequired')).max(50, t('agents.form.validation.nameMax')),
+  description: z.string().min(1, t('agents.form.validation.descRequired')).max(500, t('agents.form.validation.descMax')),
+  provider_id: z.string().min(1, t('agents.form.validation.providerRequired')),
+  model: z.string().min(1, t('agents.form.validation.modelRequired')),
   agent_type: z.enum(["text", "image", "multimodal", "video"]).default("text"),
-  system_prompt: z.string().min(1, "请输入系统提示词").max(5000, "最大长度5000字符"),
+  system_prompt: z.string().min(1, t('agents.form.validation.systemPromptRequired')).max(5000, t('agents.form.validation.systemPromptMax')),
   temperature: z.number().min(0).max(1),
-  context_window: z.number().min(4096, "最小值为4096").max(1048576, "最大值为1048576"),
+  context_window: z.number().min(4096, t('agents.form.validation.contextMin')).max(1048576, t('agents.form.validation.contextMax')),
   thinking_mode: z.boolean().optional(),
   tools_enabled: z.boolean().optional(),
   tools: z.array(z.string()).optional(),
-  input_credit_per_1m: z.number().min(0, "不能为负数").default(0),
-  output_credit_per_1m: z.number().min(0, "不能为负数").default(0),
-  image_output_credit_per_1m: z.number().min(0, "不能为负数").default(0),
-  search_credit_per_query: z.number().min(0, "不能为负数").default(0),
+  input_credit_per_1m: z.number().min(0, t('agents.form.validation.creditNonNegative')).default(0),
+  output_credit_per_1m: z.number().min(0, t('agents.form.validation.creditNonNegative')).default(0),
+  image_output_credit_per_1m: z.number().min(0, t('agents.form.validation.creditNonNegative')).default(0),
+  search_credit_per_query: z.number().min(0, t('agents.form.validation.creditNonNegative')).default(0),
   // Video pricing
-  video_input_image_credit: z.number().min(0, "不能为负数").default(0),
-  video_input_second_credit: z.number().min(0, "不能为负数").default(0),
-  video_output_480p_credit: z.number().min(0, "不能为负数").default(0),
-  video_output_720p_credit: z.number().min(0, "不能为负数").default(0),
+  video_input_image_credit: z.number().min(0, t('agents.form.validation.creditNonNegative')).default(0),
+  video_input_second_credit: z.number().min(0, t('agents.form.validation.creditNonNegative')).default(0),
+  video_output_480p_credit: z.number().min(0, t('agents.form.validation.creditNonNegative')).default(0),
+  video_output_720p_credit: z.number().min(0, t('agents.form.validation.creditNonNegative')).default(0),
   // 画布节点控制
   target_node_types: z.array(
     z.enum(["script", "character", "storyboard", "video"])
@@ -80,7 +81,7 @@ export const agentFormSchema = z.object({
   gemini_config: geminiConfigSchema,
   // 统一图像生成配置
   image_config: unifiedImageGenConfigSchema,
-  image_credit_per_image: z.number().min(0, "不能为负数").default(0),
+  image_credit_per_image: z.number().min(0, t('agents.form.validation.creditNonNegative')).default(0),
   // 视频生成配置
   video_config: videoGenConfigSchema,
   // 上下文压缩配置
@@ -95,8 +96,8 @@ export const agentFormSchema = z.object({
   const hasCanvas = (data.target_node_types?.length ?? 0) > 0;
   return !data.tools_enabled || hasSkills || hasImageGen || hasVideoGen || hasCanvas;
 }, {
-  message: "启用能力时至少开启一项工具或功能",
+  message: t('agents.form.validation.capabilityRequired'),
   path: ["tools"],
 });
 
-export type AgentFormValues = z.infer<typeof agentFormSchema>;
+export type AgentFormValues = z.infer<ReturnType<typeof createAgentFormSchema>>;

--- a/backend/admin/src/components/admin/agents/ChatInterface.tsx
+++ b/backend/admin/src/components/admin/agents/ChatInterface.tsx
@@ -1,6 +1,7 @@
-'use client';
+ 'use client';
 
 import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Send, Plus, Trash2, Bot, User, MoreHorizontal, Loader2, MessageSquare, ChevronDown, ImagePlus, X, Zap, Terminal } from 'lucide-react';
 import useSWR, { mutate } from 'swr';
 import api from '@/lib/axios';
@@ -68,6 +69,7 @@ function extractImageUrl(content: string): string | null {
 }
 
 export default function ChatInterface({ agentId }: ChatInterfaceProps) {
+  const { t } = useTranslation();
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [inputValue, setInputValue] = useState('');
@@ -98,7 +100,7 @@ export default function ChatInterface({ agentId }: ChatInterfaceProps) {
       setMessages([]);
       api.get(`/admin/debug/sessions/${selectedSessionId}/messages`)
         .then(res => setMessages(res.data))
-        .catch(err => toast({ variant: "destructive", title: "Failed to load messages" }));
+        .catch(err => toast({ variant: "destructive", title: t('agents.chat.loadFailed') }));
     }
   }, [selectedSessionId]);
 
@@ -133,7 +135,7 @@ export default function ChatInterface({ agentId }: ChatInterfaceProps) {
       mutate(`/admin/debug/sessions?agent_id=${agentId}`);
       setSelectedSessionId(res.data.id);
     } catch (err) {
-      toast({ variant: "destructive", title: "Failed to create debug session" });
+      toast({ variant: "destructive", title: t('agents.chat.createFailed') });
     }
   };
 
@@ -147,7 +149,7 @@ export default function ChatInterface({ agentId }: ChatInterfaceProps) {
         setMessages([]);
       }
     } catch (err) {
-      toast({ variant: "destructive", title: "Failed to delete debug session" });
+      toast({ variant: "destructive", title: t('agents.chat.deleteFailed') });
     }
   };
 
@@ -321,12 +323,12 @@ export default function ChatInterface({ agentId }: ChatInterfaceProps) {
                   };
                   stepMap.set(data.subtask_id, step);
                   steps.push(step);
-                  assistantMsg.content = `正在协作... (${steps.length} 个智能体)`;
+                  assistantMsg.content = t('agents.chat.collaboratingWithAgents', { count: steps.length });
                 },
                 subtask_started: () => {
                   const step = stepMap.get(data.subtask_id);
                   step && (step.status = 'running', step.result = '');
-                  assistantMsg.content = `协作中... (${data.agent_name || ''} 正在生成)`;
+                  assistantMsg.content = t('agents.chat.collaboratingAgentGenerating', { name: data.agent_name || '' });
                 },
                 subtask_chunk: () => {
                   const step = stepMap.get(data.subtask_id);
@@ -341,7 +343,7 @@ export default function ChatInterface({ agentId }: ChatInterfaceProps) {
                   target.agent_name = data.agent_name || target.agent_name;
                   target.description = data.description || target.description;
                   const completed = steps.filter(s => s.status === 'completed').length;
-                  assistantMsg.content = `协作中... (${completed}/${steps.length} 完成)`;
+                  assistantMsg.content = t('agents.chat.collaboratingProgress', { completed, total: steps.length });
                 },
                 subtask_failed: () => {
                   const step = stepMap.get(data.subtask_id);
@@ -402,20 +404,20 @@ export default function ChatInterface({ agentId }: ChatInterfaceProps) {
       <div className="h-12 border-b flex items-center justify-between px-4 shrink-0 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 z-10">
         <div className="flex items-center gap-2 font-medium text-sm text-muted-foreground">
           <MessageSquare className="h-4 w-4" />
-          <span>预览对话</span>
+          <span>{t('agents.chat.preview')}</span>
         </div>
         <div className="flex items-center gap-2">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button variant="outline" size="sm" className="h-8 min-w-[140px] justify-between font-normal text-xs px-3">
                 <span className="truncate max-w-[100px]">
-                  {sessions?.find((s: ChatSession) => s.id === selectedSessionId)?.title || "选择对话"}
+                  {sessions?.find((s: ChatSession) => s.id === selectedSessionId)?.title || t('agents.chat.selectConversation')}
                 </span>
                 <ChevronDown className="ml-2 h-3 w-3 opacity-50" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-[200px]">
-              {sessionsLoading && <div className="p-2 text-xs text-center text-muted-foreground">Loading...</div>}
+              {sessionsLoading && <div className="p-2 text-xs text-center text-muted-foreground">{t('agents.header.loading')}</div>}
               {sessions?.map((item: ChatSession) => (
                 <DropdownMenuItem 
                   key={item.id} 
@@ -435,7 +437,7 @@ export default function ChatInterface({ agentId }: ChatInterfaceProps) {
                 </DropdownMenuItem>
               ))}
               {(!sessions || sessions.length === 0) && (
-                <div className="text-center text-muted-foreground text-xs py-2">无历史记录</div>
+                <div className="text-center text-muted-foreground text-xs py-2">{t('agents.chat.noHistory')}</div>
               )}
             </DropdownMenuContent>
           </DropdownMenu>
@@ -445,7 +447,7 @@ export default function ChatInterface({ agentId }: ChatInterfaceProps) {
             size="icon" 
             onClick={handleCreateSession}
             className="h-8 w-8 text-muted-foreground hover:text-foreground"
-            title="新对话"
+            title={t('agents.chat.newConversation')}
           >
             <Plus className="h-4 w-4" />
           </Button>
@@ -461,7 +463,7 @@ export default function ChatInterface({ agentId }: ChatInterfaceProps) {
                 {messages.length === 0 && (
                   <div className="h-full flex flex-col items-center justify-center text-muted-foreground mt-20">
                     <Bot className="h-12 w-12 mb-4 opacity-20" />
-                    <p>开始一个新的对话</p>
+                    <p>{t('agents.chat.startNew')}</p>
                   </div>
                 )}
                 {messages.map((msg, index) => (
@@ -492,7 +494,7 @@ export default function ChatInterface({ agentId }: ChatInterfaceProps) {
                                     ? <Loader2 className="h-3 w-3 animate-spin" />
                                     : <Zap className="h-3 w-3" />}
                                   <span>
-                                    {sc.status === 'loading' ? `正在加载技能: ${sc.skill_name}` : `已加载技能: ${sc.skill_name}`}
+                                    {sc.status === 'loading' ? t('agents.chat.skill.loading', { name: sc.skill_name }) : t('agents.chat.skill.loaded', { name: sc.skill_name })}
                                   </span>
                                 </div>
                               ))}
@@ -503,7 +505,7 @@ export default function ChatInterface({ agentId }: ChatInterfaceProps) {
                                     ? <Loader2 className="h-3 w-3 animate-spin" />
                                     : <Terminal className="h-3 w-3" />}
                                   <span>
-                                    {tc.status === 'executing' ? `正在执行: ${tc.tool_name}` : `已完成: ${tc.tool_name}`}
+                                    {tc.status === 'executing' ? t('agents.chat.tool.executing', { name: tc.tool_name }) : t('agents.chat.tool.completed', { name: tc.tool_name })}
                                   </span>
                                 </div>
                               ))}
@@ -540,15 +542,15 @@ export default function ChatInterface({ agentId }: ChatInterfaceProps) {
                                                     setEditImageUrl(dataUrl);
                                                     textareaRef.current?.focus();
                                                     toast({ 
-                                                      title: "已选择此图进行编辑", 
-                                                      description: "下一条消息将基于这张图片进行修改" 
+                                                      title: t('agents.chat.edit.selectedTitle'),
+                                                      description: t('agents.chat.edit.selectedDesc')
                                                     });
                                                   };
                                                   reader.readAsDataURL(blob);
                                                 } catch (err) {
                                                   toast({ 
                                                     variant: "destructive", 
-                                                    title: "无法加载图片" 
+                                                    title: t('agents.chat.edit.failed')
                                                   });
                                                 }
                                               }}
@@ -556,7 +558,7 @@ export default function ChatInterface({ agentId }: ChatInterfaceProps) {
                                               className="h-7 text-xs shadow-lg"
                                             >
                                               <ImagePlus className="h-3 w-3 mr-1" />
-                                              继续编辑
+                                              {t('agents.chat.edit.continueEdit')}
                                             </Button>
                                           </span>
                                         )}
@@ -619,7 +621,7 @@ export default function ChatInterface({ agentId }: ChatInterfaceProps) {
                  {editImageUrl && (
                    <div className="flex items-center gap-2 mb-2 p-2 bg-primary/10 text-primary text-xs rounded-lg">
                      <ImagePlus className="h-3 w-3" />
-                     <span>编辑模式：下一条消息将基于选中的图片进行修改</span>
+                     <span>{t('agents.chat.edit.mode')}</span>
                      <Button
                        variant="ghost"
                        size="sm"
@@ -663,7 +665,7 @@ export default function ChatInterface({ agentId }: ChatInterfaceProps) {
                    value={inputValue}
                    onChange={(e) => setInputValue(e.target.value)}
                    onKeyDown={handleKeyDown}
-                   placeholder="输入消息..."
+                   placeholder={t('agents.chat.inputPlaceholder')}
                    rows={1}
                     className="min-h-[44px] max-h-[280px] pl-12 pr-12 resize-none rounded-xl bg-muted/30 border-muted focus:bg-background transition-colors overflow-y-auto py-3"
                   />
@@ -677,7 +679,7 @@ export default function ChatInterface({ agentId }: ChatInterfaceProps) {
                      onClick={() => fileInputRef.current?.click()}
                      disabled={isStreaming}
                      className="h-8 w-8 rounded-lg text-muted-foreground hover:text-foreground"
-                     title="上传图片"
+                     title={t('agents.chat.uploadImage')}
                    >
                      <ImagePlus className="h-4 w-4" />
                    </Button>
@@ -695,7 +697,7 @@ export default function ChatInterface({ agentId }: ChatInterfaceProps) {
                  </div>
                </div>
                <div className="text-center mt-2">
-                 <span className="text-[10px] text-muted-foreground/60">AI 可能会生成不准确的信息，请核对重要事实。</span>
+                 <span className="text-[10px] text-muted-foreground/60">{t('agents.chat.aiNotice')}</span>
                </div>
             </div>
           </>
@@ -703,10 +705,10 @@ export default function ChatInterface({ agentId }: ChatInterfaceProps) {
           <div className="flex-1 flex flex-col items-center justify-center text-muted-foreground bg-muted/5">
             <div className="flex flex-col items-center gap-2">
               <Bot className="h-12 w-12 opacity-10" />
-              <p className="text-sm">选择或创建一个对话开始</p>
+              <p className="text-sm">{t('agents.chat.selectOrCreate')}</p>
               <Button variant="outline" size="sm" onClick={handleCreateSession} className="mt-4">
                 <Plus className="mr-2 h-4 w-4" />
-                创建新对话
+                {t('agents.chat.createNewSession')}
               </Button>
             </div>
           </div>

--- a/backend/admin/src/components/admin/agents/MultiAgentSteps.tsx
+++ b/backend/admin/src/components/admin/agents/MultiAgentSteps.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ChevronRight, Bot, CheckCircle2, XCircle, Loader2 } from 'lucide-react';
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible';
 import { Badge } from '@/components/ui/badge';
@@ -25,14 +26,15 @@ export interface MultiAgentData {
   creditCost: number;
 }
 
-const STATUS_CONFIG: Record<string, { icon: React.ReactNode; label: string; color: string }> = {
-  pending: { icon: <Loader2 className="h-3 w-3 text-muted-foreground" />, label: '等待中', color: 'text-muted-foreground' },
-  running: { icon: <Loader2 className="h-3 w-3 animate-spin text-foreground" />, label: '执行中', color: 'text-foreground' },
-  completed: { icon: <CheckCircle2 className="h-3 w-3 text-emerald-600" />, label: '已完成', color: 'text-emerald-600' },
-  failed: { icon: <XCircle className="h-3 w-3 text-destructive" />, label: '失败', color: 'text-destructive' },
+const STATUS_CONFIG: Record<string, { icon: React.ReactNode; labelKey: string; color: string }> = {
+  pending: { icon: <Loader2 className="h-3 w-3 text-muted-foreground" />, labelKey: 'agents.multiAgent.status.pending', color: 'text-muted-foreground' },
+  running: { icon: <Loader2 className="h-3 w-3 animate-spin text-foreground" />, labelKey: 'agents.multiAgent.status.running', color: 'text-foreground' },
+  completed: { icon: <CheckCircle2 className="h-3 w-3 text-emerald-600" />, labelKey: 'agents.multiAgent.status.completed', color: 'text-emerald-600' },
+  failed: { icon: <XCircle className="h-3 w-3 text-destructive" />, labelKey: 'agents.multiAgent.status.failed', color: 'text-destructive' },
 };
 
 export default function MultiAgentSteps({ steps, finalResult, totalTokens, creditCost }: MultiAgentData) {
+  const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const completedCount = steps.filter(s => s.status === 'completed').length;
   const totalCount = steps.length;
@@ -51,14 +53,14 @@ export default function MultiAgentSteps({ steps, finalResult, totalTokens, credi
           {isStreaming ? (
             <>
               <Loader2 className="h-3 w-3 animate-spin" />
-              <span>协作中 ({completedCount}/{totalCount} 个智能体)</span>
+              <span>{t('agents.multiAgent.collaborating')} ({completedCount}/{totalCount} {t('agents.multiAgent.agents')})</span>
             </>
           ) : (
-            <span>协作过程 ({completedCount}/{totalCount} 个智能体)</span>
+            <span>{t('agents.multiAgent.collaborationProcess')} ({completedCount}/{totalCount} {t('agents.multiAgent.agents')})</span>
           )}
           <span className="text-[10px] opacity-60">
-            {totalTokens.input + totalTokens.output > 0 && `${totalTokens.input + totalTokens.output} tokens`}
-            {creditCost > 0 && ` · ${creditCost.toFixed(2)} 积分`}
+            {totalTokens.input + totalTokens.output > 0 && `${totalTokens.input + totalTokens.output} ${t('agents.multiAgent.tokens')}`}
+            {creditCost > 0 && ` · ${creditCost.toFixed(2)} ${t('agents.multiAgent.credits')}`}
           </span>
         </CollapsibleTrigger>
 

--- a/backend/admin/src/i18n/locales/en-US.json
+++ b/backend/admin/src/i18n/locales/en-US.json
@@ -1,4 +1,797 @@
 {
+  "common": {
+    "buttons": {
+      "save": "Save",
+      "cancel": "Cancel",
+      "confirm": "Confirm",
+      "delete": "Delete",
+      "edit": "Edit",
+      "create": "Create",
+      "add": "Add",
+      "back": "Back",
+      "search": "Search",
+      "refresh": "Refresh",
+      "close": "Close",
+      "submit": "Submit",
+      "reset": "Reset",
+      "retry": "Retry",
+      "view": "View",
+      "copy": "Copy",
+      "export": "Export",
+      "import": "Import",
+      "upload": "Upload",
+      "download": "Download",
+      "more": "More",
+      "details": "Details",
+      "yes": "Yes",
+      "no": "No",
+      "enable": "Enable",
+      "disable": "Disable"
+    },
+    "status": {
+      "loading": "Loading...",
+      "submitting": "Submitting...",
+      "saving": "Saving...",
+      "deleting": "Deleting...",
+      "empty": "No data",
+      "error": "Failed to load",
+      "success": "Success",
+      "failed": "Failed",
+      "enabled": "Enabled",
+      "disabled": "Disabled",
+      "active": "Active",
+      "inactive": "Inactive"
+    },
+    "dialog": {
+      "confirmTitle": "Confirm Action",
+      "confirmDelete": "Confirm Deletion",
+      "deleteWarning": "This action cannot be undone. Continue?",
+      "unsavedChanges": "You have unsaved changes. Leave anyway?"
+    },
+    "table": {
+      "actions": "Actions",
+      "createdAt": "Created At",
+      "updatedAt": "Updated At",
+      "total": "{{count}} items in total",
+      "page": "Page {{page}}",
+      "prev": "Previous",
+      "next": "Next",
+      "noData": "No data",
+      "searchPlaceholder": "Search..."
+    },
+    "validation": {
+      "required": "This field is required",
+      "invalidFormat": "Invalid format",
+      "tooShort": "Too short",
+      "tooLong": "Too long"
+    },
+    "toast": {
+      "saveSuccess": "Saved successfully",
+      "saveFailed": "Failed to save",
+      "deleteSuccess": "Deleted successfully",
+      "deleteFailed": "Failed to delete",
+      "operationSuccess": "Operation successful",
+      "operationFailed": "Operation failed",
+      "networkError": "Network error, please try again later",
+      "unknownError": "Unknown error"
+    }
+  },
+  "layout": {
+    "sidebar": {
+      "dashboard": "Dashboard",
+      "llm": "AI Providers",
+      "agents": "Agents",
+      "skills": "Skills",
+      "mcp": "MCP Clients",
+      "tools": "Tools",
+      "videos": "Video Generation",
+      "virtualHumans": "Virtual Humans",
+      "promptTemplates": "Prompt Templates",
+      "users": "Users",
+      "subscriptions": "Subscriptions",
+      "admins": "Administrators",
+      "toggleMenu": "Toggle Menu"
+    },
+    "account": {
+      "admin": "Administrator",
+      "myAccount": "My Account",
+      "logout": "Sign Out"
+    },
+    "language": {
+      "label": "Language",
+      "zhCN": "简体中文",
+      "enUS": "English"
+    }
+  },
+  "dashboard": {
+    "title": "Dashboard",
+    "stat": {
+      "totalUsers": "Total Users",
+      "todayActive": "Active Today",
+      "todayRevenue": "Revenue Today",
+      "totalRevenue": "Total Revenue"
+    },
+    "bucket": {
+      "today": "Today",
+      "yesterday": "Yesterday",
+      "this_week": "This Week",
+      "this_month": "This Month",
+      "older": "Earlier"
+    },
+    "period": {
+      "today": "Today",
+      "yesterday": "Yesterday",
+      "week": "This Week",
+      "month": "This Month",
+      "quarter": "Last 3 Months",
+      "all": "All Time",
+      "rangeLabel": {
+        "today": "Today",
+        "yesterday": "Last 2 Days",
+        "week": "This Week",
+        "month": "Last 30 Days",
+        "quarter": "Last 3 Months",
+        "all": "All Time"
+      }
+    },
+    "trend": {
+      "registration": "Registration Trend",
+      "active": "Active Trend",
+      "conversion": "Subscription Conversion",
+      "registrationSeries": "Registrations",
+      "activeSeries": "Active Users",
+      "conversionSeries": "New Subscriptions",
+      "titleWithRange": "{{name}} ({{range}})",
+      "dateLabel": "Date: {{date}}"
+    },
+    "leaderboard": {
+      "title": "Token Consumption Leaderboard",
+      "rank": "#",
+      "user": "User",
+      "totalTokens": "Total Tokens",
+      "credits": "Credits",
+      "top": "Top {{n}}",
+      "empty": "No data",
+      "nicknamePlaceholder": "—"
+    },
+    "metrics": {
+      "title": "Operational Metrics",
+      "pur": "Paid User Ratio (PUR)",
+      "retention": "Retention Rate",
+      "mrr": "MRR (Monthly Recurring Revenue)",
+      "churn": "Churn Rate"
+    }
+  },
+  "users": {
+    "title": "Users",
+    "actions": {
+      "recalcStorage": "Recalculate Storage",
+      "recalcing": "Recalculating..."
+    },
+    "table": {
+      "user": "User",
+      "credits": "Credits",
+      "tokenIO": "Tokens (In/Out)",
+      "subscriptionStatus": "Subscription",
+      "storage": "Storage Usage",
+      "authSource": "Auth Source",
+      "time": "Time",
+      "actions": "Actions",
+      "loading": "Loading..."
+    },
+    "subscriptionStatus": {
+      "active": "Active",
+      "inactive": "Not Subscribed",
+      "expired": "Expired"
+    },
+    "tooltip": {
+      "viewDetail": "View Details",
+      "manageCredits": "Manage Credits",
+      "manageSubscription": "Manage Subscription",
+      "creditHistory": "Credit History",
+      "usageRate": "Usage: {{percent}}%"
+    },
+    "delete": {
+      "title": "Confirm deletion?",
+      "description": "This action cannot be undone. The user and related data will be permanently deleted.",
+      "cancel": "Cancel",
+      "confirm": "Confirm Delete"
+    },
+    "toast": {
+      "deleteSuccess": "User deleted successfully",
+      "deleteSuccessDesc": "The user has been removed from the system",
+      "deleteFailed": "Failed to delete user",
+      "retryLater": "Please try again later",
+      "rechargeSuccess": "Recharge successful",
+      "deductSuccess": "Deduction successful",
+      "rechargeDesc": "Recharged {{amount}} credits",
+      "deductDesc": "Deducted {{amount}} credits",
+      "operationFailed": "Operation failed",
+      "subscriptionSetSuccess": "Subscription set successfully",
+      "subscriptionSetFailed": "Failed to set subscription",
+      "subscriptionCanceled": "Subscription canceled",
+      "subscriptionCancelFailed": "Failed to cancel",
+      "recalcSuccess": "Storage usage recalculated",
+      "recalcFailed": "Recalculation failed"
+    },
+    "detail": {
+      "title": "User Details",
+      "active": "Active",
+      "disabled": "Disabled",
+      "frozen": "Balance Frozen",
+      "authSource": "Auth Source",
+      "providerGoogleGitHub": "Google + GitHub linked login",
+      "providerGoogle": "Google linked login",
+      "providerGitHub": "GitHub linked login",
+      "providerLocal": "Local registration",
+      "stats": {
+        "creditBalance": "Credit Balance",
+        "inputToken": "Input Tokens",
+        "outputToken": "Output Tokens"
+      },
+      "storage": {
+        "title": "Storage"
+      },
+      "subscription": {
+        "title": "Subscription",
+        "status": "Status",
+        "plan": "Current Plan",
+        "startTime": "Start Time",
+        "endTime": "End Time",
+        "empty": "-"
+      },
+      "login": {
+        "title": "Login & Device",
+        "registerTime": "Registered At",
+        "lastLogin": "Last Login",
+        "registerIp": "Register IP",
+        "loginIp": "Login IP",
+        "deviceType": "Device Type",
+        "os": "Operating System",
+        "browser": "Browser"
+      }
+    },
+    "credit": {
+      "dialogTitle": "Manage Credits",
+      "description": "Adjust credits for {{nickname}} (Current balance: {{balance}})",
+      "amount": "Adjustment Amount",
+      "amountPlaceholder": "Positive = recharge, negative = deduct",
+      "reason": "Description",
+      "reasonPlaceholder": "Enter reason",
+      "cancel": "Cancel",
+      "confirm": "Confirm",
+      "submitting": "Submitting...",
+      "validation": {
+        "nonZero": "Amount cannot be 0",
+        "reasonRequired": "Please enter a description"
+      }
+    },
+    "subscription": {
+      "dialogTitle": "Manage Subscription",
+      "description": "Set subscription plan for {{nickname}}",
+      "plan": "Plan",
+      "planPlaceholder": "Select a plan",
+      "planItem": "{{name}} - ${{price}} ({{credits}} credits)",
+      "startTime": "Start Time",
+      "endTime": "End Time",
+      "autoGrant": "Auto-grant plan credits",
+      "cancelSub": "Cancel Subscription",
+      "cancel": "Cancel",
+      "submit": "Save Subscription",
+      "submitting": "Submitting...",
+      "validation": {
+        "planRequired": "Please select a plan",
+        "startRequired": "Please select a start time",
+        "endRequired": "Please select an end time"
+      }
+    },
+    "creditsPage": {
+      "title": "Credit History",
+      "userLabel": "User: {{nickname}}",
+      "userLoading": "Loading...",
+      "balanceLabel": "Current Balance: {{balance}}",
+      "back": "Back to Users",
+      "table": {
+        "time": "Time",
+        "type": "Type",
+        "amount": "Amount",
+        "balanceBefore": "Before",
+        "balanceAfter": "After",
+        "tokens": "Tokens",
+        "description": "Description"
+      },
+      "loading": "Loading...",
+      "empty": "No credit transactions",
+      "types": {
+        "recharge": "Recharge",
+        "deduction": "Consume",
+        "admin_adjust": "Adjust"
+      }
+    }
+  },
+  "subscriptions": {
+    "title": "Subscription Plans",
+    "subtitle": "Manage subscription plans and pricing",
+    "newPlan": "New Plan",
+    "table": {
+      "order": "Order",
+      "name": "Plan Name",
+      "billingCycle": "Billing Cycle",
+      "price": "Price (USD)",
+      "credits": "Credits",
+      "storage": "Storage",
+      "unitPrice": "Unit ($/credit)",
+      "margin": "Margin",
+      "status": "Status",
+      "actions": "Actions",
+      "loading": "Loading...",
+      "empty": "No plans"
+    },
+    "billingCycle": {
+      "monthly": "Monthly",
+      "yearly": "Yearly",
+      "lifetime": "Lifetime"
+    },
+    "dialog": {
+      "createTitle": "New Plan",
+      "editTitle": "Edit Plan",
+      "createDescription": "Create a new subscription plan",
+      "editDescription": "Modify subscription plan details"
+    },
+    "form": {
+      "name": "Plan Name",
+      "namePlaceholder": "e.g. Basic",
+      "description": "Description",
+      "descriptionPlaceholder": "Plan description (optional)",
+      "price": "Price (USD)",
+      "credits": "Credits",
+      "billingCycle": "Billing Cycle",
+      "sortOrder": "Sort Order",
+      "storageQuota": "Storage Quota (GB)",
+      "features": "Plan Features",
+      "featureAdd": "Add",
+      "featurePlaceholder": "e.g. 1000 credits per month",
+      "featuresEmpty": "No features. Click \"Add\" to create.",
+      "isActive": "Active",
+      "cancel": "Cancel",
+      "save": "Save",
+      "create": "Create",
+      "submitting": "Submitting..."
+    },
+    "metrics": {
+      "unitPrice": "Unit Price",
+      "unitPriceValue": "${{value}} / credit",
+      "baseCost": "Base Cost (1 credit = $0.01)",
+      "baseCostValue": "${{value}}",
+      "margin": "Margin"
+    },
+    "status": {
+      "active": "Active",
+      "inactive": "Inactive"
+    },
+    "delete": {
+      "title": "Confirm Delete",
+      "description": "Are you sure you want to delete the plan \"{{name}}\"? This cannot be undone.",
+      "cancel": "Cancel",
+      "confirm": "Confirm Delete"
+    },
+    "toast": {
+      "createSuccess": "Created successfully",
+      "updateSuccess": "Updated successfully",
+      "createFailed": "Failed to create",
+      "updateFailed": "Failed to update",
+      "deleteSuccess": "Deleted successfully",
+      "deleteSuccessDesc": "Plan \"{{name}}\" has been deleted.",
+      "deleteFailed": "Failed to delete",
+      "retryLater": "Please try again later"
+    },
+    "validation": {
+      "nameRequired": "Please enter a plan name",
+      "pricePositive": "Price must be greater than 0",
+      "creditsPositive": "Credits must be greater than 0",
+      "storagePositive": "Storage quota must be greater than 0",
+      "featureRequired": "Please enter feature description"
+    }
+  },
+  "llm": {
+    "title": "AI Providers",
+    "subtitle": "Manage and configure AI providers and their model parameters",
+    "addProvider": "Add Provider",
+    "list": {
+      "loadFailed": "Failed to load, please refresh",
+      "empty": "No AI providers yet",
+      "emptyAction": "Add your first AI provider",
+      "defaultUrl": "Default URL",
+      "editTooltip": "Edit",
+      "deleteTooltip": "Delete",
+      "table": {
+        "name": "Name",
+        "brand": "Brand",
+        "tags": "Tags",
+        "models": "Models",
+        "actions": "Actions"
+      },
+      "toast": {
+        "deleteSuccess": "Provider deleted successfully",
+        "deleteFailed": "Failed to delete"
+      },
+      "delete": {
+        "title": "Confirm deletion?",
+        "description": "This will permanently delete the provider configuration ({{name}}). This action cannot be undone.",
+        "cancel": "Cancel",
+        "confirm": "Confirm Delete"
+      }
+    },
+    "edit": {
+      "loading": "Loading...",
+      "loadFailed": "Failed to load, please refresh",
+      "notFound": "Provider not found"
+    },
+    "form": {
+      "createTitle": "Create Provider",
+      "editTitle": "Edit Provider",
+      "subtitle": "Configure the basic info, model parameters, and connection authentication for the LLM provider.",
+      "testConnection": "Test Connection",
+      "back": "Back",
+      "save": "Save",
+      "saving": "Saving...",
+      "idLabel": "ID: {{id}}",
+      "basic": {
+        "title": "Basic Info",
+        "description": "Configure provider name, brand, and tags.",
+        "name": "Name",
+        "namePlaceholder": "Enter a name (e.g. OpenAI)",
+        "brand": "Brand",
+        "brandPlaceholder": "Select a brand",
+        "tags": "Tags",
+        "tagsPlaceholder": "Type a tag and press Enter",
+        "tagsDescription": "Used for categorization and filtering. Multiple tags supported."
+      },
+      "connection": {
+        "title": "Connection & Authentication",
+        "description": "Configure API key and advanced options.",
+        "baseUrl": "Base URL (optional)",
+        "baseUrlPlaceholder": "e.g. https://api.openai.com/v1",
+        "baseUrlDescription": "Fill in if you use a proxy or custom endpoint.",
+        "apiKey": "API Key",
+        "apiKeyPlaceholder": "sk-...",
+        "advancedConfig": "Advanced Config (JSON)",
+        "advancedConfigPlaceholder": "{\"timeout\": 30, \"max_retries\": 3}"
+      },
+      "models": {
+        "title": "Model Configuration",
+        "description": "Add supported models and their cost information.",
+        "modelNamePlaceholder": "Model name (e.g. gpt-4)",
+        "aliasPlaceholder": "Alias (optional)",
+        "typePlaceholder": "Type",
+        "addModel": "Add Model",
+        "costsTitle": "Model Cost Configuration (optional)",
+        "costsUnit": "USD / Unit",
+        "configCount": "{{count}} config(s)",
+        "customParamsTitle": "Custom Parameters",
+        "customParamName": "Param Name",
+        "customParamCost": "Cost (USD)",
+        "addCustomParam": "Add Custom Cost Parameter",
+        "customParamPrompt": "Enter a custom parameter name (English, e.g. reasoning_output)",
+        "customParamFormatError": "Invalid parameter name",
+        "customParamFormatErrorDesc": "Only lowercase letters, digits, and underscores are allowed",
+        "customParamExists": "Parameter name already exists"
+      },
+      "toast": {
+        "selectModelForTest": "Please add at least one model to test",
+        "testSuccess": "Connection successful",
+        "testSuccessDesc": "Response: {{response}}",
+        "testFailed": "Connection failed",
+        "testError": "Test failed",
+        "unknownError": "Unknown error",
+        "updateSuccess": "Provider updated successfully",
+        "createSuccess": "Provider created successfully",
+        "submitFailed": "Operation failed"
+      },
+      "validation": {
+        "nameRequired": "Please enter a name",
+        "providerRequired": "Please select a brand",
+        "modelNameRequired": "Please enter the model name",
+        "modelsRequired": "At least one model is required",
+        "apiKeyRequired": "Please enter the API key",
+        "invalidJson": "Please enter valid JSON"
+      }
+    },
+    "modelType": {
+      "language": "Language Model",
+      "image": "Image Model",
+      "video": "Video Model",
+      "audio": "Audio Model",
+      "multimodal": "Multimodal"
+    },
+    "costDimension": {
+      "input": "Input",
+      "text_output": "Text Output",
+      "image_output": "Image Output",
+      "search": "Search Query",
+      "video_input_image": "Video Input Image",
+      "video_input_second": "Video Input Duration",
+      "video_output_480p": "Video Output 480p",
+      "video_output_720p": "Video Output 720p",
+      "audio_generation": "Audio Generation"
+    }
+  },
+  "agents": {
+    "title": "Agents",
+    "subtitle": "Create, configure and manage your AI agents",
+    "create": "Create Agent",
+    "searchPlaceholder": "Search agents...",
+    "loading": "Loading...",
+    "noTools": "No Tools",
+    "header": {
+      "newAgent": "Create New Agent",
+      "config": "Configuration",
+      "cancel": "Cancel",
+      "save": "Save",
+      "saving": "Saving...",
+      "loading": "Loading...",
+      "notFound": "Agent Not Found",
+      "backHome": "Back Home"
+    },
+    "table": {
+      "name": "Name",
+      "model": "Model Config",
+      "params": "Parameters",
+      "capabilities": "Capabilities",
+      "createdAt": "Created At",
+      "actions": "Actions",
+      "provider": "Provider",
+      "modelLabel": "Model",
+      "temperature": "Temperature",
+      "contextWindow": "Context",
+      "editTooltip": "Edit"
+    },
+    "delete": {
+      "title": "Confirm deletion?",
+      "description": "This action cannot be undone. Agent \"{{name}}\" will be permanently deleted.",
+      "cancel": "Cancel",
+      "confirm": "Confirm Delete"
+    },
+    "toast": {
+      "deleteSuccess": "Agent deleted successfully",
+      "deleteFailed": "Delete failed",
+      "unknownError": "Unknown error",
+      "createSuccess": "Created successfully",
+      "updateSuccess": "Updated successfully",
+      "submitFailed": "Operation failed"
+    },
+    "form": {
+      "sections": {
+        "basic": "Basic Info",
+        "system": "System Prompt",
+        "params": "Parameters",
+        "capabilities": "Capabilities",
+        "leader": "Collaboration"
+      },
+      "fieldLabels": {
+        "name": "Name",
+        "description": "Description",
+        "provider_id": "Provider",
+        "model": "Model",
+        "system_prompt": "System Prompt",
+        "temperature": "Temperature",
+        "context_window": "Context Window",
+        "tools": "Tools",
+        "coordination_modes": "Coordination Modes",
+        "gemini_config": "Gemini Config"
+      },
+      "validation": {
+        "nameRequired": "Please enter the agent name",
+        "nameMax": "Max length 50 characters",
+        "descRequired": "Please enter description",
+        "descMax": "Max length 500 characters",
+        "providerRequired": "Please select a provider",
+        "modelRequired": "Please select a model",
+        "systemPromptRequired": "Please enter the system prompt",
+        "systemPromptMax": "Max length 5000 characters",
+        "contextMin": "Minimum value is 4096",
+        "contextMax": "Maximum value is 1048576",
+        "creditNonNegative": "Must be non-negative",
+        "capabilityRequired": "Enable at least one tool or function when capabilities are enabled"
+      },
+      "invalidToastTitle": "Please check the following fields",
+      "invalidToastJoiner": ", ",
+      "submitFailedTitle": "Submission failed",
+      "submitFailedDesc": "Please try again",
+      "basicInfo": {
+        "namePlaceholder": "Give the agent a name, e.g. Story Director",
+        "descPlaceholder": "Briefly describe the agent's responsibilities...",
+        "modelConfig": "Model Configuration",
+        "selectProvider": "Select provider",
+        "selectModel": "Select model",
+        "selectProviderFirst": "Select provider first"
+      },
+      "systemPrompt": {
+        "label": "System Prompt",
+        "importTemplate": "Import from template",
+        "placeholder": "You are a professional assistant...",
+        "dialogTitle": "Select a Prompt Template",
+        "searchPlaceholder": "Search template names...",
+        "allCategories": "All Categories",
+        "noMatch": "No matching templates",
+        "default": "Default"
+      },
+      "leader": {
+        "leaderMode": "Leader Mode",
+        "leaderModeDesc": "Enable intelligent coordination of multiple member agents for complex tasks",
+        "memberAgents": "Member Agents",
+        "memberAgentsDesc": "Select agents that can be dispatched",
+        "noMembers": "No member agents available, please create other agents first",
+        "maxSubtasks": "Max Subtasks",
+        "maxSubtasksDesc": "Limit the number of subtasks a single task can be split into",
+        "autoReview": "Auto Review",
+        "autoReviewDesc": "Leader automatically reviews results after subtasks complete"
+      },
+      "parameters": {
+        "thinkingMode": "Thinking Mode",
+        "thinkingModeDesc": "Enable deep reasoning (supported by some models)",
+        "on": "On",
+        "off": "Off",
+        "contextWindow": "Context Window",
+        "contextWindowTokens": "Tokens",
+        "contextWindowMin": "4K",
+        "contextWindowMax": "1M",
+        "contextWindowValue": "{{display}} ({{tokens}} tokens)",
+        "compaction": {
+          "title": "Context Compaction",
+          "desc": "Automatically summarize and compact old messages when the conversation grows too long",
+          "on": "On",
+          "off": "Off",
+          "compactionProvider": "Summary Provider",
+          "useDefault": "Use this agent's provider (default)",
+          "compactionModel": "Summary Model",
+          "selectProvider": "Select provider",
+          "selectModel": "Select model",
+          "compactRatio": "Trigger Threshold ({{percent}}%)",
+          "reserveRatio": "Reserve Ratio ({{percent}}%)",
+          "toolOldThreshold": "Old Tool Char Threshold",
+          "toolRecentN": "Recent Entries Kept",
+          "maxSummaryTokens": "Max Summary Tokens",
+          "maxSummaryTokensDesc": "max_tokens limit when the LLM generates summaries"
+        },
+        "maxToolRounds": {
+          "title": "Max Tool Rounds",
+          "desc": "Max number of tool calls per conversation round",
+          "times": "times",
+          "min": "10 times",
+          "max": "200 times"
+        },
+        "temperature": "Temperature",
+        "temperatureLow": "0 (precise)",
+        "temperatureHigh": "1 (creative)",
+        "thinkingModeDesc": "When enabled, the model performs a chain-of-thought reasoning process before answering.",
+        "pricing": {
+          "title": "Credit Pricing",
+          "markupMultiplier": "Cost Multiplier",
+          "applyAll": "Apply All Suggestions",
+          "setFree": "Set All Free",
+          "freeDesc": "Set to 0 to make it free (no credits consumed).",
+          "profitOverview": "Profit Overview",
+          "apiCost": "API cost: ${{cost}}{{unit}}",
+          "suggestion": "Suggested: {{value}} credits",
+          "credits": "credits",
+          "naLabel": "N/A"
+        },
+        "costDimensions": {
+          "input": "Input Price",
+          "text_output": "Output Price",
+          "image_output": "Image Output Price",
+          "search": "Search Query Price",
+          "image_generation": "Image Generation Price",
+          "video_input_image": "Video - Input Image",
+          "video_input_second": "Video - Input Duration",
+          "video_output_480p": "Video Output (480p)",
+          "video_output_720p": "Video Output (720p)"
+        },
+        "units": {
+          "per_1m": "credits/1M tokens",
+          "per_query": "credits/query",
+          "per_image": "credits/image",
+          "per_second": "credits/second"
+        },
+        "costUnits": {
+          "per_1m": "/1M tokens",
+          "per_query": "/query",
+          "per_image": "/image",
+          "per_second": "/second"
+        }
+      },
+      "tools": {
+        "title": "Capabilities",
+        "desc": "Enable to allow the agent to access external skills, MCP and built-in tools",
+        "noToolsEnabled": "No capabilities enabled. Enable to configure specific tools",
+        "skills": {
+          "title": "Skills",
+          "loading": "Loading skills…",
+          "empty": "No skills available. Please create one in Skills Management"
+        },
+        "mcp": {
+          "title": "MCP Clients (Model Context Protocol)",
+          "inDevelopment": "Feature in development, stay tuned"
+        },
+        "capabilities": {
+          "title": "Tool Toggles",
+          "image": {
+            "title": "Image Tools",
+            "desc": "Image generation (generate_image) and image editing (edit_image) tools.",
+            "globalDisabled": "Global config not enabled. Please enable image generation in Tools Management first",
+            "params": "Configure parameters in Tools Management"
+          },
+          "video": {
+            "title": "Video Tools",
+            "desc": "Video generation (generate_video) and video editing (edit_video) tools.",
+            "globalDisabled": "Global config not enabled. Please enable video generation in Tools Management first",
+            "params": "Configure parameters in Tools Management"
+          },
+          "canvas": {
+            "title": "Canvas Tools",
+            "desc": "When enabled, the agent can control canvas node content."
+          },
+          "nodeTypes": {
+            "script": "Text Node",
+            "scriptDesc": "Rich text content",
+            "character": "Image Node",
+            "characterDesc": "Image generation and management",
+            "video": "Video Node",
+            "videoDesc": "Video generation and management",
+            "storyboard": "Data Table",
+            "storyboardDesc": "Data tables and analysis"
+          }
+        }
+      }
+    },
+    "multiAgent": {
+      "collaborating": "Collaborating",
+      "collaborationProcess": "Collaboration Process",
+      "agents": "agents",
+      "tokens": "tokens",
+      "credits": "credits",
+      "status": {
+        "pending": "Pending",
+        "running": "Running",
+        "completed": "Completed",
+        "failed": "Failed"
+      }
+    },
+    "chat": {
+      "preview": "Preview Chat",
+      "selectConversation": "Select Conversation",
+      "noHistory": "No history",
+      "newConversation": "New Chat",
+      "startNew": "Start a new conversation",
+      "inputPlaceholder": "Type a message...",
+      "uploadImage": "Upload Image",
+      "aiNotice": "AI may generate inaccurate information. Verify important facts.",
+      "selectOrCreate": "Select or create a conversation to start",
+      "createNewSession": "Create New Conversation",
+      "loadFailed": "Failed to load messages",
+      "createFailed": "Failed to create debug session",
+      "deleteFailed": "Failed to delete debug session",
+      "collaboratingWithAgents": "Collaborating... ({{count}} agents)",
+      "collaboratingAgentGenerating": "Collaborating... ({{name}} is generating)",
+      "collaboratingProgress": "Collaborating... ({{completed}}/{{total}} done)",
+      "skill": {
+        "loading": "Loading skill: {{name}}",
+        "loaded": "Skill loaded: {{name}}"
+      },
+      "tool": {
+        "executing": "Executing: {{name}}",
+        "completed": "Completed: {{name}}"
+      },
+      "edit": {
+        "selectedTitle": "Image selected for editing",
+        "selectedDesc": "The next message will be based on this image",
+        "mode": "Edit mode: the next message will be based on the selected image",
+        "failed": "Unable to load image",
+        "continueEdit": "Continue Editing"
+      }
+    }
+  },
   "login": {
     "title": "Admin Login",
     "email": "Email",

--- a/backend/admin/src/i18n/locales/zh-CN.json
+++ b/backend/admin/src/i18n/locales/zh-CN.json
@@ -1,4 +1,797 @@
 {
+  "common": {
+    "buttons": {
+      "save": "保存",
+      "cancel": "取消",
+      "confirm": "确认",
+      "delete": "删除",
+      "edit": "编辑",
+      "create": "创建",
+      "add": "新增",
+      "back": "返回",
+      "search": "搜索",
+      "refresh": "刷新",
+      "close": "关闭",
+      "submit": "提交",
+      "reset": "重置",
+      "retry": "重试",
+      "view": "查看",
+      "copy": "复制",
+      "export": "导出",
+      "import": "导入",
+      "upload": "上传",
+      "download": "下载",
+      "more": "更多",
+      "details": "详情",
+      "yes": "是",
+      "no": "否",
+      "enable": "启用",
+      "disable": "禁用"
+    },
+    "status": {
+      "loading": "加载中...",
+      "submitting": "提交中...",
+      "saving": "保存中...",
+      "deleting": "删除中...",
+      "empty": "暂无数据",
+      "error": "加载失败",
+      "success": "操作成功",
+      "failed": "操作失败",
+      "enabled": "启用",
+      "disabled": "禁用",
+      "active": "已启用",
+      "inactive": "已禁用"
+    },
+    "dialog": {
+      "confirmTitle": "确认操作",
+      "confirmDelete": "确认删除",
+      "deleteWarning": "此操作无法撤销，是否继续？",
+      "unsavedChanges": "有未保存的修改，确定要离开吗？"
+    },
+    "table": {
+      "actions": "操作",
+      "createdAt": "创建时间",
+      "updatedAt": "更新时间",
+      "total": "共 {{count}} 条",
+      "page": "第 {{page}} 页",
+      "prev": "上一页",
+      "next": "下一页",
+      "noData": "暂无数据",
+      "searchPlaceholder": "搜索..."
+    },
+    "validation": {
+      "required": "此字段为必填项",
+      "invalidFormat": "格式不正确",
+      "tooShort": "长度不足",
+      "tooLong": "长度超出限制"
+    },
+    "toast": {
+      "saveSuccess": "保存成功",
+      "saveFailed": "保存失败",
+      "deleteSuccess": "删除成功",
+      "deleteFailed": "删除失败",
+      "operationSuccess": "操作成功",
+      "operationFailed": "操作失败",
+      "networkError": "网络错误，请稍后重试",
+      "unknownError": "未知错误"
+    }
+  },
+  "layout": {
+    "sidebar": {
+      "dashboard": "仪表盘",
+      "llm": "AI 供应商",
+      "agents": "智能体管理",
+      "skills": "技能管理 (Skills)",
+      "mcp": "MCP 客户端",
+      "tools": "工具管理",
+      "videos": "视频生成",
+      "virtualHumans": "虚拟人像",
+      "promptTemplates": "提示词模板",
+      "users": "用户管理",
+      "subscriptions": "订阅套餐",
+      "admins": "管理员",
+      "toggleMenu": "切换菜单"
+    },
+    "account": {
+      "admin": "管理员",
+      "myAccount": "我的账户",
+      "logout": "退出登录"
+    },
+    "language": {
+      "label": "语言",
+      "zhCN": "简体中文",
+      "enUS": "English"
+    }
+  },
+  "dashboard": {
+    "title": "仪表盘",
+    "stat": {
+      "totalUsers": "用户总数",
+      "todayActive": "今日活跃",
+      "todayRevenue": "今日营收",
+      "totalRevenue": "总营收"
+    },
+    "bucket": {
+      "today": "今日",
+      "yesterday": "昨日",
+      "this_week": "本周",
+      "this_month": "本月",
+      "older": "更早"
+    },
+    "period": {
+      "today": "今日",
+      "yesterday": "昨日",
+      "week": "本周",
+      "month": "本月",
+      "quarter": "近三月",
+      "all": "全部",
+      "rangeLabel": {
+        "today": "今日",
+        "yesterday": "近 2 天",
+        "week": "本周",
+        "month": "近 30 天",
+        "quarter": "近 3 个月",
+        "all": "全部"
+      }
+    },
+    "trend": {
+      "registration": "注册趋势",
+      "active": "活跃趋势",
+      "conversion": "订阅转化",
+      "registrationSeries": "注册数",
+      "activeSeries": "活跃用户",
+      "conversionSeries": "新增订阅",
+      "titleWithRange": "{{name}}（{{range}}）",
+      "dateLabel": "日期：{{date}}"
+    },
+    "leaderboard": {
+      "title": "Token 消耗排行榜",
+      "rank": "#",
+      "user": "用户",
+      "totalTokens": "总 Token",
+      "credits": "积分",
+      "top": "Top {{n}}",
+      "empty": "暂无数据",
+      "nicknamePlaceholder": "—"
+    },
+    "metrics": {
+      "title": "运营指标",
+      "pur": "付费用户占比 (PUR)",
+      "retention": "活跃留存率",
+      "mrr": "MRR (月经常性收入)",
+      "churn": "退订率"
+    }
+  },
+  "users": {
+    "title": "用户管理",
+    "actions": {
+      "recalcStorage": "重算存储用量",
+      "recalcing": "重算中..."
+    },
+    "table": {
+      "user": "用户",
+      "credits": "积分",
+      "tokenIO": "Token (输入/输出)",
+      "subscriptionStatus": "订阅状态",
+      "storage": "存储用量",
+      "authSource": "注册来源",
+      "time": "时间",
+      "actions": "操作",
+      "loading": "加载中..."
+    },
+    "subscriptionStatus": {
+      "active": "生效中",
+      "inactive": "未订阅",
+      "expired": "已过期"
+    },
+    "tooltip": {
+      "viewDetail": "查看详情",
+      "manageCredits": "积分管理",
+      "manageSubscription": "订阅管理",
+      "creditHistory": "积分历史",
+      "usageRate": "使用率: {{percent}}%"
+    },
+    "delete": {
+      "title": "确认删除？",
+      "description": "此操作不可撤销。这将永久删除该用户及其相关数据。",
+      "cancel": "取消",
+      "confirm": "确认删除"
+    },
+    "toast": {
+      "deleteSuccess": "用户删除成功",
+      "deleteSuccessDesc": "用户已从系统中移除",
+      "deleteFailed": "删除用户失败",
+      "retryLater": "请稍后重试",
+      "rechargeSuccess": "充值成功",
+      "deductSuccess": "扣除成功",
+      "rechargeDesc": "已充值 {{amount}} 积分",
+      "deductDesc": "已扣除 {{amount}} 积分",
+      "operationFailed": "操作失败",
+      "subscriptionSetSuccess": "订阅设置成功",
+      "subscriptionSetFailed": "设置失败",
+      "subscriptionCanceled": "订阅已取消",
+      "subscriptionCancelFailed": "取消失败",
+      "recalcSuccess": "存储用量重算完成",
+      "recalcFailed": "重算失败"
+    },
+    "detail": {
+      "title": "用户详情",
+      "active": "活跃",
+      "disabled": "禁用",
+      "frozen": "余额冻结",
+      "authSource": "注册来源",
+      "providerGoogleGitHub": "Google + GitHub 联合登录",
+      "providerGoogle": "Google 联合登录",
+      "providerGitHub": "GitHub 联合登录",
+      "providerLocal": "本地注册",
+      "stats": {
+        "creditBalance": "积分余额",
+        "inputToken": "输入 Token",
+        "outputToken": "输出 Token"
+      },
+      "storage": {
+        "title": "存储空间"
+      },
+      "subscription": {
+        "title": "订阅信息",
+        "status": "订阅状态",
+        "plan": "当前套餐",
+        "startTime": "开始时间",
+        "endTime": "到期时间",
+        "empty": "-"
+      },
+      "login": {
+        "title": "登录与设备",
+        "registerTime": "注册时间",
+        "lastLogin": "最后登录",
+        "registerIp": "注册IP",
+        "loginIp": "登录IP",
+        "deviceType": "设备类型",
+        "os": "操作系统",
+        "browser": "浏览器"
+      }
+    },
+    "credit": {
+      "dialogTitle": "积分管理",
+      "description": "为用户 {{nickname}} 调整积分（当前余额: {{balance}}）",
+      "amount": "调整金额",
+      "amountPlaceholder": "正数=充值，负数=扣除",
+      "reason": "操作说明",
+      "reasonPlaceholder": "请输入操作原因",
+      "cancel": "取消",
+      "confirm": "确认",
+      "submitting": "提交中...",
+      "validation": {
+        "nonZero": "金额不能为 0",
+        "reasonRequired": "请输入操作说明"
+      }
+    },
+    "subscription": {
+      "dialogTitle": "订阅管理",
+      "description": "为用户 {{nickname}} 设置订阅套餐",
+      "plan": "订阅套餐",
+      "planPlaceholder": "选择套餐",
+      "planItem": "{{name}} - ${{price}} ({{credits}} 积分)",
+      "startTime": "开始时间",
+      "endTime": "结束时间",
+      "autoGrant": "自动发放套餐积分",
+      "cancelSub": "取消订阅",
+      "cancel": "取消",
+      "submit": "设置订阅",
+      "submitting": "提交中...",
+      "validation": {
+        "planRequired": "请选择套餐",
+        "startRequired": "请选择开始时间",
+        "endRequired": "请选择结束时间"
+      }
+    },
+    "creditsPage": {
+      "title": "积分历史",
+      "userLabel": "用户: {{nickname}}",
+      "userLoading": "加载中...",
+      "balanceLabel": "当前余额: {{balance}}",
+      "back": "返回用户列表",
+      "table": {
+        "time": "时间",
+        "type": "类型",
+        "amount": "金额",
+        "balanceBefore": "变动前",
+        "balanceAfter": "变动后",
+        "tokens": "Token",
+        "description": "说明"
+      },
+      "loading": "加载中...",
+      "empty": "暂无积分变动记录",
+      "types": {
+        "recharge": "充值",
+        "deduction": "消费",
+        "admin_adjust": "调整"
+      }
+    }
+  },
+  "subscriptions": {
+    "title": "订阅套餐管理",
+    "subtitle": "管理用户订阅套餐和定价策略",
+    "newPlan": "新建套餐",
+    "table": {
+      "order": "排序",
+      "name": "套餐名称",
+      "billingCycle": "计费周期",
+      "price": "价格 (USD)",
+      "credits": "积分",
+      "storage": "存储配额",
+      "unitPrice": "单价 ($/积分)",
+      "margin": "利润率",
+      "status": "状态",
+      "actions": "操作",
+      "loading": "加载中...",
+      "empty": "暂无套餐数据"
+    },
+    "billingCycle": {
+      "monthly": "月付",
+      "yearly": "年付",
+      "lifetime": "终身"
+    },
+    "dialog": {
+      "createTitle": "新建套餐",
+      "editTitle": "编辑套餐",
+      "createDescription": "创建新的订阅套餐",
+      "editDescription": "修改订阅套餐信息"
+    },
+    "form": {
+      "name": "套餐名称",
+      "namePlaceholder": "例如：基础版",
+      "description": "描述",
+      "descriptionPlaceholder": "套餐描述（可选）",
+      "price": "价格 (USD)",
+      "credits": "积分数量",
+      "billingCycle": "计费周期",
+      "sortOrder": "排序",
+      "storageQuota": "存储配额 (GB)",
+      "features": "套餐特性",
+      "featureAdd": "添加",
+      "featurePlaceholder": "例如：每月 1000 积分",
+      "featuresEmpty": "暂无特性，点击\"添加\"按钮",
+      "isActive": "启用",
+      "cancel": "取消",
+      "save": "保存",
+      "create": "创建",
+      "submitting": "提交中..."
+    },
+    "metrics": {
+      "unitPrice": "单价",
+      "unitPriceValue": "${{value}} / 积分",
+      "baseCost": "基准成本 (1积分=$0.01)",
+      "baseCostValue": "${{value}}",
+      "margin": "利润率"
+    },
+    "status": {
+      "active": "启用",
+      "inactive": "停用"
+    },
+    "delete": {
+      "title": "确认删除",
+      "description": "确定要删除套餐 \"{{name}}\" 吗？此操作不可撤销。",
+      "cancel": "取消",
+      "confirm": "确认删除"
+    },
+    "toast": {
+      "createSuccess": "创建成功",
+      "updateSuccess": "更新成功",
+      "createFailed": "创建失败",
+      "updateFailed": "更新失败",
+      "deleteSuccess": "删除成功",
+      "deleteSuccessDesc": "套餐 \"{{name}}\" 已删除。",
+      "deleteFailed": "删除失败",
+      "retryLater": "请稍后再试"
+    },
+    "validation": {
+      "nameRequired": "请输入套餐名称",
+      "pricePositive": "价格必须大于 0",
+      "creditsPositive": "积分数量必须大于 0",
+      "storagePositive": "存储配额必须大于 0",
+      "featureRequired": "请输入特性描述"
+    }
+  },
+  "llm": {
+    "title": "AI 供应商",
+    "subtitle": "管理和配置 AI 供应商及其模型参数",
+    "addProvider": "添加供应商",
+    "list": {
+      "loadFailed": "加载失败，请刷新重试",
+      "empty": "暂无 AI 供应商",
+      "emptyAction": "添加第一个 AI 供应商",
+      "defaultUrl": "默认URL",
+      "editTooltip": "编辑",
+      "deleteTooltip": "删除",
+      "table": {
+        "name": "名称",
+        "brand": "品牌",
+        "tags": "标签",
+        "models": "模型",
+        "actions": "操作"
+      },
+      "toast": {
+        "deleteSuccess": "供应商删除成功",
+        "deleteFailed": "删除失败"
+      },
+      "delete": {
+        "title": "确认删除供应商？",
+        "description": "此操作将永久删除该供应商配置 ({{name}})，不可撤销。",
+        "cancel": "取消",
+        "confirm": "确认删除"
+      }
+    },
+    "edit": {
+      "loading": "加载中...",
+      "loadFailed": "加载失败，请刷新重试",
+      "notFound": "未找到该供应商"
+    },
+    "form": {
+      "createTitle": "创建供应商",
+      "editTitle": "编辑供应商",
+      "subtitle": "配置 LLM 供应商的基础信息、模型参数及连接认证。",
+      "testConnection": "测试连接",
+      "back": "返回",
+      "save": "保存",
+      "saving": "保存中...",
+      "idLabel": "ID: {{id}}",
+      "basic": {
+        "title": "基本信息",
+        "description": "配置供应商的名称、品牌和标签。",
+        "name": "名称",
+        "namePlaceholder": "输入名称 (如 OpenAI)",
+        "brand": "品牌",
+        "brandPlaceholder": "选择品牌",
+        "tags": "标签",
+        "tagsPlaceholder": "输入标签后按回车添加",
+        "tagsDescription": "用于分类和筛选，支持多个标签。"
+      },
+      "connection": {
+        "title": "连接与认证",
+        "description": "配置 API 密钥和高级选项。",
+        "baseUrl": "基础 URL (选填)",
+        "baseUrlPlaceholder": "例如 https://api.openai.com/v1",
+        "baseUrlDescription": "如果使用代理或自定义端点，请填写此项。",
+        "apiKey": "API 密钥",
+        "apiKeyPlaceholder": "sk-...",
+        "advancedConfig": "高级配置 (JSON)",
+        "advancedConfigPlaceholder": "{\"timeout\": 30, \"max_retries\": 3}"
+      },
+      "models": {
+        "title": "模型配置",
+        "description": "添加支持的模型及其成本信息。",
+        "modelNamePlaceholder": "模型名称 (例如 gpt-4)",
+        "aliasPlaceholder": "别称（选填）",
+        "typePlaceholder": "类型",
+        "addModel": "添加模型",
+        "costsTitle": "模型成本配置 (选填)",
+        "costsUnit": "USD / Unit",
+        "configCount": "{{count}} 项配置",
+        "customParamsTitle": "自定义参数",
+        "customParamName": "参数名",
+        "customParamCost": "成本 (USD)",
+        "addCustomParam": "添加自定义成本参数",
+        "customParamPrompt": "输入自定义参数名 (英文, 如 reasoning_output)",
+        "customParamFormatError": "参数名格式错误",
+        "customParamFormatErrorDesc": "仅支持小写字母、数字和下划线",
+        "customParamExists": "参数名已存在"
+      },
+      "toast": {
+        "selectModelForTest": "请至少添加一个模型进行测试",
+        "testSuccess": "连接成功",
+        "testSuccessDesc": "回复：{{response}}",
+        "testFailed": "连接失败",
+        "testError": "测试失败",
+        "unknownError": "未知错误",
+        "updateSuccess": "供应商更新成功",
+        "createSuccess": "供应商创建成功",
+        "submitFailed": "操作失败"
+      },
+      "validation": {
+        "nameRequired": "请输入名称",
+        "providerRequired": "请选择平台",
+        "modelNameRequired": "请输入模型名称",
+        "modelsRequired": "至少需要一个模型",
+        "apiKeyRequired": "请输入 API 密钥",
+        "invalidJson": "请输入有效的 JSON 格式"
+      }
+    },
+    "modelType": {
+      "language": "语言模型",
+      "image": "图像模型",
+      "video": "视频模型",
+      "audio": "音频模型",
+      "multimodal": "多模态模型"
+    },
+    "costDimension": {
+      "input": "输入",
+      "text_output": "文本输出",
+      "image_output": "图片输出",
+      "search": "搜索查询",
+      "video_input_image": "视频输入图片",
+      "video_input_second": "视频输入时长",
+      "video_output_480p": "视频输出480p",
+      "video_output_720p": "视频输出720p",
+      "audio_generation": "音频生成"
+    }
+  },
+  "agents": {
+    "title": "智能体管理",
+    "subtitle": "创建、配置和管理您的 AI 智能体",
+    "create": "创建智能体",
+    "searchPlaceholder": "搜索智能体...",
+    "loading": "加载中...",
+    "noTools": "无工具",
+    "header": {
+      "newAgent": "创建新智能体",
+      "config": "配置",
+      "cancel": "取消",
+      "save": "保存",
+      "saving": "保存中...",
+      "loading": "Loading...",
+      "notFound": "Agent Not Found",
+      "backHome": "Back Home"
+    },
+    "table": {
+      "name": "名称",
+      "model": "模型配置",
+      "params": "参数",
+      "capabilities": "能力",
+      "createdAt": "创建时间",
+      "actions": "操作",
+      "provider": "供应商",
+      "modelLabel": "模型",
+      "temperature": "温度",
+      "contextWindow": "上下文",
+      "editTooltip": "编辑"
+    },
+    "delete": {
+      "title": "确认删除？",
+      "description": "此操作无法撤销。将永久删除智能体 \"{{name}}\"。",
+      "cancel": "取消",
+      "confirm": "确认删除"
+    },
+    "toast": {
+      "deleteSuccess": "智能体删除成功",
+      "deleteFailed": "删除失败",
+      "unknownError": "未知错误",
+      "createSuccess": "创建成功",
+      "updateSuccess": "更新成功",
+      "submitFailed": "操作失败"
+    },
+    "form": {
+      "sections": {
+        "basic": "基础信息",
+        "system": "系统设定",
+        "params": "参数设置",
+        "capabilities": "能力",
+        "leader": "协作配置"
+      },
+      "fieldLabels": {
+        "name": "名称",
+        "description": "描述",
+        "provider_id": "供应商",
+        "model": "模型",
+        "system_prompt": "系统提示词",
+        "temperature": "温度",
+        "context_window": "上下文窗口",
+        "tools": "工具",
+        "coordination_modes": "协作模式",
+        "gemini_config": "Gemini 配置"
+      },
+      "validation": {
+        "nameRequired": "请输入智能体名称",
+        "nameMax": "最大长度50字符",
+        "descRequired": "请输入描述",
+        "descMax": "最大长度500字符",
+        "providerRequired": "请选择供应商",
+        "modelRequired": "请选择模型",
+        "systemPromptRequired": "请输入系统提示词",
+        "systemPromptMax": "最大长度5000字符",
+        "contextMin": "最小值为4096",
+        "contextMax": "最大值为1048576",
+        "creditNonNegative": "不能为负数",
+        "capabilityRequired": "启用能力时至少开启一项工具或功能"
+      },
+      "invalidToastTitle": "请检查以下字段",
+      "invalidToastJoiner": "、",
+      "submitFailedTitle": "提交失败",
+      "submitFailedDesc": "请重试",
+      "basicInfo": {
+        "namePlaceholder": "给智能体起个名字，例如: 故事导演",
+        "descPlaceholder": "简要描述智能体的职责和功能...",
+        "modelConfig": "模型配置",
+        "selectProvider": "选择供应商",
+        "selectModel": "选择模型",
+        "selectProviderFirst": "先选择供应商"
+      },
+      "systemPrompt": {
+        "label": "系统提示词",
+        "importTemplate": "从模板导入",
+        "placeholder": "你是一个专业的助手...",
+        "dialogTitle": "选择提示词模板",
+        "searchPlaceholder": "搜索模板名称...",
+        "allCategories": "全部分类",
+        "noMatch": "没有匹配的模板",
+        "default": "默认"
+      },
+      "leader": {
+        "leaderMode": "Leader 模式",
+        "leaderModeDesc": "启用后可智能协调多个成员智能体完成复杂任务",
+        "memberAgents": "成员智能体",
+        "memberAgentsDesc": "选择可调度的智能体",
+        "noMembers": "暂无可用的成员智能体，请先创建其他智能体",
+        "maxSubtasks": "最大子任务数",
+        "maxSubtasksDesc": "限制单次任务可拆解的子任务数量",
+        "autoReview": "自动审查",
+        "autoReviewDesc": "子任务完成后由 Leader 自动审查结果"
+      },
+      "parameters": {
+        "thinkingMode": "思考模式",
+        "thinkingModeDesc": "启用深度推理（仅部分模型支持）",
+        "on": "开启",
+        "off": "关闭",
+        "contextWindow": "上下文窗口",
+        "contextWindowTokens": "Token",
+        "contextWindowMin": "4K",
+        "contextWindowMax": "1M",
+        "contextWindowValue": "{{display}} ({{tokens}} tokens)",
+        "compaction": {
+          "title": "上下文压缩",
+          "desc": "对话过长时自动摘要压缩旧消息",
+          "on": "开启",
+          "off": "关闭",
+          "compactionProvider": "摘要生成供应商",
+          "useDefault": "使用当前智能体的供应商（默认）",
+          "compactionModel": "摘要生成模型",
+          "selectProvider": "选择供应商",
+          "selectModel": "选择模型",
+          "compactRatio": "压缩触发阈值 ({{percent}}%)",
+          "reserveRatio": "保留比例 ({{percent}}%)",
+          "toolOldThreshold": "旧工具截断字符数",
+          "toolRecentN": "最近完整保留条数",
+          "maxSummaryTokens": "最大摘要 Token 数",
+          "maxSummaryTokensDesc": "LLM 生成摘要时的 max_tokens 限制"
+        },
+        "maxToolRounds": {
+          "title": "工具调用轮次限制",
+          "desc": "单轮对话中最大工具调用次数",
+          "times": "次",
+          "min": "10次",
+          "max": "200次"
+        },
+        "temperature": "温度 (Temperature)",
+        "temperatureLow": "0 (精确)",
+        "temperatureHigh": "1 (创造性)",
+        "thinkingModeDesc": "开启后，模型会在回答前进行思考过程（Chain of Thought）。",
+        "pricing": {
+          "title": "积分定价",
+          "markupMultiplier": "成本倍率",
+          "applyAll": "应用全部建议",
+          "setFree": "一键免费",
+          "freeDesc": "设置为 0 表示免费，不消耗用户积分。",
+          "profitOverview": "利润概览",
+          "apiCost": "API 成本: ${{cost}}{{unit}}",
+          "suggestion": "建议: {{value}} 积分",
+          "credits": "积分",
+          "naLabel": "N/A"
+        },
+        "costDimensions": {
+          "input": "输入价格",
+          "text_output": "输出价格",
+          "image_output": "图片输出价格",
+          "search": "搜索查询价格",
+          "image_generation": "图片生成价格",
+          "video_input_image": "视频-输入图片",
+          "video_input_second": "视频-输入时长",
+          "video_output_480p": "视频输出(480p)",
+          "video_output_720p": "视频输出(720p)"
+        },
+        "units": {
+          "per_1m": "积分/1M tokens",
+          "per_query": "积分/次",
+          "per_image": "积分/张",
+          "per_second": "积分/秒"
+        },
+        "costUnits": {
+          "per_1m": "/1M tokens",
+          "per_query": "/次",
+          "per_image": "/张",
+          "per_second": "/秒"
+        }
+      },
+      "tools": {
+        "title": "能力",
+        "desc": "启用以允许智能体访问外部技能、MCP 与内置工具",
+        "noToolsEnabled": "当前未启用能力，开启后可配置具体工具",
+        "skills": {
+          "title": "技能 (Skills)",
+          "loading": "正在加载技能列表…",
+          "empty": "暂无可用技能，请先在技能管理中创建"
+        },
+        "mcp": {
+          "title": "MCP 客户端 (Model Context Protocol)",
+          "inDevelopment": "功能开发中，敬请期待"
+        },
+        "capabilities": {
+          "title": "工具开关",
+          "image": {
+            "title": "图像工具",
+            "desc": "图像生成 (generate_image) 和图像编辑 (edit_image) 工具。",
+            "globalDisabled": "全局配置未启用，请在「工具管理」中先启用图像生成",
+            "params": "参数配置请在「工具管理」中设置"
+          },
+          "video": {
+            "title": "视频工具",
+            "desc": "视频生成 (generate_video) 和视频编辑 (edit_video) 工具。",
+            "globalDisabled": "全局配置未启用，请在「工具管理」中先启用视频生成",
+            "params": "参数配置请在「工具管理」中设置"
+          },
+          "canvas": {
+            "title": "画布工具",
+            "desc": "开启后，智能体可以控制画布节点内容。"
+          },
+          "nodeTypes": {
+            "script": "文本节点",
+            "scriptDesc": "富文本内容",
+            "character": "图像节点",
+            "characterDesc": "图片生成与管理",
+            "video": "视频节点",
+            "videoDesc": "视频生成与管理",
+            "storyboard": "多维表格",
+            "storyboardDesc": "数据表格与分析"
+          }
+        }
+      }
+    },
+    "multiAgent": {
+      "collaborating": "协作中",
+      "collaborationProcess": "协作过程",
+      "agents": "个智能体",
+      "tokens": "tokens",
+      "credits": "积分",
+      "status": {
+        "pending": "等待中",
+        "running": "执行中",
+        "completed": "已完成",
+        "failed": "失败"
+      }
+    },
+    "chat": {
+      "preview": "预览对话",
+      "selectConversation": "选择对话",
+      "noHistory": "无历史记录",
+      "newConversation": "新对话",
+      "startNew": "开始一个新的对话",
+      "inputPlaceholder": "输入消息...",
+      "uploadImage": "上传图片",
+      "aiNotice": "AI 可能会生成不准确的信息，请核对重要事实。",
+      "selectOrCreate": "选择或创建一个对话开始",
+      "createNewSession": "创建新对话",
+      "loadFailed": "Failed to load messages",
+      "createFailed": "Failed to create debug session",
+      "deleteFailed": "Failed to delete debug session",
+      "collaboratingWithAgents": "正在协作... ({{count}} 个智能体)",
+      "collaboratingAgentGenerating": "协作中... ({{name}} 正在生成)",
+      "collaboratingProgress": "协作中... ({{completed}}/{{total}} 完成)",
+      "skill": {
+        "loading": "正在加载技能: {{name}}",
+        "loaded": "已加载技能: {{name}}"
+      },
+      "tool": {
+        "executing": "正在执行: {{name}}",
+        "completed": "已完成: {{name}}"
+      },
+      "edit": {
+        "selectedTitle": "已选择此图进行编辑",
+        "selectedDesc": "下一条消息将基于这张图片进行修改",
+        "mode": "编辑模式：下一条消息将基于选中的图片进行修改",
+        "failed": "无法加载图片",
+        "continueEdit": "继续编辑"
+      }
+    }
+  },
   "login": {
     "title": "管理员登录",
     "email": "邮箱",


### PR DESCRIPTION
- 在多个管理页面引入 useTranslation，替换硬编码中文文本为国际化 key
- 将仪表盘统计卡、趋势图、排行榜、运营指标等文字用 t() 调用
- Agents 管理列表及详情页表头、提示、操作文案替换为国际化文本
- LLM 供应商管理页及编辑表单校验提示改用国际化支持
- next-env.d.ts 修正路径引用以兼容开发环境类型定义
- 相关枚举和常量中的标签由静态中文改为国际化 key，支持动态翻译显示