### PR TITLE
feat(admin): 实现管理员和提示词模板页面的国际化支持

### DIFF
--- a/backend/admin/next-env.d.ts
+++ b/backend/admin/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/backend/admin/src/app/admin/admins/page.tsx
+++ b/backend/admin/src/app/admin/admins/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
@@ -59,32 +60,30 @@ import { Textarea } from '@/components/ui/textarea';
 
 const fetcher = (url: string) => api.get(url).then((res) => res.data);
 
-// 权限级别映射表
-const PERMISSION_LEVELS: Record<string, { label: string; variant: 'default' | 'secondary' }> = {
-  admin: { label: '管理员', variant: 'default' },
-  super_admin: { label: '超级管理员', variant: 'secondary' },
+// 权限级别变体映射
+const PERMISSION_VARIANT: Record<string, 'default' | 'secondary'> = {
+  admin: 'default',
+  super_admin: 'secondary',
 };
 
-// 创建管理员表单 Schema
-const createSchema = z.object({
-  email: z.string().email('请输入有效的邮箱地址'),
-  nickname: z.string().min(1, '请输入昵称').max(100),
-  password: z.string().min(6, '密码至少 6 位'),
-  permission_level: z.string(),
-});
+const PERMISSION_KEYS = ['admin', 'super_admin'] as const;
 
-// 编辑管理员表单 Schema
-const editSchema = z.object({
-  nickname: z.string().min(1, '请输入昵称').max(100),
-  password: z.string().optional(),
-  permission_level: z.string(),
-  is_active: z.boolean(),
-});
+type CreateValues = {
+  email: string;
+  nickname: string;
+  password: string;
+  permission_level: string;
+};
 
-type CreateValues = z.infer<typeof createSchema>;
-type EditValues = z.infer<typeof editSchema>;
+type EditValues = {
+  nickname: string;
+  password?: string;
+  permission_level: string;
+  is_active: boolean;
+};
 
 export default function AdminsPage() {
+  const { t } = useTranslation();
   const { data: admins, isLoading } = useSWR<Admin[]>('/admin/admins', fetcher);
   const { toast } = useToast();
 
@@ -95,6 +94,29 @@ export default function AdminsPage() {
   const [submitting, setSubmitting] = useState(false);
   const [creditAmount, setCreditAmount] = useState('');
   const [creditDescription, setCreditDescription] = useState('');
+
+  // Schema 随语言切换动态重建
+  const createSchema = useMemo(
+    () =>
+      z.object({
+        email: z.string().email(t('admins.validation.emailInvalid')),
+        nickname: z.string().min(1, t('admins.validation.nicknameRequired')).max(100),
+        password: z.string().min(6, t('admins.validation.passwordMin')),
+        permission_level: z.string(),
+      }),
+    [t],
+  );
+
+  const editSchema = useMemo(
+    () =>
+      z.object({
+        nickname: z.string().min(1, t('admins.validation.nicknameRequired')).max(100),
+        password: z.string().optional(),
+        permission_level: z.string(),
+        is_active: z.boolean(),
+      }),
+    [t],
+  );
 
   const createForm = useForm<CreateValues>({
     resolver: zodResolver(createSchema),
@@ -141,14 +163,17 @@ export default function AdminsPage() {
     setSubmitting(true);
     try {
       await api.post('/admin/admins', values);
-      toast({ title: '创建成功', description: `管理员 ${values.nickname} 已创建` });
+      toast({
+        title: t('admins.toast.createSuccess'),
+        description: t('admins.toast.createSuccessDesc', { name: values.nickname }),
+      });
       setCreateDialogOpen(false);
       mutate('/admin/admins');
     } catch (err: any) {
       toast({
         variant: 'destructive',
-        title: '创建失败',
-        description: err?.response?.data?.detail || '请稍后重试',
+        title: t('admins.toast.createFailed'),
+        description: err?.response?.data?.detail || t('admins.toast.retryLater'),
       });
     } finally {
       setSubmitting(false);
@@ -169,14 +194,14 @@ export default function AdminsPage() {
         payload.password = values.password;
       }
       await api.put(`/admin/admins/${selectedAdmin.id}`, payload);
-      toast({ title: '更新成功' });
+      toast({ title: t('admins.toast.updateSuccess') });
       setEditDialogOpen(false);
       mutate('/admin/admins');
     } catch (err: any) {
       toast({
         variant: 'destructive',
-        title: '更新失败',
-        description: err?.response?.data?.detail || '请稍后重试',
+        title: t('admins.toast.updateFailed'),
+        description: err?.response?.data?.detail || t('admins.toast.retryLater'),
       });
     } finally {
       setSubmitting(false);
@@ -186,13 +211,16 @@ export default function AdminsPage() {
   const onDelete = async (admin: Admin) => {
     try {
       await api.delete(`/admin/admins/${admin.id}`);
-      toast({ title: '删除成功', description: `管理员 ${admin.nickname} 已删除` });
+      toast({
+        title: t('admins.toast.deleteSuccess'),
+        description: t('admins.toast.deleteSuccessDesc', { name: admin.nickname }),
+      });
       mutate('/admin/admins');
     } catch (err: any) {
       toast({
         variant: 'destructive',
-        title: '删除失败',
-        description: err?.response?.data?.detail || '请稍后重试',
+        title: t('admins.toast.deleteFailed'),
+        description: err?.response?.data?.detail || t('admins.toast.retryLater'),
       });
     }
   };
@@ -212,14 +240,14 @@ export default function AdminsPage() {
         amount: parseFloat(creditAmount),
         description: creditDescription || undefined,
       });
-      toast({ title: '积分调整成功' });
+      toast({ title: t('admins.toast.creditsSuccess') });
       setCreditsDialogOpen(false);
       mutate('/admin/admins');
     } catch (err: any) {
       toast({
         variant: 'destructive',
-        title: '调整失败',
-        description: err?.response?.data?.detail || '请稍后重试',
+        title: t('admins.toast.creditsFailed'),
+        description: err?.response?.data?.detail || t('admins.toast.retryLater'),
       });
     } finally {
       setSubmitting(false);
@@ -229,9 +257,9 @@ export default function AdminsPage() {
   return (
     <div className="max-w-[1200px] mx-auto w-full space-y-4">
       <div className="flex justify-between items-center">
-        <h2 className="text-3xl font-bold tracking-tight">管理员管理</h2>
+        <h2 className="text-3xl font-bold tracking-tight">{t('admins.title')}</h2>
         <Button onClick={openCreateDialog}>
-          <Plus className="mr-2 h-4 w-4" /> 新增管理员
+          <Plus className="mr-2 h-4 w-4" /> {t('admins.addBtn')}
         </Button>
       </div>
 
@@ -239,43 +267,52 @@ export default function AdminsPage() {
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead>邮箱</TableHead>
-              <TableHead>昵称</TableHead>
-              <TableHead>权限级别</TableHead>
-              <TableHead>积分</TableHead>
-              <TableHead>状态</TableHead>
-              <TableHead>最后登录</TableHead>
-              <TableHead className="text-right">操作</TableHead>
+              <TableHead>{t('admins.table.email')}</TableHead>
+              <TableHead>{t('admins.table.nickname')}</TableHead>
+              <TableHead>{t('admins.table.permissionLevel')}</TableHead>
+              <TableHead>{t('admins.table.credits')}</TableHead>
+              <TableHead>{t('admins.table.status')}</TableHead>
+              <TableHead>{t('admins.table.lastLogin')}</TableHead>
+              <TableHead className="text-right">{t('admins.table.actions')}</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {isLoading ? (
               <TableRow>
                 <TableCell colSpan={7} className="h-24 text-center">
-                  加载中...
+                  {t('admins.table.loading')}
                 </TableCell>
               </TableRow>
             ) : admins?.map((admin) => {
-              const levelInfo = PERMISSION_LEVELS[admin.permission_level] || PERMISSION_LEVELS.admin;
+              const variant = PERMISSION_VARIANT[admin.permission_level] ?? PERMISSION_VARIANT.admin;
               return (
                 <TableRow key={admin.id}>
                   <TableCell className="font-medium">{admin.email}</TableCell>
                   <TableCell>{admin.nickname}</TableCell>
                   <TableCell>
-                    <Badge variant={levelInfo.variant}>{levelInfo.label}</Badge>
+                    <Badge variant={variant}>
+                      {t(`admins.permission.${admin.permission_level}`, { defaultValue: admin.permission_level })}
+                    </Badge>
                   </TableCell>
                   <TableCell className="font-mono">{Number(admin.credits ?? 0).toFixed(2)}</TableCell>
                   <TableCell>
                     <Badge variant={admin.is_active ? 'default' : 'secondary'}>
-                      {admin.is_active ? '启用' : '禁用'}
+                      {admin.is_active
+                        ? t('admins.status.enabled')
+                        : t('admins.status.disabled')}
                     </Badge>
                   </TableCell>
                   <TableCell>
-                    {admin.last_login_at ? new Date(admin.last_login_at).toLocaleString() : '-'}
+                    {admin.last_login_at ? new Date(admin.last_login_at).toLocaleString() : t('admins.table.dash')}
                   </TableCell>
                   <TableCell className="text-right">
                     <div className="flex items-center justify-end gap-1">
-                      <Button variant="ghost" size="icon" title="调整积分" onClick={() => openCreditsDialog(admin)}>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        title={t('admins.tooltip.adjustCredits')}
+                        onClick={() => openCreditsDialog(admin)}
+                      >
                         <Coins className="h-4 w-4" />
                       </Button>
                       <Button variant="ghost" size="icon" onClick={() => openEditDialog(admin)}>
@@ -289,14 +326,16 @@ export default function AdminsPage() {
                         </AlertDialogTrigger>
                         <AlertDialogContent>
                           <AlertDialogHeader>
-                            <AlertDialogTitle>确认删除？</AlertDialogTitle>
+                            <AlertDialogTitle>{t('admins.delete.title')}</AlertDialogTitle>
                             <AlertDialogDescription>
-                              确定要删除管理员 &quot;{admin.nickname}&quot; 吗？此操作不可撤销。
+                              {t('admins.delete.description', { name: admin.nickname })}
                             </AlertDialogDescription>
                           </AlertDialogHeader>
                           <AlertDialogFooter>
-                            <AlertDialogCancel>取消</AlertDialogCancel>
-                            <AlertDialogAction onClick={() => onDelete(admin)}>确认删除</AlertDialogAction>
+                            <AlertDialogCancel>{t('admins.delete.cancel')}</AlertDialogCancel>
+                            <AlertDialogAction onClick={() => onDelete(admin)}>
+                              {t('admins.delete.confirm')}
+                            </AlertDialogAction>
                           </AlertDialogFooter>
                         </AlertDialogContent>
                       </AlertDialog>
@@ -313,8 +352,8 @@ export default function AdminsPage() {
       <Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>新增管理员</DialogTitle>
-            <DialogDescription>创建新的管理员账户</DialogDescription>
+            <DialogTitle>{t('admins.create.title')}</DialogTitle>
+            <DialogDescription>{t('admins.create.description')}</DialogDescription>
           </DialogHeader>
           <Form {...createForm}>
             <form onSubmit={createForm.handleSubmit(onCreate)} className="space-y-4">
@@ -323,9 +362,9 @@ export default function AdminsPage() {
                 name="email"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>邮箱</FormLabel>
+                    <FormLabel>{t('admins.form.email')}</FormLabel>
                     <FormControl>
-                      <Input placeholder="admin@example.com" {...field} />
+                      <Input placeholder={t('admins.create.emailPlaceholder')} {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -336,9 +375,9 @@ export default function AdminsPage() {
                 name="nickname"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>昵称</FormLabel>
+                    <FormLabel>{t('admins.form.nickname')}</FormLabel>
                     <FormControl>
-                      <Input placeholder="管理员昵称" {...field} />
+                      <Input placeholder={t('admins.create.nicknamePlaceholder')} {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -349,9 +388,9 @@ export default function AdminsPage() {
                 name="password"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>密码</FormLabel>
+                    <FormLabel>{t('admins.form.password')}</FormLabel>
                     <FormControl>
-                      <Input type="password" placeholder="至少 6 位" {...field} />
+                      <Input type="password" placeholder={t('admins.create.passwordPlaceholder')} {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -362,15 +401,17 @@ export default function AdminsPage() {
                 name="permission_level"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>权限级别</FormLabel>
+                    <FormLabel>{t('admins.form.permissionLevel')}</FormLabel>
                     <FormControl>
                       <Select onValueChange={field.onChange} value={field.value}>
                         <SelectTrigger>
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent>
-                          {Object.entries(PERMISSION_LEVELS).map(([key, val]) => (
-                            <SelectItem key={key} value={key}>{val.label}</SelectItem>
+                          {PERMISSION_KEYS.map((key) => (
+                            <SelectItem key={key} value={key}>
+                              {t(`admins.permission.${key}`)}
+                            </SelectItem>
                           ))}
                         </SelectContent>
                       </Select>
@@ -380,9 +421,11 @@ export default function AdminsPage() {
                 )}
               />
               <DialogFooter>
-                <Button type="button" variant="outline" onClick={() => setCreateDialogOpen(false)}>取消</Button>
+                <Button type="button" variant="outline" onClick={() => setCreateDialogOpen(false)}>
+                  {t('admins.delete.cancel')}
+                </Button>
                 <Button type="submit" disabled={submitting}>
-                  {submitting ? '创建中...' : '创建'}
+                  {submitting ? t('admins.create.submitting') : t('admins.create.submit')}
                 </Button>
               </DialogFooter>
             </form>
@@ -394,8 +437,10 @@ export default function AdminsPage() {
       <Dialog open={editDialogOpen} onOpenChange={setEditDialogOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>编辑管理员</DialogTitle>
-            <DialogDescription>修改管理员 {selectedAdmin?.nickname} 的信息</DialogDescription>
+            <DialogTitle>{t('admins.edit.title')}</DialogTitle>
+            <DialogDescription>
+              {t('admins.edit.description', { name: selectedAdmin?.nickname ?? '' })}
+            </DialogDescription>
           </DialogHeader>
           <Form {...editForm}>
             <form onSubmit={editForm.handleSubmit(onEdit)} className="space-y-4">
@@ -404,7 +449,7 @@ export default function AdminsPage() {
                 name="nickname"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>昵称</FormLabel>
+                    <FormLabel>{t('admins.form.nickname')}</FormLabel>
                     <FormControl>
                       <Input {...field} />
                     </FormControl>
@@ -417,9 +462,9 @@ export default function AdminsPage() {
                 name="password"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>新密码（留空则不修改）</FormLabel>
+                    <FormLabel>{t('admins.edit.passwordLabel')}</FormLabel>
                     <FormControl>
-                      <Input type="password" placeholder="输入新密码" {...field} />
+                      <Input type="password" placeholder={t('admins.edit.passwordPlaceholder')} {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -430,15 +475,17 @@ export default function AdminsPage() {
                 name="permission_level"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>权限级别</FormLabel>
+                    <FormLabel>{t('admins.form.permissionLevel')}</FormLabel>
                     <FormControl>
                       <Select onValueChange={field.onChange} value={field.value}>
                         <SelectTrigger>
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent>
-                          {Object.entries(PERMISSION_LEVELS).map(([key, val]) => (
-                            <SelectItem key={key} value={key}>{val.label}</SelectItem>
+                          {PERMISSION_KEYS.map((key) => (
+                            <SelectItem key={key} value={key}>
+                              {t(`admins.permission.${key}`)}
+                            </SelectItem>
                           ))}
                         </SelectContent>
                       </Select>
@@ -453,7 +500,7 @@ export default function AdminsPage() {
                 render={({ field }) => (
                   <FormItem>
                     <div className="flex items-center justify-between">
-                      <FormLabel>启用账户</FormLabel>
+                      <FormLabel>{t('admins.edit.isActive')}</FormLabel>
                       <FormControl>
                         <Switch checked={field.value} onCheckedChange={field.onChange} />
                       </FormControl>
@@ -463,9 +510,11 @@ export default function AdminsPage() {
                 )}
               />
               <DialogFooter>
-                <Button type="button" variant="outline" onClick={() => setEditDialogOpen(false)}>取消</Button>
+                <Button type="button" variant="outline" onClick={() => setEditDialogOpen(false)}>
+                  {t('admins.delete.cancel')}
+                </Button>
                 <Button type="submit" disabled={submitting}>
-                  {submitting ? '保存中...' : '保存'}
+                  {submitting ? t('admins.edit.submitting') : t('admins.edit.submit')}
                 </Button>
               </DialogFooter>
             </form>
@@ -477,9 +526,12 @@ export default function AdminsPage() {
       <Dialog open={creditsDialogOpen} onOpenChange={setCreditsDialogOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>调整积分</DialogTitle>
+            <DialogTitle>{t('admins.credits.title')}</DialogTitle>
             <DialogDescription>
-              管理员: {selectedAdmin?.nickname} | 当前余额: {Number(selectedAdmin?.credits ?? 0).toFixed(2)}
+              {t('admins.credits.description', {
+                name: selectedAdmin?.nickname ?? '',
+                balance: Number(selectedAdmin?.credits ?? 0).toFixed(2),
+              })}
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
@@ -496,30 +548,32 @@ export default function AdminsPage() {
               ))}
             </div>
             <div>
-              <label className="text-sm font-medium">调整数量</label>
+              <label className="text-sm font-medium">{t('admins.credits.amountLabel')}</label>
               <Input
                 type="number"
-                placeholder="正数=充值，负数=扣减"
+                placeholder={t('admins.credits.amountPlaceholder')}
                 value={creditAmount}
                 onChange={(e) => setCreditAmount(e.target.value)}
               />
             </div>
             <div>
-              <label className="text-sm font-medium">备注说明</label>
+              <label className="text-sm font-medium">{t('admins.credits.noteLabel')}</label>
               <Textarea
-                placeholder="可选：填写调整原因"
+                placeholder={t('admins.credits.notePlaceholder')}
                 value={creditDescription}
                 onChange={(e) => setCreditDescription(e.target.value)}
               />
             </div>
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setCreditsDialogOpen(false)}>取消</Button>
+            <Button variant="outline" onClick={() => setCreditsDialogOpen(false)}>
+              {t('admins.credits.cancel')}
+            </Button>
             <Button
               onClick={onAdjustCredits}
               disabled={submitting || !creditAmount || parseFloat(creditAmount) === 0}
             >
-              {submitting ? '处理中...' : '确认调整'}
+              {submitting ? t('admins.credits.processing') : t('admins.credits.confirm')}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/backend/admin/src/app/admin/mcp/page.tsx
+++ b/backend/admin/src/app/admin/mcp/page.tsx
@@ -1,24 +1,24 @@
 'use client';
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { ServerCog } from 'lucide-react';
 
 export default function MCPPage() {
+  const { t } = useTranslation();
   return (
     <div className="max-w-[1200px] mx-auto w-full space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h2 className="text-3xl font-bold tracking-tight">MCP 客户端管理</h2>
-          <p className="text-muted-foreground mt-2">
-            Model Context Protocol (MCP) 允许 Agent 动态连接到外部工具和数据源。支持无感热重载。
-          </p>
+          <h2 className="text-3xl font-bold tracking-tight">{t('mcp.title')}</h2>
+          <p className="text-muted-foreground mt-2">{t('mcp.subtitle')}</p>
         </div>
       </div>
 
       <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border/60 bg-muted/20 py-20">
         <ServerCog className="h-12 w-12 text-muted-foreground/40 mb-4" />
-        <h3 className="text-lg font-medium text-muted-foreground mb-1">功能开发中</h3>
-        <p className="text-sm text-muted-foreground/60">MCP 客户端管理功能尚未实装，敬请期待</p>
+        <h3 className="text-lg font-medium text-muted-foreground mb-1">{t('mcp.inDevelopment.title')}</h3>
+        <p className="text-sm text-muted-foreground/60">{t('mcp.inDevelopment.desc')}</p>
       </div>
     </div>
   );

--- a/backend/admin/src/app/admin/prompt-templates/[id]/page.tsx
+++ b/backend/admin/src/app/admin/prompt-templates/[id]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useRouter, useParams } from 'next/navigation';
 import { useForm, useFieldArray } from 'react-hook-form';
 import { PromptTemplateVariable } from '@/types';
@@ -31,15 +32,10 @@ interface FormValues {
   variables: PromptTemplateVariable[];
 }
 
-const VARIABLE_TYPES = [
-  { value: 'string', label: '单行文本' },
-  { value: 'textarea', label: '多行文本' },
-  { value: 'number', label: '数字' },
-  { value: 'boolean', label: '布尔值' },
-  { value: 'select', label: '下拉选择' },
-];
+const VARIABLE_TYPE_KEYS = ['string', 'textarea', 'number', 'boolean', 'select'] as const;
 
 export default function EditPromptTemplatePage() {
+  const { t } = useTranslation();
   const router = useRouter();
   const params = useParams();
   const templateId = params?.id as string;
@@ -97,7 +93,7 @@ export default function EditPromptTemplatePage() {
         variables_schema: values.variables,
         output_schema: {},
       });
-      toast({ title: '模板更新成功' });
+      toast({ title: t('promptTemplates.toast.updateSuccess') });
       router.push('/admin/prompt-templates');
     } catch (err: any) {
       const detail = err.response?.data?.detail;
@@ -105,8 +101,12 @@ export default function EditPromptTemplatePage() {
         ? detail
         : Array.isArray(detail)
           ? detail.map((e: any) => e.msg).join('; ')
-          : '未知错误';
-      toast({ variant: 'destructive', title: '更新失败', description: message });
+          : t('promptTemplates.toast.unknownError');
+      toast({
+        variant: 'destructive',
+        title: t('promptTemplates.toast.updateFailed'),
+        description: message,
+      });
     } finally {
       setSaving(false);
     }
@@ -125,15 +125,19 @@ export default function EditPromptTemplatePage() {
       {/* Header */}
       <div className="flex items-center justify-between mb-8">
         <div>
-          <h2 className="text-3xl font-bold tracking-tight">编辑提示词模板</h2>
-          <p className="text-muted-foreground mt-1">编辑模板「{template?.name}」的配置与内容</p>
+          <h2 className="text-3xl font-bold tracking-tight">{t('promptTemplates.edit.title')}</h2>
+          <p className="text-muted-foreground mt-1">
+            {t('promptTemplates.edit.description', { name: template?.name ?? '' })}
+          </p>
         </div>
         <div className="flex gap-3 items-center">
           <Button variant="outline" onClick={() => router.back()}>
-            <ArrowLeft className="mr-2 h-4 w-4" /> 返回
+            <ArrowLeft className="mr-2 h-4 w-4" /> {t('promptTemplates.action.back')}
           </Button>
           <Button type="submit" form="template-form" disabled={saving}>
-            {saving ? '保存中...' : <><Save className="mr-2 h-4 w-4" /> 保存</>}
+            {saving
+              ? t('promptTemplates.action.saving')
+              : <><Save className="mr-2 h-4 w-4" /> {t('promptTemplates.action.save')}</>}
           </Button>
         </div>
       </div>
@@ -143,51 +147,55 @@ export default function EditPromptTemplatePage() {
         <div className="grid grid-cols-3 gap-4">
           <div className="space-y-2">
             <Label htmlFor="tpl-name">
-              模板名称 <span className="text-destructive">*</span>
+              {t('promptTemplates.form.name')} <span className="text-destructive">*</span>
             </Label>
             <Input
               id="tpl-name"
-              placeholder="例如：故事设定生成"
+              placeholder={t('promptTemplates.form.namePlaceholder')}
               className={errors.name ? 'border-destructive' : ''}
               {...register('name', { required: true })}
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="tpl-desc">描述</Label>
+            <Label htmlFor="tpl-desc">{t('promptTemplates.form.description')}</Label>
             <Input
               id="tpl-desc"
-              placeholder="简要描述此模板的用途..."
+              placeholder={t('promptTemplates.form.descriptionPlaceholder')}
               {...register('description')}
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="tpl-type">分类标签</Label>
+            <Label htmlFor="tpl-type">{t('promptTemplates.form.category')}</Label>
             <Input
               id="tpl-type"
-              placeholder="自定义分类，最多12字"
+              placeholder={t('promptTemplates.form.categoryPlaceholder')}
               maxLength={12}
               value={watchedTemplateType}
               onChange={(e) => setValue('template_type', e.target.value)}
             />
-            <p className="text-xs text-muted-foreground">支持中英文，最多12个字符</p>
+            <p className="text-xs text-muted-foreground">{t('promptTemplates.form.categoryHint')}</p>
           </div>
         </div>
 
         {/* 提示词内容 */}
         <div className="space-y-4">
           <div className="flex items-center justify-between">
-            <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">提示词内容</h3>
+            <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+              {t('promptTemplates.form.contentTitle')}
+            </h3>
             <p className="text-xs text-muted-foreground">
-              使用 <code className="bg-muted px-1 rounded">{'{{ variable_name }}'}</code> 插入变量
+              {t('promptTemplates.form.varsUsageHintPrefix')}
+              <code className="bg-muted px-1 rounded">{'{{ variable_name }}'}</code>
+              {t('promptTemplates.form.varsUsageHintSuffix')}
             </p>
           </div>
           <div className="space-y-2">
             <Label htmlFor="system_prompt">
-              系统提示词 <span className="text-destructive">*</span>
+              {t('promptTemplates.form.systemPrompt')} <span className="text-destructive">*</span>
             </Label>
             <Textarea
               id="system_prompt"
-              placeholder="你是一个专业的剧场剧情设计师..."
+              placeholder={t('promptTemplates.form.systemPromptPlaceholder')}
               className={`font-mono text-sm resize-y min-h-[calc(100vh-680px)] ${errors.system_prompt_template ? 'border-destructive' : ''}`}
               {...register('system_prompt_template', { required: true })}
             />
@@ -200,11 +208,11 @@ export default function EditPromptTemplatePage() {
               onClick={() => setShowUserPrompt((v) => !v)}
             >
               {showUserPrompt ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-              用户提示词（可选）
+              {t('promptTemplates.form.userPrompt')}
             </button>
             {showUserPrompt && (
               <Textarea
-                placeholder={'请根据以下信息生成内容...\n\n剧场名称：{{ theater_name }}'}
+                placeholder={`${t('promptTemplates.form.userPromptPlaceholderPrefix')}{{ theater_name }}`}
                 rows={4}
                 className="font-mono text-sm resize-y"
                 {...register('user_prompt_template')}
@@ -216,20 +224,22 @@ export default function EditPromptTemplatePage() {
         {/* 输入变量定义 */}
         <div className="space-y-4">
           <div className="flex items-center justify-between">
-            <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">输入变量</h3>
+            <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+              {t('promptTemplates.form.varsTitle')}
+            </h3>
             <Button
               type="button"
               variant="outline"
               size="sm"
               onClick={() => append({ name: '', label: '', type: 'string', required: true, options: null, default: null, description: null })}
             >
-              <Plus className="h-3.5 w-3.5 mr-1" /> 添加变量
+              <Plus className="h-3.5 w-3.5 mr-1" /> {t('promptTemplates.action.addVariable')}
             </Button>
           </div>
 
           {fields.length === 0 && (
             <p className="text-sm text-muted-foreground text-center py-4 border rounded-lg border-dashed">
-              暂无变量，点击「添加变量」定义提示词中的占位符
+              {t('promptTemplates.form.varsEmpty')}
             </p>
           )}
 
@@ -237,30 +247,32 @@ export default function EditPromptTemplatePage() {
             {fields.map((field, index) => (
               <div key={field.id} className="p-4 border rounded-lg bg-muted/30 space-y-3">
                 <div className="flex items-center justify-between">
-                  <span className="text-xs font-medium text-muted-foreground">变量 #{index + 1}</span>
+                  <span className="text-xs font-medium text-muted-foreground">
+                    {t('promptTemplates.form.varIndex', { index: index + 1 })}
+                  </span>
                   <Button type="button" variant="ghost" size="icon" className="h-7 w-7 text-destructive" onClick={() => remove(index)}>
                     <Trash2 className="h-3.5 w-3.5" />
                   </Button>
                 </div>
                 <div className="grid grid-cols-2 gap-3">
                   <div className="space-y-1.5">
-                    <Label className="text-xs">变量名（英文）</Label>
+                    <Label className="text-xs">{t('promptTemplates.form.varName')}</Label>
                     <Input
-                      placeholder="theater_name"
+                      placeholder={t('promptTemplates.form.varNamePlaceholder')}
                       className="h-8 text-sm font-mono"
                       {...register(`variables.${index}.name`)}
                     />
                   </div>
                   <div className="space-y-1.5">
-                    <Label className="text-xs">显示标签</Label>
+                    <Label className="text-xs">{t('promptTemplates.form.varLabel')}</Label>
                     <Input
-                      placeholder="剧场名称"
+                      placeholder={t('promptTemplates.form.varLabelPlaceholder')}
                       className="h-8 text-sm"
                       {...register(`variables.${index}.label`)}
                     />
                   </div>
                   <div className="space-y-1.5">
-                    <Label className="text-xs">类型</Label>
+                    <Label className="text-xs">{t('promptTemplates.form.varType')}</Label>
                     <Select
                       value={watch(`variables.${index}.type`)}
                       onValueChange={(v) => setValue(`variables.${index}.type`, v as any)}
@@ -269,16 +281,18 @@ export default function EditPromptTemplatePage() {
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
-                        {VARIABLE_TYPES.map((t) => (
-                          <SelectItem key={t.value} value={t.value}>{t.label}</SelectItem>
+                        {VARIABLE_TYPE_KEYS.map((key) => (
+                          <SelectItem key={key} value={key}>
+                            {t(`promptTemplates.varTypes.${key}`)}
+                          </SelectItem>
                         ))}
                       </SelectContent>
                     </Select>
                   </div>
                   <div className="space-y-1.5">
-                    <Label className="text-xs">描述（可选）</Label>
+                    <Label className="text-xs">{t('promptTemplates.form.varDescription')}</Label>
                     <Input
-                      placeholder="变量说明..."
+                      placeholder={t('promptTemplates.form.varDescriptionPlaceholder')}
                       className="h-8 text-sm"
                       {...register(`variables.${index}.description`)}
                     />
@@ -290,7 +304,9 @@ export default function EditPromptTemplatePage() {
                     onCheckedChange={(v) => setValue(`variables.${index}.required`, v)}
                     id={`required-${index}`}
                   />
-                  <Label htmlFor={`required-${index}`} className="text-xs cursor-pointer">必填</Label>
+                  <Label htmlFor={`required-${index}`} className="text-xs cursor-pointer">
+                    {t('promptTemplates.form.varRequired')}
+                  </Label>
                 </div>
               </div>
             ))}
@@ -305,7 +321,9 @@ export default function EditPromptTemplatePage() {
               onCheckedChange={(v) => setValue('is_active', v)}
               id="is_active"
             />
-            <Label htmlFor="is_active" className="cursor-pointer text-sm">启用模板</Label>
+            <Label htmlFor="is_active" className="cursor-pointer text-sm">
+              {t('promptTemplates.form.statusActive')}
+            </Label>
           </div>
           <div className="flex items-center gap-2">
             <Switch
@@ -313,7 +331,9 @@ export default function EditPromptTemplatePage() {
               onCheckedChange={(v) => setValue('is_default', v)}
               id="is_default"
             />
-            <Label htmlFor="is_default" className="cursor-pointer text-sm">设为该类型默认模板</Label>
+            <Label htmlFor="is_default" className="cursor-pointer text-sm">
+              {t('promptTemplates.form.statusDefault')}
+            </Label>
           </div>
         </div>
       </form>

--- a/backend/admin/src/app/admin/prompt-templates/new/page.tsx
+++ b/backend/admin/src/app/admin/prompt-templates/new/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useRouter } from 'next/navigation';
 import { useForm, useFieldArray } from 'react-hook-form';
 import { PromptTemplateVariable } from '@/types';
@@ -31,15 +32,10 @@ interface FormValues {
   variables: PromptTemplateVariable[];
 }
 
-const VARIABLE_TYPES = [
-  { value: 'string', label: '单行文本' },
-  { value: 'textarea', label: '多行文本' },
-  { value: 'number', label: '数字' },
-  { value: 'boolean', label: '布尔值' },
-  { value: 'select', label: '下拉选择' },
-];
+const VARIABLE_TYPE_KEYS = ['string', 'textarea', 'number', 'boolean', 'select'] as const;
 
 export default function CreatePromptTemplatePage() {
+  const { t } = useTranslation();
   const router = useRouter();
   const { toast } = useToast();
   const { createTemplate } = useCreatePromptTemplate();
@@ -80,7 +76,7 @@ export default function CreatePromptTemplatePage() {
         variables_schema: values.variables,
         output_schema: {},
       });
-      toast({ title: '模板创建成功' });
+      toast({ title: t('promptTemplates.toast.createSuccess') });
       router.push('/admin/prompt-templates');
     } catch (err: any) {
       const detail = err.response?.data?.detail;
@@ -88,8 +84,12 @@ export default function CreatePromptTemplatePage() {
         ? detail
         : Array.isArray(detail)
           ? detail.map((e: any) => e.msg).join('; ')
-          : '未知错误';
-      toast({ variant: 'destructive', title: '创建失败', description: message });
+          : t('promptTemplates.toast.unknownError');
+      toast({
+        variant: 'destructive',
+        title: t('promptTemplates.toast.createFailed'),
+        description: message,
+      });
     } finally {
       setSaving(false);
     }
@@ -100,15 +100,17 @@ export default function CreatePromptTemplatePage() {
       {/* Header */}
       <div className="flex items-center justify-between mb-8">
         <div>
-          <h2 className="text-3xl font-bold tracking-tight">创建提示词模板</h2>
-          <p className="text-muted-foreground mt-1">定义一个新的 AI 生成提示词模板</p>
+          <h2 className="text-3xl font-bold tracking-tight">{t('promptTemplates.create.title')}</h2>
+          <p className="text-muted-foreground mt-1">{t('promptTemplates.create.description')}</p>
         </div>
         <div className="flex gap-3 items-center">
           <Button variant="outline" onClick={() => router.back()}>
-            <ArrowLeft className="mr-2 h-4 w-4" /> 返回
+            <ArrowLeft className="mr-2 h-4 w-4" /> {t('promptTemplates.action.back')}
           </Button>
           <Button type="submit" form="template-form" disabled={saving}>
-            {saving ? '创建中...' : <><Save className="mr-2 h-4 w-4" /> 创建模板</>}
+            {saving
+              ? t('promptTemplates.action.creating')
+              : <><Save className="mr-2 h-4 w-4" /> {t('promptTemplates.action.create')}</>}
           </Button>
         </div>
       </div>
@@ -118,51 +120,55 @@ export default function CreatePromptTemplatePage() {
         <div className="grid grid-cols-3 gap-4">
           <div className="space-y-2">
             <Label htmlFor="tpl-name">
-              模板名称 <span className="text-destructive">*</span>
+              {t('promptTemplates.form.name')} <span className="text-destructive">*</span>
             </Label>
             <Input
               id="tpl-name"
-              placeholder="例如：故事设定生成"
+              placeholder={t('promptTemplates.form.namePlaceholder')}
               className={errors.name ? 'border-destructive' : ''}
               {...register('name', { required: true })}
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="tpl-desc">描述</Label>
+            <Label htmlFor="tpl-desc">{t('promptTemplates.form.description')}</Label>
             <Input
               id="tpl-desc"
-              placeholder="简要描述此模板的用途..."
+              placeholder={t('promptTemplates.form.descriptionPlaceholder')}
               {...register('description')}
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="tpl-type">分类标签</Label>
+            <Label htmlFor="tpl-type">{t('promptTemplates.form.category')}</Label>
             <Input
               id="tpl-type"
-              placeholder="自定义分类，最多12字"
+              placeholder={t('promptTemplates.form.categoryPlaceholder')}
               maxLength={12}
               value={watchedTemplateType}
               onChange={(e) => setValue('template_type', e.target.value)}
             />
-            <p className="text-xs text-muted-foreground">支持中英文，最多12个字符</p>
+            <p className="text-xs text-muted-foreground">{t('promptTemplates.form.categoryHint')}</p>
           </div>
         </div>
 
         {/* 提示词内容 */}
         <div className="space-y-4">
           <div className="flex items-center justify-between">
-            <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">提示词内容</h3>
+            <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+              {t('promptTemplates.form.contentTitle')}
+            </h3>
             <p className="text-xs text-muted-foreground">
-              使用 <code className="bg-muted px-1 rounded">{'{{ variable_name }}'}</code> 插入变量
+              {t('promptTemplates.form.varsUsageHintPrefix')}
+              <code className="bg-muted px-1 rounded">{'{{ variable_name }}'}</code>
+              {t('promptTemplates.form.varsUsageHintSuffix')}
             </p>
           </div>
           <div className="space-y-2">
             <Label htmlFor="system_prompt">
-              系统提示词 <span className="text-destructive">*</span>
+              {t('promptTemplates.form.systemPrompt')} <span className="text-destructive">*</span>
             </Label>
             <Textarea
               id="system_prompt"
-              placeholder="你是一个专业的剧场剧情设计师..."
+              placeholder={t('promptTemplates.form.systemPromptPlaceholder')}
               className={`font-mono text-sm resize-y min-h-[calc(100vh-680px)] ${errors.system_prompt_template ? 'border-destructive' : ''}`}
               {...register('system_prompt_template', { required: true })}
             />
@@ -175,11 +181,11 @@ export default function CreatePromptTemplatePage() {
               onClick={() => setShowUserPrompt((v) => !v)}
             >
               {showUserPrompt ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-              用户提示词（可选）
+              {t('promptTemplates.form.userPrompt')}
             </button>
             {showUserPrompt && (
               <Textarea
-                placeholder={'请根据以下信息生成内容...\n\n剧场名称：{{ theater_name }}'}
+                placeholder={`${t('promptTemplates.form.userPromptPlaceholderPrefix')}{{ theater_name }}`}
                 rows={4}
                 className="font-mono text-sm resize-y"
                 {...register('user_prompt_template')}
@@ -191,20 +197,22 @@ export default function CreatePromptTemplatePage() {
         {/* 输入变量定义 */}
         <div className="space-y-4">
           <div className="flex items-center justify-between">
-            <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">输入变量</h3>
+            <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+              {t('promptTemplates.form.varsTitle')}
+            </h3>
             <Button
               type="button"
               variant="outline"
               size="sm"
               onClick={() => append({ name: '', label: '', type: 'string', required: true, options: null, default: null, description: null })}
             >
-              <Plus className="h-3.5 w-3.5 mr-1" /> 添加变量
+              <Plus className="h-3.5 w-3.5 mr-1" /> {t('promptTemplates.action.addVariable')}
             </Button>
           </div>
 
           {fields.length === 0 && (
             <p className="text-sm text-muted-foreground text-center py-4 border rounded-lg border-dashed">
-              暂无变量，点击「添加变量」定义提示词中的占位符
+              {t('promptTemplates.form.varsEmpty')}
             </p>
           )}
 
@@ -212,30 +220,32 @@ export default function CreatePromptTemplatePage() {
             {fields.map((field, index) => (
               <div key={field.id} className="p-4 border rounded-lg bg-muted/30 space-y-3">
                 <div className="flex items-center justify-between">
-                  <span className="text-xs font-medium text-muted-foreground">变量 #{index + 1}</span>
+                  <span className="text-xs font-medium text-muted-foreground">
+                    {t('promptTemplates.form.varIndex', { index: index + 1 })}
+                  </span>
                   <Button type="button" variant="ghost" size="icon" className="h-7 w-7 text-destructive" onClick={() => remove(index)}>
                     <Trash2 className="h-3.5 w-3.5" />
                   </Button>
                 </div>
                 <div className="grid grid-cols-2 gap-3">
                   <div className="space-y-1.5">
-                    <Label className="text-xs">变量名（英文）</Label>
+                    <Label className="text-xs">{t('promptTemplates.form.varName')}</Label>
                     <Input
-                      placeholder="theater_name"
+                      placeholder={t('promptTemplates.form.varNamePlaceholder')}
                       className="h-8 text-sm font-mono"
                       {...register(`variables.${index}.name`)}
                     />
                   </div>
                   <div className="space-y-1.5">
-                    <Label className="text-xs">显示标签</Label>
+                    <Label className="text-xs">{t('promptTemplates.form.varLabel')}</Label>
                     <Input
-                      placeholder="剧场名称"
+                      placeholder={t('promptTemplates.form.varLabelPlaceholder')}
                       className="h-8 text-sm"
                       {...register(`variables.${index}.label`)}
                     />
                   </div>
                   <div className="space-y-1.5">
-                    <Label className="text-xs">类型</Label>
+                    <Label className="text-xs">{t('promptTemplates.form.varType')}</Label>
                     <Select
                       value={watch(`variables.${index}.type`)}
                       onValueChange={(v) => setValue(`variables.${index}.type`, v as any)}
@@ -244,16 +254,18 @@ export default function CreatePromptTemplatePage() {
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
-                        {VARIABLE_TYPES.map((t) => (
-                          <SelectItem key={t.value} value={t.value}>{t.label}</SelectItem>
+                        {VARIABLE_TYPE_KEYS.map((key) => (
+                          <SelectItem key={key} value={key}>
+                            {t(`promptTemplates.varTypes.${key}`)}
+                          </SelectItem>
                         ))}
                       </SelectContent>
                     </Select>
                   </div>
                   <div className="space-y-1.5">
-                    <Label className="text-xs">描述（可选）</Label>
+                    <Label className="text-xs">{t('promptTemplates.form.varDescription')}</Label>
                     <Input
-                      placeholder="变量说明..."
+                      placeholder={t('promptTemplates.form.varDescriptionPlaceholder')}
                       className="h-8 text-sm"
                       {...register(`variables.${index}.description`)}
                     />
@@ -265,7 +277,9 @@ export default function CreatePromptTemplatePage() {
                     onCheckedChange={(v) => setValue(`variables.${index}.required`, v)}
                     id={`required-${index}`}
                   />
-                  <Label htmlFor={`required-${index}`} className="text-xs cursor-pointer">必填</Label>
+                  <Label htmlFor={`required-${index}`} className="text-xs cursor-pointer">
+                    {t('promptTemplates.form.varRequired')}
+                  </Label>
                 </div>
               </div>
             ))}
@@ -280,7 +294,9 @@ export default function CreatePromptTemplatePage() {
               onCheckedChange={(v) => setValue('is_active', v)}
               id="is_active"
             />
-            <Label htmlFor="is_active" className="cursor-pointer text-sm">启用模板</Label>
+            <Label htmlFor="is_active" className="cursor-pointer text-sm">
+              {t('promptTemplates.form.statusActive')}
+            </Label>
           </div>
           <div className="flex items-center gap-2">
             <Switch
@@ -288,7 +304,9 @@ export default function CreatePromptTemplatePage() {
               onCheckedChange={(v) => setValue('is_default', v)}
               id="is_default"
             />
-            <Label htmlFor="is_default" className="cursor-pointer text-sm">设为该类型默认模板</Label>
+            <Label htmlFor="is_default" className="cursor-pointer text-sm">
+              {t('promptTemplates.form.statusDefault')}
+            </Label>
           </div>
         </div>
       </form>

--- a/backend/admin/src/app/admin/prompt-templates/page.tsx
+++ b/backend/admin/src/app/admin/prompt-templates/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useRouter } from 'next/navigation';
 import { usePromptTemplates, useDeletePromptTemplate } from '@/hooks/usePromptTemplates';
 import { Button } from '@/components/ui/button';
@@ -37,6 +38,7 @@ import { Plus, Pencil, Trash2, Search, FileText } from 'lucide-react';
 import api from '@/lib/axios';
 
 export default function PromptTemplatesPage() {
+  const { t } = useTranslation();
   const router = useRouter();
   const [searchText, setSearchText] = useState('');
   const [filterTemplateType, setFilterTemplateType] = useState<string>('');
@@ -55,17 +57,17 @@ export default function PromptTemplatesPage() {
       .catch(() => {});
   }, [templates]);
 
-  const filteredTemplates = templates?.filter((t) =>
+  const filteredTemplates = templates?.filter((tpl) =>
     searchText
-      ? t.name.toLowerCase().includes(searchText.toLowerCase()) ||
-        t.description?.toLowerCase().includes(searchText.toLowerCase())
+      ? tpl.name.toLowerCase().includes(searchText.toLowerCase()) ||
+        tpl.description?.toLowerCase().includes(searchText.toLowerCase())
       : true
   );
 
   const handleDelete = async (id: string) => {
     try {
       await deleteTemplate(id);
-      toast({ title: '模板删除成功' });
+      toast({ title: t('promptTemplates.toast.deleteSuccess') });
       mutate();
     } catch (err: any) {
       const detail = err.response?.data?.detail;
@@ -73,8 +75,12 @@ export default function PromptTemplatesPage() {
         ? detail
         : Array.isArray(detail)
           ? detail.map((e: any) => e.msg).join('; ')
-          : '未知错误';
-      toast({ variant: 'destructive', title: '删除失败', description: message });
+          : t('promptTemplates.toast.unknownError');
+      toast({
+        variant: 'destructive',
+        title: t('promptTemplates.toast.deleteFailed'),
+        description: message,
+      });
     }
   };
 
@@ -82,11 +88,11 @@ export default function PromptTemplatesPage() {
     <div className="max-w-[1200px] mx-auto w-full space-y-6 animate-in fade-in duration-500">
       <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
         <div>
-          <h2 className="text-3xl font-bold tracking-tight">提示词模板</h2>
-          <p className="text-muted-foreground">管理 AI 生成使用的提示词模板</p>
+          <h2 className="text-3xl font-bold tracking-tight">{t('promptTemplates.title')}</h2>
+          <p className="text-muted-foreground">{t('promptTemplates.subtitle')}</p>
         </div>
         <Button onClick={() => router.push('/admin/prompt-templates/new')}>
-          <Plus className="mr-2 h-4 w-4" /> 创建模板
+          <Plus className="mr-2 h-4 w-4" /> {t('promptTemplates.createBtn')}
         </Button>
       </div>
 
@@ -95,7 +101,7 @@ export default function PromptTemplatesPage() {
         <div className="relative">
           <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
           <Input
-            placeholder="搜索模板名称或描述..."
+            placeholder={t('promptTemplates.searchPlaceholder')}
             className="pl-9 w-64"
             value={searchText}
             onChange={(e) => setSearchText(e.target.value)}
@@ -103,10 +109,10 @@ export default function PromptTemplatesPage() {
         </div>
         <Select value={filterTemplateType || '__all__'} onValueChange={(v) => setFilterTemplateType(v === '__all__' ? '' : v)}>
           <SelectTrigger className="w-44">
-            <SelectValue placeholder="模板分类" />
+            <SelectValue placeholder={t('promptTemplates.filterPlaceholder')} />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="__all__">全部分类</SelectItem>
+            <SelectItem value="__all__">{t('promptTemplates.filterAll')}</SelectItem>
             {categoryOptions.map((cat) => (
               <SelectItem key={cat.value} value={cat.value}>{cat.label}</SelectItem>
             ))}
@@ -119,24 +125,24 @@ export default function PromptTemplatesPage() {
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead>模板名称</TableHead>
-              <TableHead>分类</TableHead>
-              <TableHead>变量数</TableHead>
-              <TableHead>状态</TableHead>
-              <TableHead className="text-right">操作</TableHead>
+              <TableHead>{t('promptTemplates.table.name')}</TableHead>
+              <TableHead>{t('promptTemplates.table.category')}</TableHead>
+              <TableHead>{t('promptTemplates.table.varsCount')}</TableHead>
+              <TableHead>{t('promptTemplates.table.status')}</TableHead>
+              <TableHead className="text-right">{t('promptTemplates.table.actions')}</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {isLoading ? (
               <TableRow>
                 <TableCell colSpan={5} className="h-24 text-center">
-                  加载中...
+                  {t('promptTemplates.table.loading')}
                 </TableCell>
               </TableRow>
             ) : filteredTemplates?.length === 0 ? (
               <TableRow>
                 <TableCell colSpan={5} className="h-24 text-center text-muted-foreground">
-                  暂无模板，点击「创建模板」开始添加
+                  {t('promptTemplates.table.empty')}
                 </TableCell>
               </TableRow>
             ) : (
@@ -150,7 +156,7 @@ export default function PromptTemplatesPage() {
                       <div>
                         <div className="font-medium">{template.name}</div>
                         <div className="text-xs text-muted-foreground line-clamp-1 max-w-[220px]">
-                          {template.description || '暂无描述'}
+                          {template.description || t('promptTemplates.table.noDesc')}
                         </div>
                       </div>
                     </div>
@@ -163,15 +169,21 @@ export default function PromptTemplatesPage() {
                     )}
                   </TableCell>
                   <TableCell>
-                    <span className="text-sm">{template.variables_schema?.length || 0} 个</span>
+                    <span className="text-sm">
+                      {t('promptTemplates.table.varsUnit', { count: template.variables_schema?.length || 0 })}
+                    </span>
                   </TableCell>
                   <TableCell>
                     <div className="flex items-center gap-1.5">
                       {template.is_default && (
-                        <Badge variant="secondary" className="text-xs">默认</Badge>
+                        <Badge variant="secondary" className="text-xs">
+                          {t('promptTemplates.status.default')}
+                        </Badge>
                       )}
                       <Badge variant={template.is_active ? 'default' : 'outline'} className="text-xs">
-                        {template.is_active ? '启用' : '禁用'}
+                        {template.is_active
+                          ? t('promptTemplates.status.active')
+                          : t('promptTemplates.status.inactive')}
                       </Badge>
                     </div>
                   </TableCell>
@@ -188,15 +200,15 @@ export default function PromptTemplatesPage() {
                         </AlertDialogTrigger>
                         <AlertDialogContent>
                           <AlertDialogHeader>
-                            <AlertDialogTitle>确认删除？</AlertDialogTitle>
+                            <AlertDialogTitle>{t('promptTemplates.delete.title')}</AlertDialogTitle>
                             <AlertDialogDescription>
-                              此操作不可撤销，将永久删除「{template.name}」模板。
+                              {t('promptTemplates.delete.description', { name: template.name })}
                             </AlertDialogDescription>
                           </AlertDialogHeader>
                           <AlertDialogFooter>
-                            <AlertDialogCancel>取消</AlertDialogCancel>
+                            <AlertDialogCancel>{t('promptTemplates.delete.cancel')}</AlertDialogCancel>
                             <AlertDialogAction onClick={() => template.id && handleDelete(template.id)}>
-                              确认删除
+                              {t('promptTemplates.delete.confirm')}
                             </AlertDialogAction>
                           </AlertDialogFooter>
                         </AlertDialogContent>

--- a/backend/admin/src/app/admin/skills/[name]/page.tsx
+++ b/backend/admin/src/app/admin/skills/[name]/page.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import { useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 import { useToast } from '@/components/ui/use-toast';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -23,6 +24,7 @@ export default function EditSkillPage() {
   const params = useParams();
   const skillName = params?.name as string;
   const { toast } = useToast();
+  const { t } = useTranslation();
   const [saving, setSaving] = useState(false);
   const [loading, setLoading] = useState(true);
 
@@ -47,10 +49,14 @@ export default function EditSkillPage() {
         });
       })
       .catch(() => {
-        toast({ variant: 'destructive', title: '加载失败', description: '无法获取技能详情' });
+        toast({
+          variant: 'destructive',
+          title: t('skills.toast.loadFailed'),
+          description: t('skills.toast.loadDetailFailed'),
+        });
       })
       .finally(() => setLoading(false));
-  }, [skillName, reset, toast]);
+  }, [skillName, reset, toast, t]);
 
   const handleSave = async (values: FormValues) => {
     setSaving(true);
@@ -60,13 +66,13 @@ export default function EditSkillPage() {
         content: values.content,
         version: values.version,
       });
-      toast({ title: '技能更新成功' });
+      toast({ title: t('skills.toast.updateSuccess') });
       router.push('/admin/skills');
     } catch (err: any) {
       toast({
         variant: 'destructive',
-        title: '保存失败',
-        description: err.response?.data?.detail || '未知错误',
+        title: t('skills.toast.saveFailed'),
+        description: err.response?.data?.detail || t('skills.toast.unknownError'),
       });
     } finally {
       setSaving(false);
@@ -86,16 +92,16 @@ export default function EditSkillPage() {
       {/* Header */}
       <div className="flex items-center justify-between mb-8">
         <div>
-          <h2 className="text-3xl font-bold tracking-tight">编辑技能</h2>
-          <p className="text-muted-foreground mt-1">编辑技能「{skillName}」的配置与内容</p>
+          <h2 className="text-3xl font-bold tracking-tight">{t('skills.edit.title')}</h2>
+          <p className="text-muted-foreground mt-1">{t('skills.edit.description', { name: skillName })}</p>
         </div>
         <div className="flex gap-3 items-center">
           <span className="text-xs text-muted-foreground mr-2">{skillName}</span>
           <Button variant="outline" onClick={() => router.back()}>
-            <ArrowLeft className="mr-2 h-4 w-4" /> 返回
+            <ArrowLeft className="mr-2 h-4 w-4" /> {t('skills.action.back')}
           </Button>
           <Button type="submit" form="skill-form" disabled={saving}>
-            {saving ? '保存中...' : <><Save className="mr-2 h-4 w-4" /> 保存</>}
+            {saving ? t('skills.action.saving') : <><Save className="mr-2 h-4 w-4" /> {t('skills.action.save')}</>}
           </Button>
         </div>
       </div>
@@ -105,11 +111,11 @@ export default function EditSkillPage() {
         <div className="grid grid-cols-3 gap-4">
           <div className="space-y-2">
             <Label htmlFor="skill-name">
-              技能标识 <span className="text-destructive">*</span>
+              {t('skills.form.identifier')} <span className="text-destructive">*</span>
             </Label>
             <Input
               id="skill-name"
-              placeholder="例如：web_search"
+              placeholder={t('skills.form.identifierPlaceholder')}
               disabled
               className={`font-mono ${errors.name ? 'border-destructive' : ''}`}
               {...register('name', {
@@ -120,17 +126,17 @@ export default function EditSkillPage() {
           </div>
           <div className="space-y-2">
             <Label htmlFor="skill-description">
-              描述 <span className="text-destructive">*</span>
+              {t('skills.form.description')} <span className="text-destructive">*</span>
             </Label>
             <Input
               id="skill-description"
-              placeholder="简要描述此技能的功能..."
+              placeholder={t('skills.form.descriptionPlaceholder')}
               className={errors.description ? 'border-destructive' : ''}
               {...register('description', { required: true })}
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="skill-version">版本</Label>
+            <Label htmlFor="skill-version">{t('skills.form.version')}</Label>
             <Input
               id="skill-version"
               placeholder="1.0"
@@ -142,14 +148,14 @@ export default function EditSkillPage() {
         {/* Main content area */}
         <div className="space-y-2">
           <Label htmlFor="skill-content">
-            SKILL.md 正文 <span className="text-destructive">*</span>
+            {t('skills.form.content')} <span className="text-destructive">*</span>
           </Label>
           <p className="text-xs text-muted-foreground">
-            使用 Markdown 编写技能说明。Agent 会根据此内容了解如何使用该技能。
+            {t('skills.form.contentHint')}
           </p>
           <Textarea
             id="skill-content"
-            placeholder={"# 技能名称\n\n描述该技能的用途和使用方式...\n\n## 使用示例\n\n```\n调用示例...\n```"}
+            placeholder={t('skills.form.contentPlaceholder')}
             className={`font-mono text-sm resize-y min-h-[calc(100vh-420px)] ${errors.content ? 'border-destructive' : ''}`}
             {...register('content', { required: true })}
           />

--- a/backend/admin/src/app/admin/skills/new/page.tsx
+++ b/backend/admin/src/app/admin/skills/new/page.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 import { useToast } from '@/components/ui/use-toast';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -23,6 +24,7 @@ interface FormValues {
 export default function CreateSkillPage() {
   const router = useRouter();
   const { toast } = useToast();
+  const { t } = useTranslation();
   const [saving, setSaving] = useState(false);
 
   const { register, handleSubmit, watch, setValue, formState: { errors } } = useForm<FormValues>({
@@ -47,13 +49,13 @@ export default function CreateSkillPage() {
         version: values.version,
         auto_enable: values.auto_enable,
       });
-      toast({ title: '技能创建成功' });
+      toast({ title: t('skills.toast.createSuccess') });
       router.push('/admin/skills');
     } catch (err: any) {
       toast({
         variant: 'destructive',
-        title: '保存失败',
-        description: err.response?.data?.detail || '未知错误',
+        title: t('skills.toast.saveFailed'),
+        description: err.response?.data?.detail || t('skills.toast.unknownError'),
       });
     } finally {
       setSaving(false);
@@ -65,15 +67,15 @@ export default function CreateSkillPage() {
       {/* Header */}
       <div className="flex items-center justify-between mb-8">
         <div>
-          <h2 className="text-3xl font-bold tracking-tight">创建技能</h2>
-          <p className="text-muted-foreground mt-1">使用 Markdown 定义一个新的 Agent 技能包</p>
+          <h2 className="text-3xl font-bold tracking-tight">{t('skills.create.title')}</h2>
+          <p className="text-muted-foreground mt-1">{t('skills.create.description')}</p>
         </div>
         <div className="flex gap-3 items-center">
           <Button variant="outline" onClick={() => router.back()}>
-            <ArrowLeft className="mr-2 h-4 w-4" /> 返回
+            <ArrowLeft className="mr-2 h-4 w-4" /> {t('skills.action.back')}
           </Button>
           <Button type="submit" form="skill-form" disabled={saving}>
-            {saving ? '创建中...' : <><Save className="mr-2 h-4 w-4" /> 创建技能</>}
+            {saving ? t('skills.action.creating') : <><Save className="mr-2 h-4 w-4" /> {t('skills.action.create')}</>}
           </Button>
         </div>
       </div>
@@ -83,11 +85,11 @@ export default function CreateSkillPage() {
         <div className="grid grid-cols-3 gap-4">
           <div className="space-y-2">
             <Label htmlFor="skill-name">
-              技能标识 <span className="text-destructive">*</span>
+              {t('skills.form.identifier')} <span className="text-destructive">*</span>
             </Label>
             <Input
               id="skill-name"
-              placeholder="例如：web_search"
+              placeholder={t('skills.form.identifierPlaceholder')}
               className={`font-mono ${errors.name ? 'border-destructive' : ''}`}
               {...register('name', {
                 required: true,
@@ -95,22 +97,22 @@ export default function CreateSkillPage() {
               })}
             />
             <p className="text-xs text-muted-foreground">
-              仅支持字母、数字、下划线和中划线
+              {t('skills.form.identifierHint')}
             </p>
           </div>
           <div className="space-y-2">
             <Label htmlFor="skill-description">
-              描述 <span className="text-destructive">*</span>
+              {t('skills.form.description')} <span className="text-destructive">*</span>
             </Label>
             <Input
               id="skill-description"
-              placeholder="简要描述此技能的功能..."
+              placeholder={t('skills.form.descriptionPlaceholder')}
               className={errors.description ? 'border-destructive' : ''}
               {...register('description', { required: true })}
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="skill-version">版本</Label>
+            <Label htmlFor="skill-version">{t('skills.form.version')}</Label>
             <Input
               id="skill-version"
               placeholder="1.0"
@@ -122,14 +124,14 @@ export default function CreateSkillPage() {
         {/* Main content area */}
         <div className="space-y-2">
           <Label htmlFor="skill-content">
-            SKILL.md 正文 <span className="text-destructive">*</span>
+            {t('skills.form.content')} <span className="text-destructive">*</span>
           </Label>
           <p className="text-xs text-muted-foreground">
-            使用 Markdown 编写技能说明。Agent 会根据此内容了解如何使用该技能。
+            {t('skills.form.contentHint')}
           </p>
           <Textarea
             id="skill-content"
-            placeholder={"# 技能名称\n\n描述该技能的用途和使用方式...\n\n## 使用示例\n\n```\n调用示例...\n```"}
+            placeholder={t('skills.form.contentPlaceholder')}
             className={`font-mono text-sm resize-y min-h-[calc(100vh-420px)] ${errors.content ? 'border-destructive' : ''}`}
             {...register('content', { required: true })}
           />
@@ -143,7 +145,7 @@ export default function CreateSkillPage() {
             id="auto_enable"
           />
           <Label htmlFor="auto_enable" className="cursor-pointer text-sm">
-            创建后自动启用
+            {t('skills.form.autoEnable')}
           </Label>
         </div>
       </form>

--- a/backend/admin/src/app/admin/skills/page.tsx
+++ b/backend/admin/src/app/admin/skills/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
 import { Badge } from "@/components/ui/badge";
 import { Plus, Trash2, Loader2, ArrowRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -28,14 +29,15 @@ interface SkillInfo {
   status: 'active' | 'inactive';
 }
 
-const STATUS_CONFIG = {
-  active:   { label: '运行中', variant: 'default'     as const },
-  inactive: { label: '已停用', variant: 'secondary'   as const },
+const STATUS_VARIANT: Record<SkillInfo['status'], 'default' | 'secondary'> = {
+  active: 'default',
+  inactive: 'secondary',
 };
 
 export default function SkillsPage() {
   const router = useRouter();
   const { toast } = useToast();
+  const { t } = useTranslation();
   const [skills, setSkills] = useState<SkillInfo[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -45,7 +47,11 @@ export default function SkillsPage() {
       const response = await api.get('/admin/skills');
       setSkills(response.data);
     } catch {
-      toast({ title: "加载失败", description: "无法获取技能列表，请检查网络连接", variant: "destructive" });
+      toast({
+        title: t('skills.toast.loadFailed'),
+        description: t('skills.toast.loadFailedDesc'),
+        variant: 'destructive',
+      });
     } finally {
       setLoading(false);
     }
@@ -56,20 +62,31 @@ export default function SkillsPage() {
   const handleToggle = async (skill: SkillInfo) => {
     try {
       const response = await api.post(`/admin/skills/${skill.id}/toggle`);
-      toast({ title: "操作成功", description: response.data.message });
+      toast({ title: t('skills.toast.operationSuccess'), description: response.data.message });
       fetchSkills();
     } catch (error: any) {
-      toast({ title: "操作失败", description: error.response?.data?.detail || "切换技能状态时发生错误", variant: "destructive" });
+      toast({
+        title: t('skills.toast.operationFailed'),
+        description: error.response?.data?.detail || t('skills.toast.toggleFailed'),
+        variant: 'destructive',
+      });
     }
   };
 
   const handleDelete = async (skill: SkillInfo) => {
     try {
       await api.delete(`/admin/skills/${skill.name}`);
-      toast({ title: "删除成功", description: `技能 ${skill.name} 已删除` });
+      toast({
+        title: t('skills.toast.deleteSuccess'),
+        description: t('skills.toast.deleteSuccessDesc', { name: skill.name }),
+      });
       fetchSkills();
     } catch (error: any) {
-      toast({ title: "删除失败", description: error.response?.data?.detail || "删除技能时发生错误", variant: "destructive" });
+      toast({
+        title: t('skills.toast.deleteFailed'),
+        description: error.response?.data?.detail || t('skills.toast.deleteFailedDesc'),
+        variant: 'destructive',
+      });
     }
   };
 
@@ -77,13 +94,11 @@ export default function SkillsPage() {
     <div className="max-w-[1200px] mx-auto w-full space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h2 className="text-3xl font-bold tracking-tight">技能管理 (Skills)</h2>
-          <p className="text-muted-foreground mt-2">
-            管理 Agent 的扩展能力。技能是声明式的工具包，支持热插拔和版本控制。
-          </p>
+          <h2 className="text-3xl font-bold tracking-tight">{t('skills.title')}</h2>
+          <p className="text-muted-foreground mt-2">{t('skills.subtitle')}</p>
         </div>
         <Button onClick={() => router.push('/admin/skills/new')}>
-          <Plus className="mr-2 h-4 w-4" /> 创建技能
+          <Plus className="mr-2 h-4 w-4" /> {t('skills.createBtn')}
         </Button>
       </div>
 
@@ -94,7 +109,8 @@ export default function SkillsPage() {
       ) : (
         <div className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-6">
           {skills.map(skill => {
-            const cfg = STATUS_CONFIG[skill.status];
+            const variant = STATUS_VARIANT[skill.status];
+            const sourceLabel = t(`skills.source.${skill.source}`, { defaultValue: skill.source });
             return (
               <div
                 key={skill.id}
@@ -115,18 +131,18 @@ export default function SkillsPage() {
                       </h3>
                       <p className="text-sm text-muted-foreground line-clamp-2 mb-3">{skill.description}</p>
                       <div className="flex items-center gap-2">
-                        <Badge variant="outline" className="text-xs">{skill.source}</Badge>
+                        <Badge variant="outline" className="text-xs">{sourceLabel}</Badge>
                         <span className="font-mono text-xs text-muted-foreground">v{skill.version}</span>
                       </div>
                     </div>
-                    <Badge variant={cfg.variant} className="shrink-0">{cfg.label}</Badge>
+                    <Badge variant={variant} className="shrink-0">{t(`skills.status.${skill.status}`)}</Badge>
                   </div>
                 </div>
 
                 {/* 底部操作区 */}
                 <div className="px-5 py-3 border-t border-border/50 flex items-center justify-between transition-colors duration-300 group-hover:bg-muted/30">
                   <span className="text-xs font-medium text-muted-foreground group-hover:text-primary transition-colors flex items-center gap-1">
-                    编辑配置
+                    {t('skills.action.edit')}
                     <ArrowRight className="w-3 h-3 opacity-0 -ml-2 group-hover:opacity-100 group-hover:ml-0 transition-all duration-300" />
                   </span>
 
@@ -140,15 +156,15 @@ export default function SkillsPage() {
                         </AlertDialogTrigger>
                         <AlertDialogContent>
                           <AlertDialogHeader>
-                            <AlertDialogTitle>确认删除</AlertDialogTitle>
+                            <AlertDialogTitle>{t('skills.delete.title')}</AlertDialogTitle>
                             <AlertDialogDescription>
-                              确定要删除技能「{skill.name}」吗？此操作不可撤销。
+                              {t('skills.delete.description', { name: skill.name })}
                             </AlertDialogDescription>
                           </AlertDialogHeader>
                           <AlertDialogFooter>
-                            <AlertDialogCancel>取消</AlertDialogCancel>
+                            <AlertDialogCancel>{t('skills.delete.cancel')}</AlertDialogCancel>
                             <AlertDialogAction onClick={() => handleDelete(skill)}>
-                              删除
+                              {t('skills.delete.confirm')}
                             </AlertDialogAction>
                           </AlertDialogFooter>
                         </AlertDialogContent>
@@ -161,7 +177,7 @@ export default function SkillsPage() {
                       className="h-7 px-2.5 text-xs opacity-0 translate-x-2 group-hover:opacity-100 group-hover:translate-x-0 transition-all duration-300"
                       onClick={() => handleToggle(skill)}
                     >
-                      {skill.status === 'active' ? '停用' : '启用'}
+                      {skill.status === 'active' ? t('skills.action.disable') : t('skills.action.enable')}
                     </Button>
                   </div>
                 </div>

--- a/backend/admin/src/app/admin/tools/page.tsx
+++ b/backend/admin/src/app/admin/tools/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useRef, useMemo } from 'react';
 import Link from 'next/link';
+import { useTranslation } from 'react-i18next';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -25,26 +26,27 @@ interface BatchBarProps {
   onRefresh: () => void;
 }
 
-const BatchBar: React.FC<BatchBarProps> = ({ isLoading, onRefresh }) => (
-  <div className="flex justify-between items-center mb-6">
-    <div>
-      <h2 className="text-3xl font-bold tracking-tight">工具管理</h2>
-      <p className="text-muted-foreground mt-2">
-        查看系统注册的工具 Provider、配置工具参数与执行统计。
-      </p>
-    </div>
-    <div className="flex gap-2">
-      <Link href="/admin/tools/logs">
-        <Button variant="outline">
-          <FileText className="mr-2 h-4 w-4" /> 执行日志
+const BatchBar: React.FC<BatchBarProps> = ({ isLoading, onRefresh }) => {
+  const { t } = useTranslation();
+  return (
+    <div className="flex justify-between items-center mb-6">
+      <div>
+        <h2 className="text-3xl font-bold tracking-tight">{t('tools.title')}</h2>
+        <p className="text-muted-foreground mt-2">{t('tools.subtitle')}</p>
+      </div>
+      <div className="flex gap-2">
+        <Link href="/admin/tools/logs">
+          <Button variant="outline">
+            <FileText className="mr-2 h-4 w-4" /> {t('tools.logsBtn')}
+          </Button>
+        </Link>
+        <Button variant="outline" onClick={onRefresh} disabled={isLoading}>
+          <RefreshCw className={`mr-2 h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} /> {t('tools.refresh')}
         </Button>
-      </Link>
-      <Button variant="outline" onClick={onRefresh} disabled={isLoading}>
-        <RefreshCw className={`mr-2 h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} /> 刷新
-      </Button>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 // ---------------------------------------------------------------------------
 // ToolCard Component
@@ -56,6 +58,7 @@ interface ToolCardProps {
 }
 
 const ToolCard: React.FC<ToolCardProps> = ({ provider, onOpenDetail, onEdit }) => {
+  const { t } = useTranslation();
   const hasImageGen = provider.tools.some(t => t.name === 'generate_image');
   const hasVideoGen = provider.tools.some(t => t.name === 'generate_video');
   const hasMusicGen = provider.tools.some(t => t.name === 'generate_music');
@@ -82,7 +85,10 @@ const ToolCard: React.FC<ToolCardProps> = ({ provider, onOpenDetail, onEdit }) =
               {provider.provider_name}
             </span>
           </div>
-          <div className="flex items-center justify-center w-8 h-8 shrink-0 rounded-full bg-secondary/80 text-secondary-foreground text-sm font-bold" title={`包含 ${provider.tools.length} 个工具`}>
+          <div
+            className="flex items-center justify-center w-8 h-8 shrink-0 rounded-full bg-secondary/80 text-secondary-foreground text-sm font-bold"
+            title={t('tools.card.toolCountTitle', { count: provider.tools.length })}
+          >
             {provider.tools.length}
           </div>
         </div>
@@ -91,7 +97,7 @@ const ToolCard: React.FC<ToolCardProps> = ({ provider, onOpenDetail, onEdit }) =
       {/* 底部操作区 */}
       <div className="px-5 py-3 border-t border-border/50 flex items-center justify-between transition-colors duration-300 group-hover:bg-muted/30">
         <span className="text-xs font-medium text-muted-foreground group-hover:text-primary transition-colors flex items-center gap-1">
-          查看详情
+          {t('tools.card.viewDetail')}
           <ArrowRight className="w-3 h-3 opacity-0 -ml-2 group-hover:opacity-100 group-hover:ml-0 transition-all duration-300" />
         </span>
         
@@ -106,7 +112,7 @@ const ToolCard: React.FC<ToolCardProps> = ({ provider, onOpenDetail, onEdit }) =
             }}
           >
             <Settings2 className="w-3 h-3 mr-1.5" />
-            配置
+            {t('tools.card.configBtn')}
           </Button>
         )}
       </div>
@@ -193,6 +199,7 @@ const CardGrid: React.FC<CardGridProps> = ({ registry, onOpenDetail, onEdit }) =
 // Page Component
 // ---------------------------------------------------------------------------
 export default function ToolsPage() {
+  const { t } = useTranslation();
   const { registry, isLoading: regLoading } = useToolRegistry();
   const { activeProviders } = useLLMProviders();
   const { capabilities: imageCapabilities } = useImageCapabilities();
@@ -301,7 +308,7 @@ export default function ToolsPage() {
               <div>
                 <DialogTitle className="text-xl">{detailProvider?.display_name}</DialogTitle>
                 <div className="text-sm text-muted-foreground mt-1">
-                  Provider ID: <code className="bg-muted px-1.5 py-0.5 rounded text-xs font-mono">{detailProvider?.provider_name}</code>
+                  {t('tools.detail.providerId')}: <code className="bg-muted px-1.5 py-0.5 rounded text-xs font-mono">{detailProvider?.provider_name}</code>
                 </div>
               </div>
             </div>
@@ -312,14 +319,14 @@ export default function ToolsPage() {
           
           <div className="space-y-4 mt-4">
             <div className="bg-muted/30 p-3 rounded-lg border border-border/50">
-              <span className="text-sm text-muted-foreground block mb-1">启用条件</span>
-              <span className="text-sm font-medium">{detailProvider?.condition || '无特定条件'}</span>
+              <span className="text-sm text-muted-foreground block mb-1">{t('tools.detail.enableCondition')}</span>
+              <span className="text-sm font-medium">{detailProvider?.condition || t('tools.detail.noCondition')}</span>
             </div>
             
             <div>
               <h4 className="text-sm font-semibold mb-3 flex items-center gap-2">
                 <Settings2 className="w-4 h-4" />
-                包含的工具 ({detailProvider?.tools.length})
+                {t('tools.detail.includedTools', { count: detailProvider?.tools.length ?? 0 })}
               </h4>
               <div className="grid gap-2 max-h-[300px] overflow-y-auto pr-2">
                 {detailProvider?.tools.map((tool) => (

--- a/backend/admin/src/app/admin/videos/VideoPreviewModal.tsx
+++ b/backend/admin/src/app/admin/videos/VideoPreviewModal.tsx
@@ -1,17 +1,12 @@
 'use client';
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Trash2 } from 'lucide-react';
 import { VideoTaskResponse } from '@/types';
 import { formatDateTime, formatDuration } from '@/lib/date-utils';
-
-const MODE_LABELS: Record<string, string> = {
-  text_to_video: '文字生成',
-  image_to_video: '图片生成',
-  edit: '视频编辑',
-};
 
 const DELETABLE_STATUSES = new Set(['completed', 'failed']);
 
@@ -23,13 +18,14 @@ interface VideoPreviewModalProps {
 }
 
 export default function VideoPreviewModal({ task, open, onOpenChange, onDelete }: VideoPreviewModalProps) {
+  const { t } = useTranslation();
   const canDelete = task && DELETABLE_STATUSES.has(task.status);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[640px]">
         <DialogHeader>
-          <DialogTitle>视频预览</DialogTitle>
+          <DialogTitle>{t('videos.preview.title')}</DialogTitle>
         </DialogHeader>
 
         {task && (
@@ -44,59 +40,61 @@ export default function VideoPreviewModal({ task, open, onOpenChange, onDelete }
               />
             ) : task.status === 'failed' ? (
               <div className="rounded-lg bg-destructive/10 p-4 text-sm text-destructive">
-                {task.error_message || '视频生成失败'}
+                {task.error_message || t('videos.preview.failedFallback')}
               </div>
             ) : (
               <div className="rounded-lg bg-muted p-8 text-center text-sm text-muted-foreground">
-                视频尚未生成完成
+                {t('videos.preview.pendingHint')}
               </div>
             )}
 
             {/* 任务信息 */}
             <div className="grid grid-cols-2 gap-3 text-sm">
               <div>
-                <span className="text-muted-foreground">模式：</span>
-                {MODE_LABELS[task.video_mode] ?? task.video_mode}
+                <span className="text-muted-foreground">{t('videos.preview.mode')}</span>
+                {t(`videos.mode.${task.video_mode}`, { defaultValue: task.video_mode })}
               </div>
               <div>
-                <span className="text-muted-foreground">画质：</span>
+                <span className="text-muted-foreground">{t('videos.preview.quality')}</span>
                 {task.quality}
               </div>
               <div>
-                <span className="text-muted-foreground">时长：</span>
-                {task.duration}秒
+                <span className="text-muted-foreground">{t('videos.preview.duration')}</span>
+                {t('videos.preview.durationSec', { value: task.duration })}
               </div>
               <div>
-                <span className="text-muted-foreground">比例：</span>
+                <span className="text-muted-foreground">{t('videos.preview.ratio')}</span>
                 {task.aspect_ratio ?? '16:9'}
               </div>
               <div>
-                <span className="text-muted-foreground">费用：</span>
-                {task.credit_cost > 0 ? `${task.credit_cost.toFixed(2)} 积分` : '-'}
+                <span className="text-muted-foreground">{t('videos.preview.cost')}</span>
+                {task.credit_cost > 0
+                  ? t('videos.preview.credits', { value: task.credit_cost.toFixed(2) })
+                  : t('videos.preview.dash')}
               </div>
               <div>
-                <span className="text-muted-foreground">供应商：</span>
-                {task.provider_name ?? '-'}
+                <span className="text-muted-foreground">{t('videos.preview.provider')}</span>
+                {task.provider_name ?? t('videos.preview.dash')}
               </div>
               <div>
-                <span className="text-muted-foreground">模型：</span>
-                {task.model ?? '-'}
+                <span className="text-muted-foreground">{t('videos.preview.model')}</span>
+                {task.model ?? t('videos.preview.dash')}
               </div>
             </div>
 
             {/* 提示词 */}
             <div className="text-sm">
-              <span className="text-muted-foreground">提示词：</span>
+              <span className="text-muted-foreground">{t('videos.preview.prompt')}</span>
               <p className="mt-1 whitespace-pre-wrap rounded-md bg-muted p-2 text-xs">{task.prompt}</p>
             </div>
 
             {/* 时间信息 */}
             <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
-              <span>创建: {formatDateTime(task.created_at)}</span>
+              <span>{t('videos.preview.createdAt', { time: formatDateTime(task.created_at) })}</span>
               {task.completed_at && (
                 <>
-                  <span>完成: {formatDateTime(task.completed_at)}</span>
-                  <span>耗时: {formatDuration(task.created_at, task.completed_at)}</span>
+                  <span>{t('videos.preview.completedAt', { time: formatDateTime(task.completed_at) })}</span>
+                  <span>{t('videos.preview.elapsed', { time: formatDuration(task.created_at, task.completed_at) })}</span>
                 </>
               )}
             </div>
@@ -111,7 +109,7 @@ export default function VideoPreviewModal({ task, open, onOpenChange, onDelete }
               onClick={() => onDelete(task)}
             >
               <Trash2 className="mr-2 h-4 w-4" />
-              删除任务
+              {t('videos.preview.deleteTask', { defaultValue: '删除任务' })}
             </Button>
           </DialogFooter>
         )}

--- a/backend/admin/src/app/admin/videos/new/page.tsx
+++ b/backend/admin/src/app/admin/videos/new/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useMemo, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
 import { ArrowLeft, Loader2, Sparkles, Zap, AlertCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
@@ -17,7 +18,6 @@ import { useCreateVideoTask } from '@/hooks/useVideoTasks';
 import { useModelCapabilities, useVideoFormVisibility } from '@/hooks/useModelCapabilities';
 import { LLMProvider } from '@/types';
 import { parseProviderModels } from '@/lib/api-utils';
-import { VIDEO_MODE_LABELS, RESOLUTION_LABELS, ASPECT_RATIO_LABELS } from '@/types/video';
 
 // ---------------------------------------------------------------------------
 // 页面组件
@@ -25,13 +25,14 @@ import { VIDEO_MODE_LABELS, RESOLUTION_LABELS, ASPECT_RATIO_LABELS } from '@/typ
 export default function CreateVideoPage() {
   const router = useRouter();
   const { toast } = useToast();
+  const { t } = useTranslation();
   const { providers, isLoading: providersLoading } = useLLMProviders();
   const { createVideoTask } = useCreateVideoTask();
 
   // 基础状态
   const [providerId, setProviderId] = useState('');
   const [model, setModel] = useState('');
-  
+
   // 视频配置状态
   const [videoMode, setVideoMode] = useState('text_to_video');
   const [prompt, setPrompt] = useState('');
@@ -40,11 +41,11 @@ export default function CreateVideoPage() {
   const [duration, setDuration] = useState(6);
   const [quality, setQuality] = useState<string>('720p');
   const [aspectRatio, setAspectRatio] = useState('16:9');
-  
+
   // MiniMax 特有配置
   const [promptOptimizer, setPromptOptimizer] = useState(true);
   const [fastPretreatment, setFastPretreatment] = useState(false);
-  
+
   const [submitting, setSubmitting] = useState(false);
 
   // 获取选中的供应商
@@ -59,7 +60,7 @@ export default function CreateVideoPage() {
 
   // 获取模型能力配置
   const { capabilities, isLoading: capabilitiesLoading } = useModelCapabilities(model || null);
-  
+
   // 根据能力配置计算表单可见性
   const visibility = useVideoFormVisibility(capabilities, videoMode);
 
@@ -108,20 +109,20 @@ export default function CreateVideoPage() {
         prompt: prompt.trim(),
         image_url: visibility.showFirstFrame ? imageUrl || undefined : undefined,
         last_frame_image: visibility.showLastFrame ? lastFrameImageUrl || undefined : undefined,
-        config: { 
-          duration, 
-          quality: quality as any, 
+        config: {
+          duration,
+          quality: quality as any,
           aspect_ratio: aspectRatio,
           prompt_optimizer: visibility.showPromptOptimizer ? promptOptimizer : undefined,
           fast_pretreatment: visibility.showFastPretreatment ? fastPretreatment : undefined,
         },
       });
-      toast({ title: '视频任务已提交', description: '任务已进入队列，请等待生成完成' });
+      toast({ title: t('videos.toast.submitSuccess'), description: t('videos.toast.submitSuccessDesc') });
       router.push('/admin/videos');
     } catch (e: any) {
       toast({
-        title: '提交失败',
-        description: e?.response?.data?.detail || e?.message || '未知错误',
+        title: t('videos.toast.submitFailed'),
+        description: e?.response?.data?.detail || e?.message || t('videos.toast.unknownError'),
         variant: 'destructive',
       });
     } finally {
@@ -164,8 +165,8 @@ export default function CreateVideoPage() {
             <ArrowLeft className="h-5 w-5" />
           </Button>
           <div>
-            <h2 className="text-2xl font-bold tracking-tight">新建视频任务</h2>
-            <p className="text-muted-foreground">配置参数并生成新的视频内容</p>
+            <h2 className="text-2xl font-bold tracking-tight">{t('videos.form.title')}</h2>
+            <p className="text-muted-foreground">{t('videos.form.subtitle')}</p>
           </div>
         </div>
       </div>
@@ -173,13 +174,13 @@ export default function CreateVideoPage() {
       <div className="grid gap-8">
         {/* Model Configuration */}
         <section className="space-y-4 rounded-xl border bg-card p-6 shadow-sm">
-          <h3 className="text-lg font-semibold">模型配置</h3>
+          <h3 className="text-lg font-semibold">{t('videos.form.sections.model')}</h3>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
             <div className="grid gap-2">
-              <Label>供应商</Label>
+              <Label>{t('videos.form.provider')}</Label>
               <Select value={providerId} onValueChange={handleProviderChange}>
                 <SelectTrigger>
-                  <SelectValue placeholder="选择供应商" />
+                  <SelectValue placeholder={t('videos.form.selectProvider')} />
                 </SelectTrigger>
                 <SelectContent>
                   {providers?.map((p: LLMProvider) => (
@@ -189,10 +190,10 @@ export default function CreateVideoPage() {
               </Select>
             </div>
             <div className="grid gap-2">
-              <Label>模型</Label>
+              <Label>{t('videos.form.model')}</Label>
               <Select value={model} onValueChange={handleModelChange} disabled={!providerId}>
                 <SelectTrigger>
-                  <SelectValue placeholder={providerId ? "选择模型" : "先选择供应商"} />
+                  <SelectValue placeholder={providerId ? t('videos.form.selectModel') : t('videos.form.selectProviderFirst')} />
                 </SelectTrigger>
                 <SelectContent>
                   {availableModels.map((m: string) => (
@@ -207,20 +208,24 @@ export default function CreateVideoPage() {
           {capabilities && (
             <div className="rounded-lg bg-primary/5 p-3 text-sm text-muted-foreground">
               <Sparkles className="mr-2 inline h-4 w-4 text-primary" />
-              支持模式: {capabilities.modes.map(m => VIDEO_MODE_LABELS[m]).join('、')}
-              {capabilities.supports_last_frame && '、首尾帧生成'}
+              {t('videos.form.supportModes', {
+                modes: capabilities.modes
+                  .map((m: string) => t(`videos.modeLong.${m}`, { defaultValue: m }))
+                  .join('、'),
+              })}
+              {capabilities.supports_last_frame && t('videos.form.supportLastFrame')}
             </div>
           )}
         </section>
 
         {/* Video Settings */}
         <section className="space-y-4 rounded-xl border bg-card p-6 shadow-sm">
-          <h3 className="text-lg font-semibold">视频设置</h3>
+          <h3 className="text-lg font-semibold">{t('videos.form.sections.video')}</h3>
           
           {/* 生成模式 - 仅当支持多个模式时显示 */}
           {visibility.showModeSelect && (
             <div className="grid gap-2">
-              <Label>生成模式</Label>
+              <Label>{t('videos.form.mode')}</Label>
               <Select value={videoMode} onValueChange={setVideoMode}>
                 <SelectTrigger>
                   <SelectValue />
@@ -228,7 +233,7 @@ export default function CreateVideoPage() {
                 <SelectContent>
                   {capabilities?.modes.map((mode) => (
                     <SelectItem key={mode} value={mode}>
-                      {VIDEO_MODE_LABELS[mode]}
+                      {t(`videos.modeLong.${mode}`, { defaultValue: mode })}
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -241,18 +246,20 @@ export default function CreateVideoPage() {
             <Alert variant="default" className="bg-muted">
               <AlertCircle className="h-4 w-4" />
               <AlertDescription>
-                此模型仅支持{VIDEO_MODE_LABELS[capabilities.modes[0]]}模式
+                {t('videos.form.singleModeHint', {
+                  mode: t(`videos.modeLong.${capabilities.modes[0]}`, { defaultValue: capabilities.modes[0] }),
+                })}
               </AlertDescription>
             </Alert>
           )}
 
           {/* 提示词 */}
           <div className="grid gap-2">
-            <Label>提示词</Label>
+            <Label>{t('videos.form.prompt')}</Label>
             <Textarea
               value={prompt}
               onChange={(e) => setPrompt(e.target.value)}
-              placeholder="描述你想生成的视频内容..."
+              placeholder={t('videos.form.promptPlaceholder')}
               className="min-h-[120px] resize-none"
               maxLength={2000}
             />
@@ -264,27 +271,27 @@ export default function CreateVideoPage() {
           {/* 首帧图片 */}
           {visibility.showFirstFrame && (
             <div className="grid gap-2">
-              <Label>首帧图片 URL <span className="text-destructive">*</span></Label>
+              <Label>{t('videos.form.firstFrame')} <span className="text-destructive">*</span></Label>
               <Input
                 value={imageUrl}
                 onChange={(e) => setImageUrl(e.target.value)}
-                placeholder="输入图片 URL 或 base64 data URL"
+                placeholder={t('videos.form.firstFramePlaceholder')}
                 required
               />
-              <p className="text-xs text-muted-foreground">此模型需要提供首帧图片才能生成视频</p>
+              <p className="text-xs text-muted-foreground">{t('videos.form.firstFrameHint')}</p>
             </div>
           )}
 
           {/* 尾帧图片 */}
           {visibility.showLastFrame && (
             <div className="grid gap-2">
-              <Label>尾帧图片 URL (可选)</Label>
+              <Label>{t('videos.form.lastFrame')}</Label>
               <Input
                 value={lastFrameImageUrl}
                 onChange={(e) => setLastFrameImageUrl(e.target.value)}
-                placeholder="输入尾帧图片 URL"
+                placeholder={t('videos.form.lastFramePlaceholder')}
               />
-              <p className="text-xs text-muted-foreground">视频将以这张图片结束，实现首尾帧过渡效果</p>
+              <p className="text-xs text-muted-foreground">{t('videos.form.lastFrameHint')}</p>
             </div>
           )}
 
@@ -292,8 +299,8 @@ export default function CreateVideoPage() {
           <div className="grid gap-6 pt-2">
             <div className="grid gap-4">
               <div className="flex items-center justify-between">
-                <Label>时长</Label>
-                <span className="text-sm font-medium">{duration} 秒</span>
+                <Label>{t('videos.form.duration')}</Label>
+                <span className="text-sm font-medium">{t('videos.form.durationValue', { value: duration })}</span>
               </div>
               {visibility.showDurationSlider ? (
                 <Slider
@@ -313,7 +320,7 @@ export default function CreateVideoPage() {
                       onClick={() => setDuration(d)}
                       className="flex-1"
                     >
-                      {d} 秒
+                      {t('videos.form.durationValue', { value: d })}
                     </Button>
                   ))}
                 </div>
@@ -323,7 +330,7 @@ export default function CreateVideoPage() {
             <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
               {/* 画质 */}
               <div className="grid gap-2">
-                <Label>画质</Label>
+                <Label>{t('videos.form.quality')}</Label>
                 <Select value={quality} onValueChange={setQuality}>
                   <SelectTrigger>
                     <SelectValue />
@@ -331,7 +338,7 @@ export default function CreateVideoPage() {
                   <SelectContent>
                     {visibility.resolutionOptions.map((res) => (
                       <SelectItem key={res} value={res}>
-                        {RESOLUTION_LABELS[res] || res}
+                        {t(`tools.resolutions.${res}`, { defaultValue: res })}
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -340,7 +347,7 @@ export default function CreateVideoPage() {
               
               {/* 画面比例 */}
               <div className="grid gap-2">
-                <Label>画面比例</Label>
+                <Label>{t('videos.form.aspectRatio')}</Label>
                 <Select value={aspectRatio} onValueChange={setAspectRatio}>
                   <SelectTrigger>
                     <SelectValue />
@@ -348,7 +355,7 @@ export default function CreateVideoPage() {
                   <SelectContent>
                     {(visibility.aspectRatioOptions || ['16:9', '9:16', '1:1']).map((ratio) => (
                       <SelectItem key={ratio} value={ratio}>
-                        {ASPECT_RATIO_LABELS[ratio] || ratio}
+                        {t(`tools.aspectRatios.${ratio}`, { defaultValue: ratio })}
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -361,7 +368,7 @@ export default function CreateVideoPage() {
         {/* 高级设置 */}
         {(visibility.showPromptOptimizer || visibility.showFastPretreatment) && (
           <section className="space-y-4 rounded-xl border bg-card p-6 shadow-sm">
-            <h3 className="text-lg font-semibold">高级设置</h3>
+            <h3 className="text-lg font-semibold">{t('videos.form.sections.advanced')}</h3>
             
             <div className="grid gap-4">
               {visibility.showPromptOptimizer && (
@@ -369,9 +376,9 @@ export default function CreateVideoPage() {
                   <div className="space-y-0.5">
                     <Label className="flex items-center gap-2">
                       <Sparkles className="h-4 w-4" />
-                      提示词优化
+                      {t('videos.form.promptOptimizer')}
                     </Label>
-                    <p className="text-xs text-muted-foreground">自动优化提示词以获得更好的生成效果</p>
+                    <p className="text-xs text-muted-foreground">{t('videos.form.promptOptimizerDesc')}</p>
                   </div>
                   <Switch
                     checked={promptOptimizer}
@@ -385,9 +392,9 @@ export default function CreateVideoPage() {
                   <div className="space-y-0.5">
                     <Label className="flex items-center gap-2">
                       <Zap className="h-4 w-4" />
-                      快速预处理
+                      {t('videos.form.fastPretreatment')}
                     </Label>
-                    <p className="text-xs text-muted-foreground">减少优化时间，加快生成速度</p>
+                    <p className="text-xs text-muted-foreground">{t('videos.form.fastPretreatmentDesc')}</p>
                   </div>
                   <Switch
                     checked={fastPretreatment}
@@ -401,15 +408,15 @@ export default function CreateVideoPage() {
 
         {/* Footer Actions */}
         <div className="flex items-center justify-end gap-3 pb-8">
-          <Button variant="outline" onClick={() => router.back()}>取消</Button>
+          <Button variant="outline" onClick={() => router.back()}>{t('videos.form.cancel')}</Button>
           <Button onClick={handleSubmit} disabled={!canSubmit} size="lg" className="min-w-[120px]">
             {submitting ? (
               <>
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                提交中...
+                {t('videos.form.submitting')}
               </>
             ) : (
-              '提交任务'
+              t('videos.form.submit')
             )}
           </Button>
         </div>

--- a/backend/admin/src/app/admin/videos/page.tsx
+++ b/backend/admin/src/app/admin/videos/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
 import { useVideoTasks, useDeleteVideoTask } from '@/hooks/useVideoTasks';
 import { VideoTaskResponse } from '@/types';
 import { Button } from '@/components/ui/button';
@@ -27,19 +28,13 @@ import VideoPreviewModal from './VideoPreviewModal';
 import { formatRelativeTime } from '@/lib/date-utils';
 
 // ---------------------------------------------------------------------------
-// 映射表（无 if-else）
+// Status variant map (variant-only; labels resolved via i18n)
 // ---------------------------------------------------------------------------
-const STATUS_MAP: Record<string, { label: string; variant: 'secondary' | 'default' | 'outline' | 'destructive' }> = {
-  pending:    { label: '排队中', variant: 'secondary' },
-  processing: { label: '生成中', variant: 'default' },
-  completed:  { label: '已完成', variant: 'outline' },
-  failed:     { label: '失败',   variant: 'destructive' },
-};
-
-const MODE_LABELS: Record<string, string> = {
-  text_to_video:  '文字生成',
-  image_to_video: '图片生成',
-  edit:           '视频编辑',
+const STATUS_VARIANT: Record<string, 'secondary' | 'default' | 'outline' | 'destructive'> = {
+  pending: 'secondary',
+  processing: 'default',
+  completed: 'outline',
+  failed: 'destructive',
 };
 
 const DELETABLE_STATUSES = new Set(['completed', 'failed']);
@@ -50,6 +45,7 @@ const DELETABLE_STATUSES = new Set(['completed', 'failed']);
 export default function VideosPage() {
   const router = useRouter();
   const { toast } = useToast();
+  const { t } = useTranslation();
   const [page, setPage] = useState(1);
   const pageSize = 20;
 
@@ -63,7 +59,7 @@ export default function VideosPage() {
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
 
   // 自动轮询：当有进行中的任务时，每 5 秒刷新一次
-  const hasActiveTasks = tasks.some((t: VideoTaskResponse) => 
+  const hasActiveTasks = tasks.some((t: VideoTaskResponse) =>
     t.status === 'pending' || t.status === 'processing'
   );
 
@@ -82,13 +78,13 @@ export default function VideosPage() {
     setDeleting(true);
     try {
       await deleteVideoTask(task!.id);
-      toast({ title: '删除成功' });
+      toast({ title: t('videos.delete.success') });
       setDeleteTarget(null);
       mutate();
     } catch (e: any) {
       toast({
-        title: '删除失败',
-        description: e?.response?.data?.detail || e?.message || '未知错误',
+        title: t('videos.delete.failed'),
+        description: e?.response?.data?.detail || e?.message || t('videos.toast.unknownError'),
         variant: 'destructive',
       });
     } finally {
@@ -101,11 +97,11 @@ export default function VideosPage() {
       {/* 标题区域 */}
       <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
         <div>
-          <h2 className="text-3xl font-bold tracking-tight">视频生成</h2>
-          <p className="text-muted-foreground">管理和监控视频生成任务</p>
+          <h2 className="text-3xl font-bold tracking-tight">{t('videos.title')}</h2>
+          <p className="text-muted-foreground">{t('videos.subtitle')}</p>
         </div>
         <Button onClick={() => router.push('/admin/videos/new')}>
-          <Plus className="mr-2 h-4 w-4" /> 新建视频任务
+          <Plus className="mr-2 h-4 w-4" /> {t('videos.newBtn')}
         </Button>
       </div>
 
@@ -118,23 +114,24 @@ export default function VideosPage() {
         ) : tasks.length === 0 ? (
           <div className="flex h-40 flex-col items-center justify-center rounded-lg border border-dashed bg-muted/50 text-muted-foreground">
             <Video className="mb-2 h-8 w-8 opacity-50" />
-            <p>暂无视频任务</p>
+            <p>{t('videos.empty')}</p>
           </div>
         ) : (
           <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
             {tasks.map((task: VideoTaskResponse) => {
-              const statusInfo = STATUS_MAP[task.status] ?? STATUS_MAP.pending;
+              const variant = STATUS_VARIANT[task.status] ?? STATUS_VARIANT.pending;
+              const statusLabel = t(`videos.status.${task.status}`, { defaultValue: task.status });
               const canDelete = DELETABLE_STATUSES.has(task.status);
-              
+
               return (
-                <Card 
-                  key={task.id} 
+                <Card
+                  key={task.id}
                   className="group relative flex flex-col overflow-hidden transition-all hover:border-primary/50 hover:shadow-lg"
                 >
                   <div className="relative aspect-video w-full bg-muted">
                     {task.status === 'completed' && task.video_url ? (
-                      <video 
-                        src={task.video_url} 
+                      <video
+                        src={task.video_url}
                         className="h-full w-full object-cover"
                         preload="metadata"
                       />
@@ -150,13 +147,13 @@ export default function VideosPage() {
                     
                     {/* 状态标签 */}
                     <div className="absolute right-2 top-2">
-                      <Badge variant={statusInfo.variant} className="shadow-sm">
-                        {statusInfo.label}
+                      <Badge variant={variant} className="shadow-sm">
+                        {statusLabel}
                       </Badge>
                     </div>
 
                     {/* 操作遮罩 */}
-                    <div 
+                    <div
                       className="absolute inset-0 flex items-center justify-center gap-3 bg-black/0 transition-colors group-hover:bg-black/20 cursor-pointer"
                       onClick={() => setPreviewTask(task)}
                     >
@@ -181,7 +178,7 @@ export default function VideosPage() {
                   <CardContent className="flex-1 p-4">
                     <div className="mb-2 flex items-center justify-between gap-2">
                       <Badge variant="outline" className="text-[10px] font-normal">
-                        {MODE_LABELS[task.video_mode] ?? task.video_mode}
+                        {t(`videos.mode.${task.video_mode}`, { defaultValue: task.video_mode })}
                       </Badge>
                       <span className="text-[10px] text-muted-foreground">
                         {task.quality} · {task.duration}s
@@ -213,7 +210,7 @@ export default function VideosPage() {
       {total > pageSize && (
         <div className="flex items-center justify-between pt-4">
           <span className="text-sm text-muted-foreground">
-            共 {total} 条记录
+            {t('videos.totalCount', { count: total })}
           </span>
           <div className="flex items-center gap-2">
             <Button
@@ -250,16 +247,16 @@ export default function VideosPage() {
       <AlertDialog open={!!deleteTarget} onOpenChange={(open) => { !open && setDeleteTarget(null); }}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>确认删除</AlertDialogTitle>
+            <AlertDialogTitle>{t('videos.delete.title')}</AlertDialogTitle>
             <AlertDialogDescription>
-              删除后视频文件和任务记录将不可恢复，是否继续？
+              {t('videos.delete.description')}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel disabled={deleting}>取消</AlertDialogCancel>
+            <AlertDialogCancel disabled={deleting}>{t('common.buttons.cancel')}</AlertDialogCancel>
             <AlertDialogAction onClick={handleDelete} disabled={deleting} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
               {deleting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-              删除
+              {t('videos.delete.btn')}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/backend/admin/src/app/admin/virtual-humans/page.tsx
+++ b/backend/admin/src/app/admin/virtual-humans/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useMemo, useRef, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   useVirtualHumanPresets,
   useCreateVirtualHumanPreset,
@@ -45,20 +46,15 @@ import { Plus, Trash2, UserRound, Loader2, ImageOff, ArrowRight, Upload, X } fro
 import { cn } from '@/lib/utils';
 
 // ---------------------------------------------------------------------------
-// 映射表
+// 性别变体
 // ---------------------------------------------------------------------------
-const GENDER_MAP: Record<string, { label: string; variant: 'default' | 'secondary' | 'outline' }> = {
-  male:   { label: '男', variant: 'default' },
-  female: { label: '女', variant: 'secondary' },
+const GENDER_VARIANT: Record<string, 'default' | 'secondary' | 'outline'> = {
+  male: 'default',
+  female: 'secondary',
 };
 
-const GENDER_FILTERS = [
-  { key: 'all',    label: '全部' },
-  { key: 'male',   label: '男' },
-  { key: 'female', label: '女' },
-] as const;
-
-type GenderFilter = typeof GENDER_FILTERS[number]['key'];
+const GENDER_FILTER_KEYS = ['all', 'male', 'female'] as const;
+type GenderFilter = typeof GENDER_FILTER_KEYS[number];
 
 // ---------------------------------------------------------------------------
 // 默认表单值
@@ -126,6 +122,7 @@ function PresetImage({ src, alt, className }: { src: string; alt: string; classN
 // Page
 // ---------------------------------------------------------------------------
 export default function VirtualHumansPage() {
+  const { t } = useTranslation();
   const { toast } = useToast();
 
   // data
@@ -194,14 +191,22 @@ export default function VirtualHumansPage() {
 
     // validate size
     if (file.size > MAX_FILE_SIZE) {
-      toast({ variant: 'destructive', title: '文件过大', description: '图片大小不能超过 5MB' });
+      toast({
+        variant: 'destructive',
+        title: t('virtualHumans.toast.fileTooBigTitle'),
+        description: t('virtualHumans.toast.fileTooBigDesc'),
+      });
       return;
     }
 
     // validate type
     const validTypes = ['image/png', 'image/jpeg', 'image/jpg', 'image/webp'];
     if (!validTypes.includes(file.type)) {
-      toast({ variant: 'destructive', title: '格式不支持', description: '仅支持 PNG、JPG、WEBP 格式' });
+      toast({
+        variant: 'destructive',
+        title: t('virtualHumans.toast.formatUnsupportedTitle'),
+        description: t('virtualHumans.toast.formatUnsupportedDesc'),
+      });
       return;
     }
 
@@ -217,26 +222,34 @@ export default function VirtualHumansPage() {
       });
 
       setField('preview_url', res.data.url);
-      toast({ title: '上传成功' });
+      toast({ title: t('virtualHumans.toast.uploadSuccess') });
     } catch (err: any) {
-      const msg = err?.response?.data?.detail || err?.message || '上传失败';
-      toast({ variant: 'destructive', title: '上传失败', description: msg });
+      const msg = err?.response?.data?.detail || err?.message || t('virtualHumans.toast.uploadFailedFallback');
+      toast({
+        variant: 'destructive',
+        title: t('virtualHumans.toast.uploadFailed'),
+        description: msg,
+      });
     } finally {
       setUploading(false);
     }
-  }, [toast]);
+  }, [toast, t]);
 
   const handleSubmit = async () => {
     const { asset_id, name, style, preview_url } = form;
     const missing = [
-      !asset_id.trim() && 'Asset ID',
-      !name.trim() && '名称',
-      !style.trim() && '风格',
-      !preview_url.trim() && '预览图',
+      !asset_id.trim() && t('virtualHumans.form.assetId'),
+      !name.trim() && t('virtualHumans.form.name'),
+      !style.trim() && t('virtualHumans.form.style'),
+      !preview_url.trim() && t('virtualHumans.form.preview'),
     ].filter(Boolean);
 
     if (missing.length) {
-      toast({ variant: 'destructive', title: '请填写必填项', description: missing.join('、') });
+      toast({
+        variant: 'destructive',
+        title: t('virtualHumans.toast.fieldsRequiredTitle'),
+        description: missing.join(t('virtualHumans.toast.fieldsRequiredJoiner')),
+      });
       return;
     }
 
@@ -246,15 +259,25 @@ export default function VirtualHumansPage() {
       editingPreset
         ? await updatePreset(editingPreset.id, payload)
         : await createPreset(payload);
-      toast({ title: editingPreset ? '更新成功' : '创建成功' });
+      toast({
+        title: editingPreset
+          ? t('virtualHumans.toast.updateSuccess')
+          : t('virtualHumans.toast.createSuccess'),
+      });
       setDialogOpen(false);
       mutate();
     } catch (e: any) {
       const raw = e?.response?.data?.detail;
-      const msg = typeof raw === 'string' ? raw : Array.isArray(raw) ? raw.map((d: any) => d.msg ?? JSON.stringify(d)).join('; ') : e?.message || '未知错误';
+      const msg = typeof raw === 'string'
+        ? raw
+        : Array.isArray(raw)
+          ? raw.map((d: any) => d.msg ?? JSON.stringify(d)).join('; ')
+          : e?.message || t('virtualHumans.toast.unknownError');
       toast({
         variant: 'destructive',
-        title: editingPreset ? '更新失败' : '创建失败',
+        title: editingPreset
+          ? t('virtualHumans.toast.updateFailed')
+          : t('virtualHumans.toast.createFailed'),
         description: msg,
       });
     } finally {
@@ -267,15 +290,19 @@ export default function VirtualHumansPage() {
     setDeleting(true);
     try {
       await deletePreset(deleteTarget.id);
-      toast({ title: '删除成功' });
+      toast({ title: t('virtualHumans.toast.deleteSuccess') });
       setDeleteTarget(null);
       mutate();
     } catch (e: any) {
       const raw = e?.response?.data?.detail;
-      const msg = typeof raw === 'string' ? raw : Array.isArray(raw) ? raw.map((d: any) => d.msg ?? JSON.stringify(d)).join('; ') : e?.message || '未知错误';
+      const msg = typeof raw === 'string'
+        ? raw
+        : Array.isArray(raw)
+          ? raw.map((d: any) => d.msg ?? JSON.stringify(d)).join('; ')
+          : e?.message || t('virtualHumans.toast.unknownError');
       toast({
         variant: 'destructive',
-        title: '删除失败',
+        title: t('virtualHumans.toast.deleteFailed'),
         description: msg,
       });
     } finally {
@@ -289,34 +316,34 @@ export default function VirtualHumansPage() {
       {/* Header */}
       <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
         <div>
-          <h2 className="text-3xl font-bold tracking-tight">虚拟人像库</h2>
+          <h2 className="text-3xl font-bold tracking-tight">{t('virtualHumans.title')}</h2>
           <p className="text-muted-foreground mt-1">
-            管理火山方舟预制虚拟人像，用于 Seedance 2.0 真人视频生成
+            {t('virtualHumans.subtitle')}
           </p>
         </div>
         <Button onClick={openCreateDialog}>
-          <Plus className="mr-2 h-4 w-4" /> 添加人像
+          <Plus className="mr-2 h-4 w-4" /> {t('virtualHumans.addBtn')}
         </Button>
       </div>
 
       {/* Filters */}
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
         <div className="flex items-center rounded-lg border bg-background p-1 shadow-sm">
-          {GENDER_FILTERS.map((g) => (
+          {GENDER_FILTER_KEYS.map((key) => (
             <Button
-              key={g.key}
-              variant={genderFilter === g.key ? 'secondary' : 'ghost'}
+              key={key}
+              variant={genderFilter === key ? 'secondary' : 'ghost'}
               size="sm"
               className="h-8 px-3 text-xs"
-              onClick={() => setGenderFilter(g.key)}
+              onClick={() => setGenderFilter(key)}
             >
-              {g.label}
+              {t(`virtualHumans.filter.${key}`)}
             </Button>
           ))}
         </div>
 
         <Input
-          placeholder="按风格筛选，如 realistic…"
+          placeholder={t('virtualHumans.filter.stylePlaceholder')}
           className="max-w-xs"
           value={styleFilter}
           onChange={(e) => setStyleFilter(e.target.value)}
@@ -332,12 +359,12 @@ export default function VirtualHumansPage() {
         ) : filteredPresets.length === 0 ? (
           <div className="flex h-40 flex-col items-center justify-center gap-2 rounded-lg border border-dashed bg-muted/50 text-muted-foreground">
             <UserRound className="h-8 w-8 opacity-40" />
-            <p className="text-sm">暂无虚拟人像</p>
+            <p className="text-sm">{t('virtualHumans.empty')}</p>
           </div>
         ) : (
           <div className="grid grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-6">
             {filteredPresets.map((preset) => {
-              const gender = GENDER_MAP[preset.gender] ?? GENDER_MAP.male;
+              const genderVariant = GENDER_VARIANT[preset.gender] ?? GENDER_VARIANT.male;
               return (
                 <div
                   key={preset.id}
@@ -364,7 +391,9 @@ export default function VirtualHumansPage() {
                           preset.is_active ? 'bg-emerald-500' : 'bg-gray-400',
                         )}
                       />
-                      {preset.is_active ? '启用' : '停用'}
+                      {preset.is_active
+                        ? t('virtualHumans.status.active')
+                        : t('virtualHumans.status.inactive')}
                     </div>
                   </div>
 
@@ -374,7 +403,9 @@ export default function VirtualHumansPage() {
                       {preset.name}
                     </h3>
                     <div className="flex flex-wrap items-center gap-1.5 mb-2">
-                      <Badge variant={gender.variant} className="text-[10px]">{gender.label}</Badge>
+                      <Badge variant={genderVariant} className="text-[10px]">
+                        {t(`virtualHumans.gender.${preset.gender}`, { defaultValue: preset.gender })}
+                      </Badge>
                       <Badge variant="outline" className="text-[10px] font-normal">{preset.style}</Badge>
                     </div>
                     <p className="truncate font-mono text-[11px] text-muted-foreground" title={preset.asset_id}>
@@ -385,7 +416,7 @@ export default function VirtualHumansPage() {
                   {/* 底部操作区 */}
                   <div className="px-4 py-3 border-t border-border/50 flex items-center justify-between transition-colors duration-300 group-hover:bg-muted/30">
                     <span className="text-xs font-medium text-muted-foreground group-hover:text-primary transition-colors flex items-center gap-1">
-                      编辑配置
+                      {t('virtualHumans.card.editConfig')}
                       <ArrowRight className="w-3 h-3 opacity-0 -ml-2 group-hover:opacity-100 group-hover:ml-0 transition-all duration-300" />
                     </span>
 
@@ -397,7 +428,7 @@ export default function VirtualHumansPage() {
                         onClick={() => setDeleteTarget(preset)}
                       >
                         <Trash2 className="h-3 w-3 mr-1" />
-                        删除
+                        {t('virtualHumans.card.deleteBtn')}
                       </Button>
                     </div>
                   </div>
@@ -412,9 +443,15 @@ export default function VirtualHumansPage() {
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
         <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
           <DialogHeader>
-            <DialogTitle>{editingPreset ? '编辑虚拟人像' : '添加虚拟人像'}</DialogTitle>
+            <DialogTitle>
+              {editingPreset
+                ? t('virtualHumans.dialog.editTitle')
+                : t('virtualHumans.dialog.createTitle')}
+            </DialogTitle>
             <DialogDescription>
-              {editingPreset ? '修改虚拟人像预设信息' : '添加一个新的火山方舟预制虚拟人像'}
+              {editingPreset
+                ? t('virtualHumans.dialog.editDesc')
+                : t('virtualHumans.dialog.createDesc')}
             </DialogDescription>
           </DialogHeader>
 
@@ -422,11 +459,11 @@ export default function VirtualHumansPage() {
             {/* asset_id */}
             <div className="grid gap-1.5">
               <Label htmlFor="asset_id">
-                Asset ID <span className="text-destructive">*</span>
+                {t('virtualHumans.form.assetId')} <span className="text-destructive">*</span>
               </Label>
               <Input
                 id="asset_id"
-                placeholder="asset-xxxxxxxxx-xxxxx"
+                placeholder={t('virtualHumans.form.assetIdPlaceholder')}
                 value={form.asset_id}
                 onChange={(e) => setField('asset_id', e.target.value)}
               />
@@ -435,11 +472,11 @@ export default function VirtualHumansPage() {
             {/* name */}
             <div className="grid gap-1.5">
               <Label htmlFor="name">
-                名称 <span className="text-destructive">*</span>
+                {t('virtualHumans.form.name')} <span className="text-destructive">*</span>
               </Label>
               <Input
                 id="name"
-                placeholder="人像名称"
+                placeholder={t('virtualHumans.form.namePlaceholder')}
                 value={form.name}
                 onChange={(e) => setField('name', e.target.value)}
               />
@@ -448,7 +485,7 @@ export default function VirtualHumansPage() {
             {/* gender + style row */}
             <div className="grid grid-cols-2 gap-4">
               <div className="grid gap-1.5">
-                <Label>性别</Label>
+                <Label>{t('virtualHumans.form.gender')}</Label>
                 <Select
                   value={form.gender}
                   onValueChange={(v) => setField('gender', v as 'male' | 'female')}
@@ -457,18 +494,18 @@ export default function VirtualHumansPage() {
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="male">男</SelectItem>
-                    <SelectItem value="female">女</SelectItem>
+                    <SelectItem value="male">{t('virtualHumans.gender.male')}</SelectItem>
+                    <SelectItem value="female">{t('virtualHumans.gender.female')}</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
               <div className="grid gap-1.5">
                 <Label htmlFor="style">
-                  风格 <span className="text-destructive">*</span>
+                  {t('virtualHumans.form.style')} <span className="text-destructive">*</span>
                 </Label>
                 <Input
                   id="style"
-                  placeholder="realistic"
+                  placeholder={t('virtualHumans.form.stylePlaceholder')}
                   value={form.style}
                   onChange={(e) => setField('style', e.target.value)}
                 />
@@ -478,7 +515,7 @@ export default function VirtualHumansPage() {
             {/* 预览图上传 */}
             <div className="grid gap-1.5">
               <Label>
-                预览图 <span className="text-destructive">*</span>
+                {t('virtualHumans.form.preview')} <span className="text-destructive">*</span>
               </Label>
               <input
                 ref={fileInputRef}
@@ -491,7 +528,7 @@ export default function VirtualHumansPage() {
                 <div className="relative rounded-lg border bg-muted/20 overflow-hidden">
                   <img
                     src={form.preview_url}
-                    alt="预览"
+                    alt={t('virtualHumans.form.previewAlt')}
                     className="w-full h-48 object-contain"
                   />
                   <Button
@@ -510,7 +547,7 @@ export default function VirtualHumansPage() {
                     disabled={uploading}
                   >
                     {uploading ? <Loader2 className="h-3.5 w-3.5 animate-spin mr-1" /> : <Upload className="h-3.5 w-3.5 mr-1" />}
-                    更换
+                    {t('virtualHumans.form.replace')}
                   </Button>
                 </div>
               ) : (
@@ -528,10 +565,12 @@ export default function VirtualHumansPage() {
                     <Upload className="h-8 w-8 text-muted-foreground/50 mb-2" />
                   )}
                   <p className="text-sm text-muted-foreground">
-                    {uploading ? '上传中…' : '点击上传预览图'}
+                    {uploading
+                      ? t('virtualHumans.form.uploading')
+                      : t('virtualHumans.form.uploadHint')}
                   </p>
                   <p className="text-xs text-muted-foreground/60 mt-1">
-                    支持 PNG、JPG、WEBP，最大 5MB，上传后自动压缩
+                    {t('virtualHumans.form.formatHint')}
                   </p>
                 </div>
               )}
@@ -539,10 +578,10 @@ export default function VirtualHumansPage() {
 
             {/* description */}
             <div className="grid gap-1.5">
-              <Label htmlFor="description">描述</Label>
+              <Label htmlFor="description">{t('virtualHumans.form.description')}</Label>
               <Textarea
                 id="description"
-                placeholder="可选描述信息…"
+                placeholder={t('virtualHumans.form.descriptionPlaceholder')}
                 rows={3}
                 value={form.description}
                 onChange={(e) => setField('description', e.target.value)}
@@ -558,11 +597,13 @@ export default function VirtualHumansPage() {
                   onCheckedChange={(v) => setField('is_active', v)}
                 />
                 <Label htmlFor="is_active" className="cursor-pointer">
-                  {form.is_active ? '启用' : '停用'}
+                  {form.is_active
+                    ? t('virtualHumans.form.isActive')
+                    : t('virtualHumans.form.isInactive')}
                 </Label>
               </div>
               <div className="grid gap-1.5">
-                <Label htmlFor="sort_order">排序</Label>
+                <Label htmlFor="sort_order">{t('virtualHumans.form.sortOrder')}</Label>
                 <Input
                   id="sort_order"
                   type="number"
@@ -575,11 +616,13 @@ export default function VirtualHumansPage() {
 
           <DialogFooter>
             <Button variant="outline" onClick={() => setDialogOpen(false)} disabled={submitting}>
-              取消
+              {t('virtualHumans.form.cancel')}
             </Button>
             <Button onClick={handleSubmit} disabled={submitting || uploading}>
               {submitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              {editingPreset ? '保存修改' : '创建'}
+              {editingPreset
+                ? t('virtualHumans.form.save')
+                : t('virtualHumans.form.create')}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -589,20 +632,22 @@ export default function VirtualHumansPage() {
       <AlertDialog open={!!deleteTarget} onOpenChange={(open) => { !open && setDeleteTarget(null); }}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>确认删除</AlertDialogTitle>
+            <AlertDialogTitle>{t('virtualHumans.delete.title')}</AlertDialogTitle>
             <AlertDialogDescription>
-              即将删除虚拟人像「{deleteTarget?.name}」，此操作不可撤销。
+              {t('virtualHumans.delete.description', { name: deleteTarget?.name ?? '' })}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel disabled={deleting}>取消</AlertDialogCancel>
+            <AlertDialogCancel disabled={deleting}>
+              {t('virtualHumans.delete.cancel')}
+            </AlertDialogCancel>
             <AlertDialogAction
               onClick={handleDelete}
               disabled={deleting}
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
               {deleting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              删除
+              {t('virtualHumans.delete.confirm')}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/backend/admin/src/components/admin/tools/ImageGenConfigDialog.tsx
+++ b/backend/admin/src/components/admin/tools/ImageGenConfigDialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useMemo, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   Dialog,
   DialogContent,
@@ -24,21 +25,6 @@ import { useToast } from '@/components/ui/use-toast';
 import { collectModelsByType } from '@/lib/api-utils';
 import { AlertCircle } from 'lucide-react';
 
-// 标签映射表
-const ASPECT_RATIO_LABELS: Record<string, string> = {
-  "auto": "自动", "1:1": "1:1 (方形)", "16:9": "16:9 (宽屏)", "9:16": "9:16 (手机)",
-  "4:3": "4:3 (标准)", "3:4": "3:4 (竖屏)", "3:2": "3:2", "2:3": "2:3",
-  "2:1": "2:1 (超宽)", "1:2": "1:2 (超高)",
-};
-
-const QUALITY_LABELS: Record<string, string> = {
-  "standard": "标准", "hd": "高清", "ultra": "超高清",
-};
-
-const OUTPUT_FORMAT_LABELS: Record<string, string> = {
-  "png": "PNG", "jpeg": "JPEG", "webp": "WebP",
-};
-
 interface ImageGenConfigDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -59,6 +45,7 @@ export default function ImageGenConfigDialog({
   onSaveConfig,
 }: ImageGenConfigDialogProps) {
   const { toast } = useToast();
+  const { t } = useTranslation();
   const [saving, setSaving] = useState(false);
 
   // 本地表单状态
@@ -117,14 +104,14 @@ export default function ImageGenConfigDialog({
         } : null,
       };
       await onSaveConfig(config);
-      toast({ title: '保存成功', description: '图像生成工具配置已更新' });
+      toast({ title: t('tools.imageDialog.saveSuccess'), description: t('tools.imageDialog.saveSuccessDesc') });
       onSaved();
       onOpenChange(false);
     } catch (e: any) {
       toast({
         variant: 'destructive',
-        title: '保存失败',
-        description: e?.response?.data?.detail || '请重试',
+        title: t('tools.imageDialog.saveFailed'),
+        description: e?.response?.data?.detail || t('tools.imageDialog.retry'),
       });
     } finally {
       setSaving(false);
@@ -135,16 +122,14 @@ export default function ImageGenConfigDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-lg">
         <DialogHeader>
-          <DialogTitle>配置图像生成工具</DialogTitle>
-          <DialogDescription>
-            设置全局 generate_image 工具参数（所有智能体共享此配置）
-          </DialogDescription>
+          <DialogTitle>{t('tools.imageDialog.title')}</DialogTitle>
+          <DialogDescription>{t('tools.imageDialog.description')}</DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4 py-2">
           {/* 启用开关 */}
           <div className="flex items-center justify-between">
-            <Label className="text-sm">启用图像生成</Label>
+            <Label className="text-sm">{t('tools.imageDialog.enable')}</Label>
             <Switch checked={enabled} onCheckedChange={setEnabled} />
           </div>
 
@@ -154,22 +139,20 @@ export default function ImageGenConfigDialog({
               {imageModels.length === 0 && (
                 <div className="flex items-center gap-2 text-xs text-amber-600 dark:text-amber-500 bg-amber-50 dark:bg-amber-950 rounded-md p-3">
                   <AlertCircle className="h-4 w-4 shrink-0" />
-                  <span>
-                    未找到图像模型。请先在「供应商管理」中为供应商的模型设置「图像模型」类型。
-                  </span>
+                  <span>{t('tools.imageDialog.noModelWarning')}</span>
                 </div>
               )}
 
               {/* 图像模型（扁平列表，按 model_type 过滤） */}
               <div className="space-y-1.5">
-                <Label className="text-xs text-muted-foreground">图像模型</Label>
+                <Label className="text-xs text-muted-foreground">{t('tools.imageDialog.model')}</Label>
                 <Select
                   value={model}
                   onValueChange={setModel}
                   disabled={imageModels.length === 0}
                 >
                   <SelectTrigger className="bg-background">
-                    <SelectValue placeholder={imageModels.length === 0 ? "无可用图像模型" : "选择图像模型"} />
+                    <SelectValue placeholder={imageModels.length === 0 ? t('tools.imageDialog.modelEmpty') : t('tools.imageDialog.modelSelect')} />
                   </SelectTrigger>
                   <SelectContent>
                     {imageModels.map((m) => (
@@ -185,18 +168,18 @@ export default function ImageGenConfigDialog({
               <div className="grid grid-cols-2 gap-3">
                 {/* 宽高比 */}
                 <div className="space-y-1.5">
-                  <Label className="text-xs text-muted-foreground">宽高比</Label>
+                  <Label className="text-xs text-muted-foreground">{t('tools.imageDialog.aspectRatio')}</Label>
                   <Select
                     value={aspectRatio}
                     onValueChange={setAspectRatio}
                     disabled={!caps}
                   >
                     <SelectTrigger className="bg-background">
-                      <SelectValue placeholder={caps ? "选择" : "请先选择供应商"} />
+                      <SelectValue placeholder={caps ? t('tools.imageDialog.selectPlaceholder') : t('tools.imageDialog.selectProviderFirst')} />
                     </SelectTrigger>
                     <SelectContent>
                       {(caps?.aspect_ratios || []).map((v: string) => (
-                        <SelectItem key={v} value={v}>{ASPECT_RATIO_LABELS[v] || v}</SelectItem>
+                        <SelectItem key={v} value={v}>{t(`tools.aspectRatios.${v}`, { defaultValue: v })}</SelectItem>
                       ))}
                     </SelectContent>
                   </Select>
@@ -204,18 +187,18 @@ export default function ImageGenConfigDialog({
 
                 {/* 画质 */}
                 <div className="space-y-1.5">
-                  <Label className="text-xs text-muted-foreground">画质</Label>
+                  <Label className="text-xs text-muted-foreground">{t('tools.imageDialog.quality')}</Label>
                   <Select
                     value={quality}
                     onValueChange={setQuality}
                     disabled={!caps}
                   >
                     <SelectTrigger className="bg-background">
-                      <SelectValue placeholder={caps ? "选择" : "请先选择供应商"} />
+                      <SelectValue placeholder={caps ? t('tools.imageDialog.selectPlaceholder') : t('tools.imageDialog.selectProviderFirst')} />
                     </SelectTrigger>
                     <SelectContent>
                       {(caps?.qualities || []).map((v: string) => (
-                        <SelectItem key={v} value={v}>{QUALITY_LABELS[v] || v}</SelectItem>
+                        <SelectItem key={v} value={v}>{t(`tools.qualities.${v}`, { defaultValue: v })}</SelectItem>
                       ))}
                     </SelectContent>
                   </Select>
@@ -225,20 +208,20 @@ export default function ImageGenConfigDialog({
               <div className="grid grid-cols-2 gap-3">
                 {/* 批量生成数量 */}
                 <div className="space-y-1.5">
-                  <Label className="text-xs text-muted-foreground">每次生成张数</Label>
+                  <Label className="text-xs text-muted-foreground">{t('tools.imageDialog.batchCount')}</Label>
                   <Select
                     value={batchCount === null || batchCount === 0 ? 'auto' : String(batchCount)}
                     onValueChange={val => setBatchCount(val === 'auto' ? 0 : Number(val))}
                   >
                     <SelectTrigger className="bg-background">
-                      <SelectValue placeholder="选择" />
+                      <SelectValue placeholder={t('tools.imageDialog.selectPlaceholder')} />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="auto">自动（智能体决定）</SelectItem>
-                      <SelectItem value="1">1 张</SelectItem>
-                      <SelectItem value="2">2 张</SelectItem>
-                      <SelectItem value="3">3 张</SelectItem>
-                      <SelectItem value="4">4 张</SelectItem>
+                      <SelectItem value="auto">{t('tools.imageDialog.batchAuto')}</SelectItem>
+                      <SelectItem value="1">{t('tools.imageDialog.batchN', { count: 1 })}</SelectItem>
+                      <SelectItem value="2">{t('tools.imageDialog.batchN', { count: 2 })}</SelectItem>
+                      <SelectItem value="3">{t('tools.imageDialog.batchN', { count: 3 })}</SelectItem>
+                      <SelectItem value="4">{t('tools.imageDialog.batchN', { count: 4 })}</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>
@@ -246,17 +229,17 @@ export default function ImageGenConfigDialog({
                 {/* 输出格式 */}
                 {(caps?.output_formats?.length ?? 0) > 0 && (
                   <div className="space-y-1.5">
-                    <Label className="text-xs text-muted-foreground">输出格式</Label>
+                    <Label className="text-xs text-muted-foreground">{t('tools.imageDialog.outputFormat')}</Label>
                     <Select
                       value={outputFormat}
                       onValueChange={setOutputFormat}
                     >
                       <SelectTrigger className="bg-background">
-                        <SelectValue placeholder="选择" />
+                        <SelectValue placeholder={t('tools.imageDialog.selectPlaceholder')} />
                       </SelectTrigger>
                       <SelectContent>
                         {(caps?.output_formats || []).map((v: string) => (
-                          <SelectItem key={v} value={v}>{OUTPUT_FORMAT_LABELS[v] || v}</SelectItem>
+                          <SelectItem key={v} value={v}>{t(`tools.outputFormats.${v}`, { defaultValue: v })}</SelectItem>
                         ))}
                       </SelectContent>
                     </Select>
@@ -269,10 +252,10 @@ export default function ImageGenConfigDialog({
 
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
-            取消
+            {t('common.buttons.cancel')}
           </Button>
           <Button onClick={handleSave} disabled={saving}>
-            {saving ? '保存中...' : '保存'}
+            {saving ? t('common.status.saving') : t('common.buttons.save')}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/backend/admin/src/components/admin/tools/MusicGenConfigDialog.tsx
+++ b/backend/admin/src/components/admin/tools/MusicGenConfigDialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useMemo, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   Dialog,
   DialogContent,
@@ -24,15 +25,6 @@ import { useToast } from '@/components/ui/use-toast';
 import { collectModelsByType } from '@/lib/api-utils';
 import { AlertCircle } from 'lucide-react';
 
-// 音频供应商类型集合（已废弃，改用 model_type 过滤）
-// const MUSIC_PROVIDER_TYPES = new Set(["gemini"]);
-
-// 输出格式选项
-const OUTPUT_FORMAT_OPTIONS = [
-  { value: 'mp3', label: 'MP3 (通用)' },
-  { value: 'wav', label: 'WAV (无损，仅 Pro)' },
-];
-
 interface MusicGenConfigDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -51,6 +43,7 @@ export default function MusicGenConfigDialog({
   onSaveConfig,
 }: MusicGenConfigDialogProps) {
   const { toast } = useToast();
+  const { t } = useTranslation();
   const [saving, setSaving] = useState(false);
 
   // 本地表单状态
@@ -78,13 +71,31 @@ export default function MusicGenConfigDialog({
     [audioModels, model],
   );
 
-  // 模型能力标签映射
-  const MODEL_CAPS: Record<string, { label: string; description: string }> = {
-    'lyria-3-clip-preview': { label: 'Clip', description: '短音乐片段 (~30秒), 仅 MP3' },
-    'lyria-3-pro-preview': { label: 'Pro', description: '完整歌曲 (3-5分钟), MP3/WAV, 支持歌词' },
-  };
+  // 输出格式选项
+  const outputFormatOptions = useMemo(
+    () => [
+      { value: 'mp3', label: t('tools.musicDialog.formats.mp3') },
+      { value: 'wav', label: t('tools.musicDialog.formats.wav') },
+    ],
+    [t],
+  );
 
-  const currentCaps = MODEL_CAPS[model];
+  // 模型能力标签映射
+  const modelCapsMap: Record<string, { label: string; description: string }> = useMemo(
+    () => ({
+      'lyria-3-clip-preview': {
+        label: t('tools.musicDialog.caps.clipLabel'),
+        description: t('tools.musicDialog.caps.clipDesc'),
+      },
+      'lyria-3-pro-preview': {
+        label: t('tools.musicDialog.caps.proLabel'),
+        description: t('tools.musicDialog.caps.proDesc'),
+      },
+    }),
+    [t],
+  );
+
+  const currentCaps = modelCapsMap[model];
 
   const handleSave = async () => {
     setSaving(true);
@@ -98,14 +109,14 @@ export default function MusicGenConfigDialog({
         } : null,
       };
       await onSaveConfig(config);
-      toast({ title: '保存成功', description: '音乐生成工具配置已更新' });
+      toast({ title: t('tools.musicDialog.saveSuccess'), description: t('tools.musicDialog.saveSuccessDesc') });
       onSaved();
       onOpenChange(false);
     } catch (e: any) {
       toast({
         variant: 'destructive',
-        title: '保存失败',
-        description: e?.response?.data?.detail || '请重试',
+        title: t('tools.musicDialog.saveFailed'),
+        description: e?.response?.data?.detail || t('tools.musicDialog.retry'),
       });
     } finally {
       setSaving(false);
@@ -116,16 +127,14 @@ export default function MusicGenConfigDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-lg">
         <DialogHeader>
-          <DialogTitle>配置音乐生成工具</DialogTitle>
-          <DialogDescription>
-            设置全局 generate_music 工具参数（所有智能体共享此配置）
-          </DialogDescription>
+          <DialogTitle>{t('tools.musicDialog.title')}</DialogTitle>
+          <DialogDescription>{t('tools.musicDialog.description')}</DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4 py-2">
           {/* 启用开关 */}
           <div className="flex items-center justify-between">
-            <Label className="text-sm">启用音乐生成</Label>
+            <Label className="text-sm">{t('tools.musicDialog.enable')}</Label>
             <Switch checked={enabled} onCheckedChange={setEnabled} />
           </div>
 
@@ -135,22 +144,20 @@ export default function MusicGenConfigDialog({
               {audioModels.length === 0 && (
                 <div className="flex items-center gap-2 text-xs text-amber-600 dark:text-amber-500 bg-amber-50 dark:bg-amber-950 rounded-md p-3">
                   <AlertCircle className="h-4 w-4 shrink-0" />
-                  <span>
-                    未找到音频模型。请先在「供应商管理」中为供应商的模型设置「音频模型」类型。
-                  </span>
+                  <span>{t('tools.musicDialog.noModelWarning')}</span>
                 </div>
               )}
 
               {/* 音乐模型（扁平列表，按 model_type 过滤） */}
               <div className="space-y-1.5">
-                <Label className="text-xs text-muted-foreground">音乐模型</Label>
+                <Label className="text-xs text-muted-foreground">{t('tools.musicDialog.model')}</Label>
                 <Select
                   value={model}
                   onValueChange={setModel}
                   disabled={audioModels.length === 0}
                 >
                   <SelectTrigger className="bg-background">
-                    <SelectValue placeholder={audioModels.length === 0 ? "无可用音频模型" : "选择音乐模型"} />
+                    <SelectValue placeholder={audioModels.length === 0 ? t('tools.musicDialog.modelEmpty') : t('tools.musicDialog.modelSelect')} />
                   </SelectTrigger>
                   <SelectContent>
                     {audioModels.map((m) => (
@@ -166,7 +173,7 @@ export default function MusicGenConfigDialog({
               {/* 模型能力概览 */}
               {currentCaps && (
                 <div className="text-xs text-muted-foreground space-y-1 pt-2 border-t">
-                  <p className="font-medium">模型能力:</p>
+                  <p className="font-medium">{t('tools.musicDialog.modelCaps')}</p>
                   <div className="flex items-center gap-2">
                     <span className="px-1.5 py-0.5 bg-pink-100 dark:bg-pink-900 rounded text-[11px]">
                       {currentCaps.label}
@@ -178,13 +185,13 @@ export default function MusicGenConfigDialog({
 
               {/* 输出格式 */}
               <div className="space-y-1.5">
-                <Label className="text-xs text-muted-foreground">默认输出格式</Label>
+                <Label className="text-xs text-muted-foreground">{t('tools.musicDialog.outputFormat')}</Label>
                 <Select value={outputFormat} onValueChange={setOutputFormat}>
                   <SelectTrigger className="bg-background">
-                    <SelectValue placeholder="选择格式" />
+                    <SelectValue placeholder={t('tools.musicDialog.selectFormat')} />
                   </SelectTrigger>
                   <SelectContent>
-                    {OUTPUT_FORMAT_OPTIONS.map(opt => (
+                    {outputFormatOptions.map(opt => (
                       <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
                     ))}
                   </SelectContent>
@@ -196,10 +203,10 @@ export default function MusicGenConfigDialog({
 
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
-            取消
+            {t('common.buttons.cancel')}
           </Button>
           <Button onClick={handleSave} disabled={saving}>
-            {saving ? '保存中...' : '保存'}
+            {saving ? t('common.status.saving') : t('common.buttons.save')}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/backend/admin/src/components/admin/tools/VideoGenConfigDialog.tsx
+++ b/backend/admin/src/components/admin/tools/VideoGenConfigDialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useMemo, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   Dialog,
   DialogContent,
@@ -24,17 +25,6 @@ import { useToast } from '@/components/ui/use-toast';
 import { collectModelsByType } from '@/lib/api-utils';
 import { AlertCircle } from 'lucide-react';
 
-// 标签映射表
-const ASPECT_RATIO_LABELS: Record<string, string> = {
-  "1:1": "1:1 (方形)", "16:9": "16:9 (宽屏)", "9:16": "9:16 (手机)",
-  "4:3": "4:3 (标准)", "3:4": "3:4 (竖屏)", "3:2": "3:2", "2:3": "2:3",
-};
-
-const RESOLUTION_LABELS: Record<string, string> = {
-  "480p": "480p", "720p": "720p (标准)", "768p": "768p",
-  "1080p": "1080p (高清)", "4k": "4K (超高清)",
-};
-
 interface VideoGenConfigDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -55,6 +45,7 @@ export default function VideoGenConfigDialog({
   onSaveConfig,
 }: VideoGenConfigDialogProps) {
   const { toast } = useToast();
+  const { t } = useTranslation();
   const [saving, setSaving] = useState(false);
 
   // 本地表单状态
@@ -86,7 +77,7 @@ export default function VideoGenConfigDialog({
     [videoModels, model],
   );
 
-  // 当前选中模型的能力（从 videoCapabilities 查询参数选项，可选增强）
+  // 当前选中模型的能力
   const caps = useMemo(
     () => videoCapabilities?.[model],
     [videoCapabilities, model],
@@ -106,14 +97,14 @@ export default function VideoGenConfigDialog({
         } : null,
       };
       await onSaveConfig(config);
-      toast({ title: '保存成功', description: '视频生成工具配置已更新' });
+      toast({ title: t('tools.videoDialog.saveSuccess'), description: t('tools.videoDialog.saveSuccessDesc') });
       onSaved();
       onOpenChange(false);
     } catch (e: any) {
       toast({
         variant: 'destructive',
-        title: '保存失败',
-        description: e?.response?.data?.detail || '请重试',
+        title: t('tools.videoDialog.saveFailed'),
+        description: e?.response?.data?.detail || t('tools.videoDialog.retry'),
       });
     } finally {
       setSaving(false);
@@ -124,16 +115,14 @@ export default function VideoGenConfigDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-lg">
         <DialogHeader>
-          <DialogTitle>配置视频生成工具</DialogTitle>
-          <DialogDescription>
-            设置全局 generate_video 工具参数（所有智能体共享此配置）
-          </DialogDescription>
+          <DialogTitle>{t('tools.videoDialog.title')}</DialogTitle>
+          <DialogDescription>{t('tools.videoDialog.description')}</DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4 py-2">
           {/* 启用开关 */}
           <div className="flex items-center justify-between">
-            <Label className="text-sm">启用视频生成</Label>
+            <Label className="text-sm">{t('tools.videoDialog.enable')}</Label>
             <Switch checked={enabled} onCheckedChange={setEnabled} />
           </div>
 
@@ -143,15 +132,13 @@ export default function VideoGenConfigDialog({
               {videoModels.length === 0 && (
                 <div className="flex items-center gap-2 text-xs text-amber-600 dark:text-amber-500 bg-amber-50 dark:bg-amber-950 rounded-md p-3">
                   <AlertCircle className="h-4 w-4 shrink-0" />
-                  <span>
-                    未找到视频模型。请先在「供应商管理」中为供应商的模型设置「视频模型」类型。
-                  </span>
+                  <span>{t('tools.videoDialog.noModelWarning')}</span>
                 </div>
               )}
 
               {/* 视频模型（扁平列表，按 model_type 过滤） */}
               <div className="space-y-1.5">
-                <Label className="text-xs text-muted-foreground">视频模型</Label>
+                <Label className="text-xs text-muted-foreground">{t('tools.videoDialog.model')}</Label>
                 <Select
                   value={model}
                   onValueChange={(val) => {
@@ -163,7 +150,7 @@ export default function VideoGenConfigDialog({
                   disabled={videoModels.length === 0}
                 >
                   <SelectTrigger className="bg-background">
-                    <SelectValue placeholder={videoModels.length === 0 ? "无可用视频模型" : "选择视频模型"} />
+                    <SelectValue placeholder={videoModels.length === 0 ? t('tools.videoDialog.modelEmpty') : t('tools.videoDialog.modelSelect')} />
                   </SelectTrigger>
                   <SelectContent>
                     {videoModels.map((m) => (
@@ -178,7 +165,7 @@ export default function VideoGenConfigDialog({
 
               {model && !caps && (
                 <div className="text-xs text-muted-foreground bg-muted/50 rounded-md p-3">
-                  该模型暂无预设参数配置，将使用默认值。
+                  {t('tools.videoDialog.noCapsHint')}
                 </div>
               )}
 
@@ -186,10 +173,10 @@ export default function VideoGenConfigDialog({
                 <div className="grid grid-cols-3 gap-3">
                   {/* 时长 */}
                   <div className="space-y-1.5">
-                    <Label className="text-xs text-muted-foreground">时长 (秒)</Label>
+                    <Label className="text-xs text-muted-foreground">{t('tools.videoDialog.duration')}</Label>
                     <Select value={duration} onValueChange={setDuration}>
                       <SelectTrigger className="bg-background">
-                        <SelectValue placeholder="选择" />
+                        <SelectValue placeholder={t('tools.videoDialog.selectPlaceholder')} />
                       </SelectTrigger>
                       <SelectContent>
                         {caps.durations.map((d: number) => (
@@ -201,14 +188,14 @@ export default function VideoGenConfigDialog({
 
                   {/* 分辨率 */}
                   <div className="space-y-1.5">
-                    <Label className="text-xs text-muted-foreground">分辨率</Label>
+                    <Label className="text-xs text-muted-foreground">{t('tools.videoDialog.resolution')}</Label>
                     <Select value={quality} onValueChange={setQuality}>
                       <SelectTrigger className="bg-background">
-                        <SelectValue placeholder="选择" />
+                        <SelectValue placeholder={t('tools.videoDialog.selectPlaceholder')} />
                       </SelectTrigger>
                       <SelectContent>
                         {caps.resolutions.map((r: string) => (
-                          <SelectItem key={r} value={r}>{RESOLUTION_LABELS[r] || r}</SelectItem>
+                          <SelectItem key={r} value={r}>{t(`tools.resolutions.${r}`, { defaultValue: r })}</SelectItem>
                         ))}
                       </SelectContent>
                     </Select>
@@ -216,14 +203,14 @@ export default function VideoGenConfigDialog({
 
                   {/* 宽高比 */}
                   <div className="space-y-1.5">
-                    <Label className="text-xs text-muted-foreground">宽高比</Label>
+                    <Label className="text-xs text-muted-foreground">{t('tools.videoDialog.aspectRatio')}</Label>
                     <Select value={aspectRatio} onValueChange={setAspectRatio}>
                       <SelectTrigger className="bg-background">
-                        <SelectValue placeholder="选择" />
+                        <SelectValue placeholder={t('tools.videoDialog.selectPlaceholder')} />
                       </SelectTrigger>
                       <SelectContent>
                         {caps.aspect_ratios.map((ar: string) => (
-                          <SelectItem key={ar} value={ar}>{ASPECT_RATIO_LABELS[ar] || ar}</SelectItem>
+                          <SelectItem key={ar} value={ar}>{t(`tools.aspectRatios.${ar}`, { defaultValue: ar })}</SelectItem>
                         ))}
                       </SelectContent>
                     </Select>
@@ -234,15 +221,15 @@ export default function VideoGenConfigDialog({
               {/* 模型能力概览 */}
               {caps && (
                 <div className="text-xs text-muted-foreground space-y-1 pt-2 border-t">
-                  <p className="font-medium">模型能力:</p>
+                  <p className="font-medium">{t('tools.videoDialog.modelCaps')}</p>
                   <div className="flex flex-wrap gap-1.5">
                     {caps.modes.map((m: string) => (
                       <span key={m} className="px-1.5 py-0.5 bg-muted rounded text-[11px]">{m}</span>
                     ))}
-                    {caps.supports_audio && <span className="px-1.5 py-0.5 bg-blue-100 dark:bg-blue-900 rounded text-[11px]">原生音频</span>}
-                    {caps.supports_reference_images && <span className="px-1.5 py-0.5 bg-green-100 dark:bg-green-900 rounded text-[11px]">参考图片</span>}
-                    {caps.supports_video_edit && <span className="px-1.5 py-0.5 bg-orange-100 dark:bg-orange-900 rounded text-[11px]">视频编辑</span>}
-                    {caps.supports_video_extension && <span className="px-1.5 py-0.5 bg-purple-100 dark:bg-purple-900 rounded text-[11px]">视频扩展</span>}
+                    {caps.supports_audio && <span className="px-1.5 py-0.5 bg-blue-100 dark:bg-blue-900 rounded text-[11px]">{t('tools.videoDialog.supportsAudio')}</span>}
+                    {caps.supports_reference_images && <span className="px-1.5 py-0.5 bg-green-100 dark:bg-green-900 rounded text-[11px]">{t('tools.videoDialog.supportsReferenceImages')}</span>}
+                    {caps.supports_video_edit && <span className="px-1.5 py-0.5 bg-orange-100 dark:bg-orange-900 rounded text-[11px]">{t('tools.videoDialog.supportsVideoEdit')}</span>}
+                    {caps.supports_video_extension && <span className="px-1.5 py-0.5 bg-purple-100 dark:bg-purple-900 rounded text-[11px]">{t('tools.videoDialog.supportsVideoExtension')}</span>}
                   </div>
                 </div>
               )}
@@ -252,10 +239,10 @@ export default function VideoGenConfigDialog({
 
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
-            取消
+            {t('common.buttons.cancel')}
           </Button>
           <Button onClick={handleSave} disabled={saving}>
-            {saving ? '保存中...' : '保存'}
+            {saving ? t('common.status.saving') : t('common.buttons.save')}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/backend/admin/src/i18n/locales/en-US.json
+++ b/backend/admin/src/i18n/locales/en-US.json
@@ -629,7 +629,6 @@
       },
       "parameters": {
         "thinkingMode": "Thinking Mode",
-        "thinkingModeDesc": "Enable deep reasoning (supported by some models)",
         "on": "On",
         "off": "Off",
         "contextWindow": "Context Window",
@@ -790,6 +789,545 @@
         "failed": "Unable to load image",
         "continueEdit": "Continue Editing"
       }
+    }
+  },
+  "skills": {
+    "title": "Skills Management",
+    "subtitle": "Manage Agent extension capabilities. Skills are declarative toolkits that support hot-swapping and version control.",
+    "createBtn": "Create Skill",
+    "status": {
+      "active": "Active",
+      "inactive": "Inactive"
+    },
+    "source": {
+      "builtin": "Built-in",
+      "customized": "Custom",
+      "active": "Active"
+    },
+    "toast": {
+      "loadFailed": "Load failed",
+      "loadFailedDesc": "Unable to fetch the skills list, please check your network connection",
+      "loadDetailFailed": "Unable to fetch skill details",
+      "operationSuccess": "Operation successful",
+      "operationFailed": "Operation failed",
+      "toggleFailed": "An error occurred while toggling the skill status",
+      "deleteSuccess": "Deleted successfully",
+      "deleteSuccessDesc": "Skill {{name}} has been deleted",
+      "deleteFailed": "Delete failed",
+      "deleteFailedDesc": "An error occurred while deleting the skill",
+      "updateSuccess": "Skill updated successfully",
+      "createSuccess": "Skill created successfully",
+      "saveFailed": "Save failed",
+      "unknownError": "Unknown error"
+    },
+    "delete": {
+      "title": "Confirm Delete",
+      "description": "Are you sure you want to delete the skill \"{{name}}\"? This action cannot be undone.",
+      "cancel": "Cancel",
+      "confirm": "Delete"
+    },
+    "action": {
+      "edit": "Edit Config",
+      "enable": "Enable",
+      "disable": "Disable",
+      "back": "Back",
+      "save": "Save",
+      "saving": "Saving...",
+      "create": "Create Skill",
+      "creating": "Creating..."
+    },
+    "edit": {
+      "title": "Edit Skill",
+      "description": "Edit the configuration and content of skill \"{{name}}\""
+    },
+    "create": {
+      "title": "Create Skill",
+      "description": "Define a new Agent skill package using Markdown"
+    },
+    "form": {
+      "identifier": "Skill Identifier",
+      "identifierPlaceholder": "e.g. web_search",
+      "identifierHint": "Only letters, digits, underscores and hyphens are allowed",
+      "description": "Description",
+      "descriptionPlaceholder": "Briefly describe what this skill does...",
+      "version": "Version",
+      "content": "SKILL.md Content",
+      "contentHint": "Write skill instructions in Markdown. The Agent will reference this content to know how to use the skill.",
+      "contentPlaceholder": "# Skill Name\n\nDescribe the purpose and usage of this skill...\n\n## Example\n\n```\nExample invocation...\n```",
+      "autoEnable": "Enable automatically after creation"
+    }
+  },
+  "mcp": {
+    "title": "MCP Client Management",
+    "subtitle": "Model Context Protocol (MCP) allows Agents to dynamically connect to external tools and data sources. Supports seamless hot reload.",
+    "inDevelopment": {
+      "title": "Under Development",
+      "desc": "MCP client management is not yet available. Stay tuned."
+    }
+  },
+  "tools": {
+    "title": "Tools Management",
+    "subtitle": "View registered tool providers, configure tool parameters and execution statistics.",
+    "logsBtn": "Execution Logs",
+    "refresh": "Refresh",
+    "loading": "Loading...",
+    "card": {
+      "toolCountTitle": "Contains {{count}} tool(s)",
+      "viewDetail": "View Details",
+      "configBtn": "Configure"
+    },
+    "detail": {
+      "providerId": "Provider ID",
+      "enableCondition": "Enable Condition",
+      "noCondition": "No specific condition",
+      "includedTools": "Included Tools ({{count}})"
+    },
+    "imageDialog": {
+      "title": "Configure Image Generation Tool",
+      "description": "Configure global generate_image tool parameters (shared by all Agents)",
+      "enable": "Enable image generation",
+      "noModelWarning": "No image model found. Please set the model type to \"Image Model\" in Provider Management first.",
+      "model": "Image Model",
+      "modelEmpty": "No available image models",
+      "modelSelect": "Select image model",
+      "aspectRatio": "Aspect Ratio",
+      "quality": "Quality",
+      "selectPlaceholder": "Select",
+      "selectProviderFirst": "Please select a provider first",
+      "batchCount": "Images per batch",
+      "batchAuto": "Auto (decided by Agent)",
+      "batchN": "{{count}} image(s)",
+      "outputFormat": "Output Format",
+      "saveSuccess": "Saved",
+      "saveSuccessDesc": "Image generation tool configuration has been updated",
+      "saveFailed": "Save failed",
+      "retry": "Please retry"
+    },
+    "videoDialog": {
+      "title": "Configure Video Generation Tool",
+      "description": "Configure global generate_video tool parameters (shared by all Agents)",
+      "enable": "Enable video generation",
+      "noModelWarning": "No video model found. Please set the model type to \"Video Model\" in Provider Management first.",
+      "model": "Video Model",
+      "modelEmpty": "No available video models",
+      "modelSelect": "Select video model",
+      "noCapsHint": "This model has no preset parameters and will use default values.",
+      "duration": "Duration (seconds)",
+      "resolution": "Resolution",
+      "aspectRatio": "Aspect Ratio",
+      "selectPlaceholder": "Select",
+      "modelCaps": "Model Capabilities:",
+      "supportsAudio": "Native Audio",
+      "supportsReferenceImages": "Reference Images",
+      "supportsVideoEdit": "Video Editing",
+      "supportsVideoExtension": "Video Extension",
+      "saveSuccess": "Saved",
+      "saveSuccessDesc": "Video generation tool configuration has been updated",
+      "saveFailed": "Save failed",
+      "retry": "Please retry"
+    },
+    "musicDialog": {
+      "title": "Configure Music Generation Tool",
+      "description": "Configure global generate_music tool parameters (shared by all Agents)",
+      "enable": "Enable music generation",
+      "noModelWarning": "No audio model found. Please set the model type to \"Audio Model\" in Provider Management first.",
+      "model": "Music Model",
+      "modelEmpty": "No available audio models",
+      "modelSelect": "Select music model",
+      "modelCaps": "Model Capabilities:",
+      "outputFormat": "Default Output Format",
+      "selectFormat": "Select format",
+      "formats": {
+        "mp3": "MP3 (General)",
+        "wav": "WAV (Lossless, Pro only)"
+      },
+      "caps": {
+        "clipLabel": "Clip",
+        "clipDesc": "Short clip (~30s), MP3 only",
+        "proLabel": "Pro",
+        "proDesc": "Full song (3-5 min), MP3/WAV, with lyrics"
+      },
+      "saveSuccess": "Saved",
+      "saveSuccessDesc": "Music generation tool configuration has been updated",
+      "saveFailed": "Save failed",
+      "retry": "Please retry"
+    },
+    "aspectRatios": {
+      "auto": "Auto",
+      "1:1": "1:1 (Square)",
+      "16:9": "16:9 (Widescreen)",
+      "9:16": "9:16 (Phone)",
+      "4:3": "4:3 (Standard)",
+      "3:4": "3:4 (Portrait)",
+      "3:2": "3:2",
+      "2:3": "2:3",
+      "2:1": "2:1 (Ultra-wide)",
+      "1:2": "1:2 (Ultra-tall)"
+    },
+    "qualities": {
+      "standard": "Standard",
+      "hd": "HD",
+      "ultra": "Ultra HD"
+    },
+    "outputFormats": {
+      "png": "PNG",
+      "jpeg": "JPEG",
+      "webp": "WebP"
+    },
+    "resolutions": {
+      "480p": "480p",
+      "720p": "720p (SD)",
+      "768p": "768p",
+      "1080p": "1080p (HD)",
+      "4k": "4K (Ultra HD)"
+    }
+  },
+  "videos": {
+    "title": "Video Generation",
+    "subtitle": "Manage and monitor video generation tasks",
+    "newBtn": "New Video Task",
+    "empty": "No video tasks yet",
+    "totalCount": "{{count}} record(s)",
+    "status": {
+      "pending": "Queued",
+      "processing": "Processing",
+      "completed": "Completed",
+      "failed": "Failed"
+    },
+    "mode": {
+      "text_to_video": "Text-to-Video",
+      "image_to_video": "Image-to-Video",
+      "edit": "Video Edit",
+      "subject_reference": "Subject Reference"
+    },
+    "modeLong": {
+      "text_to_video": "Text to Video",
+      "image_to_video": "Image to Video",
+      "edit": "Video Editing",
+      "subject_reference": "Subject Reference Generation"
+    },
+    "delete": {
+      "title": "Confirm Delete",
+      "description": "After deletion, the video file and task record cannot be recovered. Continue?",
+      "success": "Deleted successfully",
+      "failed": "Delete failed",
+      "btn": "Delete",
+      "taskBtn": "Delete Task"
+    },
+    "preview": {
+      "title": "Video Preview",
+      "pendingHint": "Video generation is not yet complete",
+      "failedFallback": "Video generation failed",
+      "mode": "Mode: ",
+      "quality": "Quality: ",
+      "duration": "Duration: ",
+      "ratio": "Ratio: ",
+      "cost": "Cost: ",
+      "credits": "{{value}} credits",
+      "provider": "Provider: ",
+      "model": "Model: ",
+      "prompt": "Prompt: ",
+      "createdAt": "Created: {{time}}",
+      "completedAt": "Completed: {{time}}",
+      "elapsed": "Elapsed: {{time}}",
+      "durationSec": "{{value}}s",
+      "dash": "-"
+    },
+    "form": {
+      "title": "New Video Task",
+      "subtitle": "Configure parameters and generate new video content",
+      "sections": {
+        "model": "Model Configuration",
+        "video": "Video Settings",
+        "advanced": "Advanced Settings"
+      },
+      "provider": "Provider",
+      "selectProvider": "Select provider",
+      "model": "Model",
+      "selectModel": "Select model",
+      "selectProviderFirst": "Please select a provider first",
+      "supportModes": "Supported modes: {{modes}}",
+      "supportLastFrame": ", first-last frame generation",
+      "mode": "Generation Mode",
+      "singleModeHint": "This model only supports {{mode}} mode",
+      "prompt": "Prompt",
+      "promptPlaceholder": "Describe the video content you want to generate...",
+      "firstFrame": "First Frame Image URL",
+      "firstFramePlaceholder": "Enter image URL or base64 data URL",
+      "firstFrameHint": "This model requires a first frame image to generate the video",
+      "lastFrame": "Last Frame Image URL (optional)",
+      "lastFramePlaceholder": "Enter last frame image URL",
+      "lastFrameHint": "The video will end with this image, producing a first-to-last-frame transition",
+      "duration": "Duration",
+      "durationValue": "{{value}} sec",
+      "quality": "Quality",
+      "aspectRatio": "Aspect Ratio",
+      "promptOptimizer": "Prompt Optimizer",
+      "promptOptimizerDesc": "Automatically optimize the prompt for better generation results",
+      "fastPretreatment": "Fast Pretreatment",
+      "fastPretreatmentDesc": "Reduce optimization time and speed up generation",
+      "cancel": "Cancel",
+      "submit": "Submit Task",
+      "submitting": "Submitting..."
+    },
+    "toast": {
+      "submitSuccess": "Video task submitted",
+      "submitSuccessDesc": "The task has been queued, please wait for generation to complete",
+      "submitFailed": "Submit failed",
+      "unknownError": "Unknown error"
+    }
+  },
+  "virtualHumans": {
+    "title": "Virtual Humans Library",
+    "subtitle": "Manage Volcano Ark preset virtual humans for Seedance 2.0 real-person video generation",
+    "addBtn": "Add Human",
+    "empty": "No virtual humans yet",
+    "filter": {
+      "all": "All",
+      "male": "Male",
+      "female": "Female",
+      "stylePlaceholder": "Filter by style, e.g. realistic..."
+    },
+    "gender": {
+      "male": "Male",
+      "female": "Female"
+    },
+    "status": {
+      "active": "Active",
+      "inactive": "Inactive"
+    },
+    "card": {
+      "editConfig": "Edit Config",
+      "deleteBtn": "Delete"
+    },
+    "dialog": {
+      "createTitle": "Add Virtual Human",
+      "editTitle": "Edit Virtual Human",
+      "createDesc": "Add a new Volcano Ark preset virtual human",
+      "editDesc": "Modify the virtual human preset information"
+    },
+    "form": {
+      "assetId": "Asset ID",
+      "assetIdPlaceholder": "asset-xxxxxxxxx-xxxxx",
+      "name": "Name",
+      "namePlaceholder": "Virtual human name",
+      "gender": "Gender",
+      "style": "Style",
+      "stylePlaceholder": "realistic",
+      "preview": "Preview Image",
+      "previewAlt": "Preview",
+      "uploadHint": "Click to upload preview image",
+      "uploading": "Uploading...",
+      "formatHint": "Supports PNG, JPG, WEBP, up to 5MB, auto-compressed after upload",
+      "replace": "Replace",
+      "description": "Description",
+      "descriptionPlaceholder": "Optional description...",
+      "isActive": "Active",
+      "isInactive": "Inactive",
+      "sortOrder": "Sort Order",
+      "cancel": "Cancel",
+      "save": "Save Changes",
+      "create": "Create"
+    },
+    "toast": {
+      "fileTooBigTitle": "File too large",
+      "fileTooBigDesc": "Image size cannot exceed 5MB",
+      "formatUnsupportedTitle": "Unsupported format",
+      "formatUnsupportedDesc": "Only PNG, JPG and WEBP formats are supported",
+      "uploadSuccess": "Upload successful",
+      "uploadFailed": "Upload failed",
+      "uploadFailedFallback": "Upload failed",
+      "fieldsRequiredTitle": "Please fill in required fields",
+      "fieldsRequiredJoiner": ", ",
+      "createSuccess": "Created successfully",
+      "updateSuccess": "Updated successfully",
+      "createFailed": "Create failed",
+      "updateFailed": "Update failed",
+      "deleteSuccess": "Deleted successfully",
+      "deleteFailed": "Delete failed",
+      "unknownError": "Unknown error"
+    },
+    "delete": {
+      "title": "Confirm Delete",
+      "description": "The virtual human \"{{name}}\" is about to be deleted. This action cannot be undone.",
+      "cancel": "Cancel",
+      "confirm": "Delete"
+    }
+  },
+  "promptTemplates": {
+    "title": "Prompt Templates",
+    "subtitle": "Manage prompt templates used for AI generation",
+    "createBtn": "Create Template",
+    "searchPlaceholder": "Search template name or description...",
+    "filterAll": "All categories",
+    "filterPlaceholder": "Template category",
+    "table": {
+      "name": "Template Name",
+      "category": "Category",
+      "varsCount": "Variables",
+      "status": "Status",
+      "actions": "Actions",
+      "empty": "No templates yet. Click \"Create Template\" to add one.",
+      "loading": "Loading...",
+      "noDesc": "No description",
+      "varsUnit": "{{count}}"
+    },
+    "status": {
+      "active": "Active",
+      "inactive": "Disabled",
+      "default": "Default"
+    },
+    "delete": {
+      "title": "Confirm Delete?",
+      "description": "This action cannot be undone. The template \"{{name}}\" will be permanently deleted.",
+      "cancel": "Cancel",
+      "confirm": "Confirm Delete"
+    },
+    "toast": {
+      "deleteSuccess": "Template deleted successfully",
+      "deleteFailed": "Delete failed",
+      "createSuccess": "Template created successfully",
+      "createFailed": "Create failed",
+      "updateSuccess": "Template updated successfully",
+      "updateFailed": "Update failed",
+      "unknownError": "Unknown error"
+    },
+    "action": {
+      "back": "Back",
+      "save": "Save",
+      "saving": "Saving...",
+      "create": "Create Template",
+      "creating": "Creating...",
+      "addVariable": "Add Variable"
+    },
+    "create": {
+      "title": "Create Prompt Template",
+      "description": "Define a new AI generation prompt template"
+    },
+    "edit": {
+      "title": "Edit Prompt Template",
+      "description": "Edit the configuration and content of template \"{{name}}\""
+    },
+    "form": {
+      "name": "Template Name",
+      "namePlaceholder": "e.g. Story Setting Generation",
+      "description": "Description",
+      "descriptionPlaceholder": "Briefly describe the purpose of this template...",
+      "category": "Category Tag",
+      "categoryPlaceholder": "Custom category, max 12 chars",
+      "categoryHint": "Supports Chinese and English, up to 12 characters",
+      "contentTitle": "Prompt Content",
+      "varsUsageHintPrefix": "Use ",
+      "varsUsageHintSuffix": " to insert variables",
+      "systemPrompt": "System Prompt",
+      "systemPromptPlaceholder": "You are a professional theater plot designer...",
+      "userPrompt": "User Prompt (optional)",
+      "userPromptPlaceholderPrefix": "Generate content based on the following information...\n\nTheater name: ",
+      "varsTitle": "Input Variables",
+      "varsEmpty": "No variables yet. Click \"Add Variable\" to define placeholders in the prompt.",
+      "varIndex": "Variable #{{index}}",
+      "varName": "Variable Name (English)",
+      "varNamePlaceholder": "theater_name",
+      "varLabel": "Display Label",
+      "varLabelPlaceholder": "Theater Name",
+      "varType": "Type",
+      "varDescription": "Description (optional)",
+      "varDescriptionPlaceholder": "Variable description...",
+      "varRequired": "Required",
+      "statusActive": "Enable template",
+      "statusDefault": "Set as default for this category"
+    },
+    "varTypes": {
+      "string": "Single-line Text",
+      "textarea": "Multi-line Text",
+      "number": "Number",
+      "boolean": "Boolean",
+      "select": "Dropdown Select"
+    }
+  },
+  "admins": {
+    "title": "Admin Management",
+    "addBtn": "Add Admin",
+    "table": {
+      "email": "Email",
+      "nickname": "Nickname",
+      "permissionLevel": "Permission Level",
+      "credits": "Credits",
+      "status": "Status",
+      "lastLogin": "Last Login",
+      "actions": "Actions",
+      "loading": "Loading...",
+      "dash": "-"
+    },
+    "permission": {
+      "admin": "Admin",
+      "super_admin": "Super Admin"
+    },
+    "status": {
+      "enabled": "Enabled",
+      "disabled": "Disabled"
+    },
+    "tooltip": {
+      "adjustCredits": "Adjust Credits"
+    },
+    "create": {
+      "title": "Add Admin",
+      "description": "Create a new admin account",
+      "emailPlaceholder": "admin@example.com",
+      "nicknamePlaceholder": "Admin nickname",
+      "passwordPlaceholder": "At least 6 characters",
+      "submit": "Create",
+      "submitting": "Creating..."
+    },
+    "edit": {
+      "title": "Edit Admin",
+      "description": "Update info for admin {{name}}",
+      "passwordLabel": "New Password (leave empty to keep unchanged)",
+      "passwordPlaceholder": "Enter new password",
+      "isActive": "Active",
+      "submit": "Save",
+      "submitting": "Saving..."
+    },
+    "form": {
+      "email": "Email",
+      "nickname": "Nickname",
+      "password": "Password",
+      "permissionLevel": "Permission Level"
+    },
+    "validation": {
+      "emailInvalid": "Please enter a valid email",
+      "nicknameRequired": "Please enter a nickname",
+      "passwordMin": "Password must be at least 6 characters"
+    },
+    "delete": {
+      "title": "Confirm deletion?",
+      "description": "Delete admin \"{{name}}\"? This action cannot be undone.",
+      "cancel": "Cancel",
+      "confirm": "Confirm Delete"
+    },
+    "credits": {
+      "title": "Adjust Credits",
+      "description": "Admin: {{name}} | Current balance: {{balance}}",
+      "amountLabel": "Adjustment Amount",
+      "amountPlaceholder": "Positive = recharge, negative = deduct",
+      "noteLabel": "Note",
+      "notePlaceholder": "Optional: reason for adjustment",
+      "cancel": "Cancel",
+      "confirm": "Confirm",
+      "processing": "Processing..."
+    },
+    "toast": {
+      "createSuccess": "Created successfully",
+      "createSuccessDesc": "Admin {{name}} has been created",
+      "createFailed": "Creation failed",
+      "updateSuccess": "Updated successfully",
+      "updateFailed": "Update failed",
+      "deleteSuccess": "Deleted successfully",
+      "deleteSuccessDesc": "Admin {{name}} has been deleted",
+      "deleteFailed": "Deletion failed",
+      "creditsSuccess": "Credits adjusted successfully",
+      "creditsFailed": "Adjustment failed",
+      "retryLater": "Please try again later"
     }
   },
   "login": {

--- a/backend/admin/src/i18n/locales/zh-CN.json
+++ b/backend/admin/src/i18n/locales/zh-CN.json
@@ -629,7 +629,6 @@
       },
       "parameters": {
         "thinkingMode": "思考模式",
-        "thinkingModeDesc": "启用深度推理（仅部分模型支持）",
         "on": "开启",
         "off": "关闭",
         "contextWindow": "上下文窗口",
@@ -790,6 +789,545 @@
         "failed": "无法加载图片",
         "continueEdit": "继续编辑"
       }
+    }
+  },
+  "skills": {
+    "title": "技能管理 (Skills)",
+    "subtitle": "管理 Agent 的扩展能力。技能是声明式的工具包，支持热插拔和版本控制。",
+    "createBtn": "创建技能",
+    "status": {
+      "active": "运行中",
+      "inactive": "已停用"
+    },
+    "source": {
+      "builtin": "内置",
+      "customized": "自定义",
+      "active": "激活"
+    },
+    "toast": {
+      "loadFailed": "加载失败",
+      "loadFailedDesc": "无法获取技能列表，请检查网络连接",
+      "loadDetailFailed": "无法获取技能详情",
+      "operationSuccess": "操作成功",
+      "operationFailed": "操作失败",
+      "toggleFailed": "切换技能状态时发生错误",
+      "deleteSuccess": "删除成功",
+      "deleteSuccessDesc": "技能 {{name}} 已删除",
+      "deleteFailed": "删除失败",
+      "deleteFailedDesc": "删除技能时发生错误",
+      "updateSuccess": "技能更新成功",
+      "createSuccess": "技能创建成功",
+      "saveFailed": "保存失败",
+      "unknownError": "未知错误"
+    },
+    "delete": {
+      "title": "确认删除",
+      "description": "确定要删除技能「{{name}}」吗？此操作不可撤销。",
+      "cancel": "取消",
+      "confirm": "删除"
+    },
+    "action": {
+      "edit": "编辑配置",
+      "enable": "启用",
+      "disable": "停用",
+      "back": "返回",
+      "save": "保存",
+      "saving": "保存中...",
+      "create": "创建技能",
+      "creating": "创建中..."
+    },
+    "edit": {
+      "title": "编辑技能",
+      "description": "编辑技能「{{name}}」的配置与内容"
+    },
+    "create": {
+      "title": "创建技能",
+      "description": "使用 Markdown 定义一个新的 Agent 技能包"
+    },
+    "form": {
+      "identifier": "技能标识",
+      "identifierPlaceholder": "例如：web_search",
+      "identifierHint": "仅支持字母、数字、下划线和中划线",
+      "description": "描述",
+      "descriptionPlaceholder": "简要描述此技能的功能...",
+      "version": "版本",
+      "content": "SKILL.md 正文",
+      "contentHint": "使用 Markdown 编写技能说明。Agent 会根据此内容了解如何使用该技能。",
+      "contentPlaceholder": "# 技能名称\n\n描述该技能的用途和使用方式...\n\n## 使用示例\n\n```\n调用示例...\n```",
+      "autoEnable": "创建后自动启用"
+    }
+  },
+  "mcp": {
+    "title": "MCP 客户端管理",
+    "subtitle": "Model Context Protocol (MCP) 允许 Agent 动态连接到外部工具和数据源。支持无感热重载。",
+    "inDevelopment": {
+      "title": "功能开发中",
+      "desc": "MCP 客户端管理功能尚未实装，敬请期待"
+    }
+  },
+  "tools": {
+    "title": "工具管理",
+    "subtitle": "查看系统注册的工具 Provider、配置工具参数与执行统计。",
+    "logsBtn": "执行日志",
+    "refresh": "刷新",
+    "loading": "加载中...",
+    "card": {
+      "toolCountTitle": "包含 {{count}} 个工具",
+      "viewDetail": "查看详情",
+      "configBtn": "配置"
+    },
+    "detail": {
+      "providerId": "Provider ID",
+      "enableCondition": "启用条件",
+      "noCondition": "无特定条件",
+      "includedTools": "包含的工具 ({{count}})"
+    },
+    "imageDialog": {
+      "title": "配置图像生成工具",
+      "description": "设置全局 generate_image 工具参数（所有智能体共享此配置）",
+      "enable": "启用图像生成",
+      "noModelWarning": "未找到图像模型。请先在「供应商管理」中为供应商的模型设置「图像模型」类型。",
+      "model": "图像模型",
+      "modelEmpty": "无可用图像模型",
+      "modelSelect": "选择图像模型",
+      "aspectRatio": "宽高比",
+      "quality": "画质",
+      "selectPlaceholder": "选择",
+      "selectProviderFirst": "请先选择供应商",
+      "batchCount": "每次生成张数",
+      "batchAuto": "自动（智能体决定）",
+      "batchN": "{{count}} 张",
+      "outputFormat": "输出格式",
+      "saveSuccess": "保存成功",
+      "saveSuccessDesc": "图像生成工具配置已更新",
+      "saveFailed": "保存失败",
+      "retry": "请重试"
+    },
+    "videoDialog": {
+      "title": "配置视频生成工具",
+      "description": "设置全局 generate_video 工具参数（所有智能体共享此配置）",
+      "enable": "启用视频生成",
+      "noModelWarning": "未找到视频模型。请先在「供应商管理」中为供应商的模型设置「视频模型」类型。",
+      "model": "视频模型",
+      "modelEmpty": "无可用视频模型",
+      "modelSelect": "选择视频模型",
+      "noCapsHint": "该模型暂无预设参数配置，将使用默认值。",
+      "duration": "时长 (秒)",
+      "resolution": "分辨率",
+      "aspectRatio": "宽高比",
+      "selectPlaceholder": "选择",
+      "modelCaps": "模型能力:",
+      "supportsAudio": "原生音频",
+      "supportsReferenceImages": "参考图片",
+      "supportsVideoEdit": "视频编辑",
+      "supportsVideoExtension": "视频扩展",
+      "saveSuccess": "保存成功",
+      "saveSuccessDesc": "视频生成工具配置已更新",
+      "saveFailed": "保存失败",
+      "retry": "请重试"
+    },
+    "musicDialog": {
+      "title": "配置音乐生成工具",
+      "description": "设置全局 generate_music 工具参数（所有智能体共享此配置）",
+      "enable": "启用音乐生成",
+      "noModelWarning": "未找到音频模型。请先在「供应商管理」中为供应商的模型设置「音频模型」类型。",
+      "model": "音乐模型",
+      "modelEmpty": "无可用音频模型",
+      "modelSelect": "选择音乐模型",
+      "modelCaps": "模型能力:",
+      "outputFormat": "默认输出格式",
+      "selectFormat": "选择格式",
+      "formats": {
+        "mp3": "MP3 (通用)",
+        "wav": "WAV (无损，仅 Pro)"
+      },
+      "caps": {
+        "clipLabel": "Clip",
+        "clipDesc": "短音乐片段 (~30秒), 仅 MP3",
+        "proLabel": "Pro",
+        "proDesc": "完整歌曲 (3-5分钟), MP3/WAV, 支持歌词"
+      },
+      "saveSuccess": "保存成功",
+      "saveSuccessDesc": "音乐生成工具配置已更新",
+      "saveFailed": "保存失败",
+      "retry": "请重试"
+    },
+    "aspectRatios": {
+      "auto": "自动",
+      "1:1": "1:1 (方形)",
+      "16:9": "16:9 (宽屏)",
+      "9:16": "9:16 (手机)",
+      "4:3": "4:3 (标准)",
+      "3:4": "3:4 (竖屏)",
+      "3:2": "3:2",
+      "2:3": "2:3",
+      "2:1": "2:1 (超宽)",
+      "1:2": "1:2 (超高)"
+    },
+    "qualities": {
+      "standard": "标准",
+      "hd": "高清",
+      "ultra": "超高清"
+    },
+    "outputFormats": {
+      "png": "PNG",
+      "jpeg": "JPEG",
+      "webp": "WebP"
+    },
+    "resolutions": {
+      "480p": "480p",
+      "720p": "720p (标准)",
+      "768p": "768p",
+      "1080p": "1080p (高清)",
+      "4k": "4K (超高清)"
+    }
+  },
+  "videos": {
+    "title": "视频生成",
+    "subtitle": "管理和监控视频生成任务",
+    "newBtn": "新建视频任务",
+    "empty": "暂无视频任务",
+    "totalCount": "共 {{count}} 条记录",
+    "status": {
+      "pending": "排队中",
+      "processing": "生成中",
+      "completed": "已完成",
+      "failed": "失败"
+    },
+    "mode": {
+      "text_to_video": "文字生成",
+      "image_to_video": "图片生成",
+      "edit": "视频编辑",
+      "subject_reference": "主题参考生成"
+    },
+    "modeLong": {
+      "text_to_video": "文字生成视频",
+      "image_to_video": "图片生成视频",
+      "edit": "视频编辑",
+      "subject_reference": "主题参考生成"
+    },
+    "delete": {
+      "title": "确认删除",
+      "description": "删除后视频文件和任务记录将不可恢复，是否继续？",
+      "success": "删除成功",
+      "failed": "删除失败",
+      "btn": "删除",
+      "taskBtn": "删除任务"
+    },
+    "preview": {
+      "title": "视频预览",
+      "pendingHint": "视频尚未生成完成",
+      "failedFallback": "视频生成失败",
+      "mode": "模式：",
+      "quality": "画质：",
+      "duration": "时长：",
+      "ratio": "比例：",
+      "cost": "费用：",
+      "credits": "{{value}} 积分",
+      "provider": "供应商：",
+      "model": "模型：",
+      "prompt": "提示词：",
+      "createdAt": "创建: {{time}}",
+      "completedAt": "完成: {{time}}",
+      "elapsed": "耗时: {{time}}",
+      "durationSec": "{{value}}秒",
+      "dash": "-"
+    },
+    "form": {
+      "title": "新建视频任务",
+      "subtitle": "配置参数并生成新的视频内容",
+      "sections": {
+        "model": "模型配置",
+        "video": "视频设置",
+        "advanced": "高级设置"
+      },
+      "provider": "供应商",
+      "selectProvider": "选择供应商",
+      "model": "模型",
+      "selectModel": "选择模型",
+      "selectProviderFirst": "先选择供应商",
+      "supportModes": "支持模式: {{modes}}",
+      "supportLastFrame": "、首尾帧生成",
+      "mode": "生成模式",
+      "singleModeHint": "此模型仅支持{{mode}}模式",
+      "prompt": "提示词",
+      "promptPlaceholder": "描述你想生成的视频内容...",
+      "firstFrame": "首帧图片 URL",
+      "firstFramePlaceholder": "输入图片 URL 或 base64 data URL",
+      "firstFrameHint": "此模型需要提供首帧图片才能生成视频",
+      "lastFrame": "尾帧图片 URL (可选)",
+      "lastFramePlaceholder": "输入尾帧图片 URL",
+      "lastFrameHint": "视频将以这张图片结束，实现首尾帧过渡效果",
+      "duration": "时长",
+      "durationValue": "{{value}} 秒",
+      "quality": "画质",
+      "aspectRatio": "画面比例",
+      "promptOptimizer": "提示词优化",
+      "promptOptimizerDesc": "自动优化提示词以获得更好的生成效果",
+      "fastPretreatment": "快速预处理",
+      "fastPretreatmentDesc": "减少优化时间，加快生成速度",
+      "cancel": "取消",
+      "submit": "提交任务",
+      "submitting": "提交中..."
+    },
+    "toast": {
+      "submitSuccess": "视频任务已提交",
+      "submitSuccessDesc": "任务已进入队列，请等待生成完成",
+      "submitFailed": "提交失败",
+      "unknownError": "未知错误"
+    }
+  },
+  "virtualHumans": {
+    "title": "虚拟人像库",
+    "subtitle": "管理火山方舟预制虚拟人像，用于 Seedance 2.0 真人视频生成",
+    "addBtn": "添加人像",
+    "empty": "暂无虚拟人像",
+    "filter": {
+      "all": "全部",
+      "male": "男",
+      "female": "女",
+      "stylePlaceholder": "按风格筛选，如 realistic…"
+    },
+    "gender": {
+      "male": "男",
+      "female": "女"
+    },
+    "status": {
+      "active": "启用",
+      "inactive": "停用"
+    },
+    "card": {
+      "editConfig": "编辑配置",
+      "deleteBtn": "删除"
+    },
+    "dialog": {
+      "createTitle": "添加虚拟人像",
+      "editTitle": "编辑虚拟人像",
+      "createDesc": "添加一个新的火山方舟预制虚拟人像",
+      "editDesc": "修改虚拟人像预设信息"
+    },
+    "form": {
+      "assetId": "Asset ID",
+      "assetIdPlaceholder": "asset-xxxxxxxxx-xxxxx",
+      "name": "名称",
+      "namePlaceholder": "人像名称",
+      "gender": "性别",
+      "style": "风格",
+      "stylePlaceholder": "realistic",
+      "preview": "预览图",
+      "previewAlt": "预览",
+      "uploadHint": "点击上传预览图",
+      "uploading": "上传中…",
+      "formatHint": "支持 PNG、JPG、WEBP，最大 5MB，上传后自动压缩",
+      "replace": "更换",
+      "description": "描述",
+      "descriptionPlaceholder": "可选描述信息…",
+      "isActive": "启用",
+      "isInactive": "停用",
+      "sortOrder": "排序",
+      "cancel": "取消",
+      "save": "保存修改",
+      "create": "创建"
+    },
+    "toast": {
+      "fileTooBigTitle": "文件过大",
+      "fileTooBigDesc": "图片大小不能超过 5MB",
+      "formatUnsupportedTitle": "格式不支持",
+      "formatUnsupportedDesc": "仅支持 PNG、JPG、WEBP 格式",
+      "uploadSuccess": "上传成功",
+      "uploadFailed": "上传失败",
+      "uploadFailedFallback": "上传失败",
+      "fieldsRequiredTitle": "请填写必填项",
+      "fieldsRequiredJoiner": "、",
+      "createSuccess": "创建成功",
+      "updateSuccess": "更新成功",
+      "createFailed": "创建失败",
+      "updateFailed": "更新失败",
+      "deleteSuccess": "删除成功",
+      "deleteFailed": "删除失败",
+      "unknownError": "未知错误"
+    },
+    "delete": {
+      "title": "确认删除",
+      "description": "即将删除虚拟人像「{{name}}」，此操作不可撤销。",
+      "cancel": "取消",
+      "confirm": "删除"
+    }
+  },
+  "promptTemplates": {
+    "title": "提示词模板",
+    "subtitle": "管理 AI 生成使用的提示词模板",
+    "createBtn": "创建模板",
+    "searchPlaceholder": "搜索模板名称或描述...",
+    "filterAll": "全部分类",
+    "filterPlaceholder": "模板分类",
+    "table": {
+      "name": "模板名称",
+      "category": "分类",
+      "varsCount": "变量数",
+      "status": "状态",
+      "actions": "操作",
+      "empty": "暂无模板，点击「创建模板」开始添加",
+      "loading": "加载中...",
+      "noDesc": "暂无描述",
+      "varsUnit": "{{count}} 个"
+    },
+    "status": {
+      "active": "启用",
+      "inactive": "禁用",
+      "default": "默认"
+    },
+    "delete": {
+      "title": "确认删除？",
+      "description": "此操作不可撤销，将永久删除「{{name}}」模板。",
+      "cancel": "取消",
+      "confirm": "确认删除"
+    },
+    "toast": {
+      "deleteSuccess": "模板删除成功",
+      "deleteFailed": "删除失败",
+      "createSuccess": "模板创建成功",
+      "createFailed": "创建失败",
+      "updateSuccess": "模板更新成功",
+      "updateFailed": "更新失败",
+      "unknownError": "未知错误"
+    },
+    "action": {
+      "back": "返回",
+      "save": "保存",
+      "saving": "保存中...",
+      "create": "创建模板",
+      "creating": "创建中...",
+      "addVariable": "添加变量"
+    },
+    "create": {
+      "title": "创建提示词模板",
+      "description": "定义一个新的 AI 生成提示词模板"
+    },
+    "edit": {
+      "title": "编辑提示词模板",
+      "description": "编辑模板「{{name}}」的配置与内容"
+    },
+    "form": {
+      "name": "模板名称",
+      "namePlaceholder": "例如：故事设定生成",
+      "description": "描述",
+      "descriptionPlaceholder": "简要描述此模板的用途...",
+      "category": "分类标签",
+      "categoryPlaceholder": "自定义分类，最多12字",
+      "categoryHint": "支持中英文，最多12个字符",
+      "contentTitle": "提示词内容",
+      "varsUsageHintPrefix": "使用 ",
+      "varsUsageHintSuffix": " 插入变量",
+      "systemPrompt": "系统提示词",
+      "systemPromptPlaceholder": "你是一个专业的剧场剧情设计师...",
+      "userPrompt": "用户提示词（可选）",
+      "userPromptPlaceholderPrefix": "请根据以下信息生成内容...\n\n剧场名称：",
+      "varsTitle": "输入变量",
+      "varsEmpty": "暂无变量，点击「添加变量」定义提示词中的占位符",
+      "varIndex": "变量 #{{index}}",
+      "varName": "变量名（英文）",
+      "varNamePlaceholder": "theater_name",
+      "varLabel": "显示标签",
+      "varLabelPlaceholder": "剧场名称",
+      "varType": "类型",
+      "varDescription": "描述（可选）",
+      "varDescriptionPlaceholder": "变量说明...",
+      "varRequired": "必填",
+      "statusActive": "启用模板",
+      "statusDefault": "设为该类型默认模板"
+    },
+    "varTypes": {
+      "string": "单行文本",
+      "textarea": "多行文本",
+      "number": "数字",
+      "boolean": "布尔值",
+      "select": "下拉选择"
+    }
+  },
+  "admins": {
+    "title": "管理员管理",
+    "addBtn": "新增管理员",
+    "table": {
+      "email": "邮箱",
+      "nickname": "昵称",
+      "permissionLevel": "权限级别",
+      "credits": "积分",
+      "status": "状态",
+      "lastLogin": "最后登录",
+      "actions": "操作",
+      "loading": "加载中...",
+      "dash": "-"
+    },
+    "permission": {
+      "admin": "管理员",
+      "super_admin": "超级管理员"
+    },
+    "status": {
+      "enabled": "启用",
+      "disabled": "禁用"
+    },
+    "tooltip": {
+      "adjustCredits": "调整积分"
+    },
+    "create": {
+      "title": "新增管理员",
+      "description": "创建新的管理员账户",
+      "emailPlaceholder": "admin@example.com",
+      "nicknamePlaceholder": "管理员昵称",
+      "passwordPlaceholder": "至少 6 位",
+      "submit": "创建",
+      "submitting": "创建中..."
+    },
+    "edit": {
+      "title": "编辑管理员",
+      "description": "修改管理员 {{name}} 的信息",
+      "passwordLabel": "新密码（留空则不修改）",
+      "passwordPlaceholder": "输入新密码",
+      "isActive": "启用账户",
+      "submit": "保存",
+      "submitting": "保存中..."
+    },
+    "form": {
+      "email": "邮箱",
+      "nickname": "昵称",
+      "password": "密码",
+      "permissionLevel": "权限级别"
+    },
+    "validation": {
+      "emailInvalid": "请输入有效的邮箱地址",
+      "nicknameRequired": "请输入昵称",
+      "passwordMin": "密码至少 6 位"
+    },
+    "delete": {
+      "title": "确认删除？",
+      "description": "确定要删除管理员 \"{{name}}\" 吗？此操作不可撤销。",
+      "cancel": "取消",
+      "confirm": "确认删除"
+    },
+    "credits": {
+      "title": "调整积分",
+      "description": "管理员: {{name}} | 当前余额: {{balance}}",
+      "amountLabel": "调整数量",
+      "amountPlaceholder": "正数=充值，负数=扣减",
+      "noteLabel": "备注说明",
+      "notePlaceholder": "可选：填写调整原因",
+      "cancel": "取消",
+      "confirm": "确认调整",
+      "processing": "处理中..."
+    },
+    "toast": {
+      "createSuccess": "创建成功",
+      "createSuccessDesc": "管理员 {{name}} 已创建",
+      "createFailed": "创建失败",
+      "updateSuccess": "更新成功",
+      "updateFailed": "更新失败",
+      "deleteSuccess": "删除成功",
+      "deleteSuccessDesc": "管理员 {{name}} 已删除",
+      "deleteFailed": "删除失败",
+      "creditsSuccess": "积分调整成功",
+      "creditsFailed": "调整失败",
+      "retryLater": "请稍后重试"
     }
   },
   "login": {

--- a/backend/services/chat_generation.py
+++ b/backend/services/chat_generation.py
@@ -564,88 +564,97 @@ async def generate_single_agent(
 
     async def _persist_message_and_billing():
         """Background task: save message, update stats, deduct credits.
-        
+
+        分两阶段持久化，降低 SQLite 写锁冲突概率：
+        - Phase 1: 独立短事务保存 assistant 消息（最关键，必须落库）
+        - Phase 2: 统计 / 扣费 / compaction（允许失败，不阻塞用户看到回复）
+
         Runs independently of the SSE request lifecycle so client disconnect
         cannot cancel the database writes.
         """
         nonlocal billing_event
+
+        # -------- Phase 1: 消息落库（短事务 + 指数退避重试） --------
+        _MAX_MSG_RETRIES = 5
+        assistant_msg_id = None
+        for attempt in range(_MAX_MSG_RETRIES):
+            try:
+                async with AsyncSessionLocal() as session:
+                    assistant_msg = ChatMessage(
+                        session_id=session_id, role="assistant", content=final_content,
+                    )
+                    session.add(assistant_msg)
+                    await session.commit()
+                    assistant_msg_id = assistant_msg.id
+                break
+            except Exception as exc:
+                is_locked = "database is locked" in str(exc)
+                remaining = _MAX_MSG_RETRIES - attempt - 1
+                # 非锁错误或耗尽重试 → 放弃
+                fatal = (not is_locked) or (remaining <= 0)
+                log_fn = logger.error if fatal else logger.warning
+                log_fn("Background message save attempt %d/%d failed: %s",
+                       attempt + 1, _MAX_MSG_RETRIES, exc)
+                if fatal:
+                    return
+                # 指数退避：0.5s, 1s, 2s, 4s, 8s
+                await asyncio.sleep(0.5 * (2 ** attempt))
+
+        # -------- Phase 2: 统计 + 扣费 + compaction（独立事务，失败可容忍） --------
         try:
             async with AsyncSessionLocal() as session:
-                assistant_msg = ChatMessage(
-                    session_id=session_id,
-                    role="assistant",
-                    content=final_content,
-                )
-                session.add(assistant_msg)
+                # no_autoflush 避免 query 时触发隐式 flush 与其他写者抢锁
+                async with session.no_autoflush:
+                    from sqlalchemy import func as sa_func
+                    s_result = await session.execute(select(ChatSession).filter(ChatSession.id == session_id))
+                    s = s_result.scalars().first()
+                    s and setattr(s, 'updated_at', sa_func.now())
+                    s and setattr(s, 'total_tokens_used', (s.total_tokens_used or 0) + result.input_tokens + result.output_tokens)
+                    s and setattr(s, 'last_round_tokens', result.input_tokens + result.output_tokens)
 
-                # 更新会话时间戳和累计 token 使用量
-                from sqlalchemy import func as sa_func
-                s_result = await session.execute(select(ChatSession).filter(ChatSession.id == session_id))
-                s = s_result.scalars().first()
-                s and setattr(s, 'updated_at', sa_func.now())
-                s and setattr(s, 'total_tokens_used', (s.total_tokens_used or 0) + result.input_tokens + result.output_tokens)
-                s and setattr(s, 'last_round_tokens', result.input_tokens + result.output_tokens)
+                    # 查询实体并更新统计（映射表驱动，避免 if-else）
+                    entity_model_map = {True: Admin, False: User}
+                    entity_model = entity_model_map[is_admin]
+                    e_result = await session.execute(select(entity_model).filter(entity_model.id == entity_id))
+                    entity = e_result.scalars().first()
+                    entity and setattr(entity, 'total_input_tokens', (entity.total_input_tokens or 0) + result.input_tokens)
+                    entity and setattr(entity, 'total_output_tokens', (entity.total_output_tokens or 0) + result.output_tokens)
+                    entity and setattr(entity, 'total_input_chars', (entity.total_input_chars or 0) + input_chars)
+                    entity and setattr(entity, 'total_output_chars', (entity.total_output_chars or 0) + len(result.full_response))
 
-                # 查询实体并更新统计（映射表驱动，避免 if-else）
-                entity_model_map = {True: Admin, False: User}
-                entity_model = entity_model_map[is_admin]
-                e_result = await session.execute(select(entity_model).filter(entity_model.id == entity_id))
-                entity = e_result.scalars().first()
-                if entity:
-                    entity.total_input_tokens = (entity.total_input_tokens or 0) + result.input_tokens
-                    entity.total_output_tokens = (entity.total_output_tokens or 0) + result.output_tokens
-                    entity.total_input_chars = (entity.total_input_chars or 0) + input_chars
-                    entity.total_output_chars = (entity.total_output_chars or 0) + len(result.full_response)
+                    # 积分扣费（统一原子扣费，User 和 Admin 均走 deduct_credits_atomic）
+                    credit_cost, billing_metadata = calculate_credit_cost(result, agent)
+                    billing_event["credit_cost"] = round(credit_cost, 6)
 
-                # 积分扣费（统一原子扣费，User 和 Admin 均走 deduct_credits_atomic）
-                credit_cost, billing_metadata = calculate_credit_cost(result, agent)
-                billing_event["credit_cost"] = round(credit_cost, 6)
+                    try:
+                        (credit_cost > 0) and await deduct_credits_atomic(
+                            user_id=entity_id,
+                            cost=credit_cost,
+                            session=session,
+                            metadata=billing_metadata,
+                            transaction_type="consumption",
+                            idempotency_key=f"chat:{assistant_msg_id}",
+                        )
+                    except InsufficientCreditsError:
+                        billing_event["insufficient"] = True
+                        logger.warning(f"Credits depleted for {'admin' if is_admin else 'user'} {entity_id}. Cost: {credit_cost}")
+                    except BalanceFrozenError:
+                        billing_event["frozen"] = True
+                        logger.warning(f"Balance frozen for {entity_id}")
 
-                try:
-                    (credit_cost > 0) and await deduct_credits_atomic(
-                        user_id=entity_id,
-                        cost=credit_cost,
-                        session=session,
-                        metadata=billing_metadata,
-                        transaction_type="consumption",
-                        idempotency_key=f"chat:{assistant_msg.id}",
+                    # Post-generation deferred compaction
+                    from services.context_compaction import compact_context
+                    _persist_state["compaction"] = await compact_context(
+                        _messages_snapshot, agent, provider, session, session_id,
+                        session_obj=s,
+                        actual_total_tokens=result.input_tokens + result.output_tokens,
                     )
-                except InsufficientCreditsError:
-                    billing_event["insufficient"] = True
-                    logger.warning(f"Credits depleted for {'admin' if is_admin else 'user'} {entity_id}. Cost: {credit_cost}")
-                except BalanceFrozenError:
-                    billing_event["frozen"] = True
-                    logger.warning(f"Balance frozen for {entity_id}")
-
-                # Post-generation deferred compaction
-                from services.context_compaction import compact_context
-                _persist_state["compaction"] = await compact_context(
-                    _messages_snapshot, agent, provider, session, session_id,
-                    session_obj=s,
-                    actual_total_tokens=result.input_tokens + result.output_tokens,
-                )
 
                 await session.commit()
                 logger.info("Message/billing saved successfully (background)")
-
         except Exception as e:
-            logger.error(f"Background save failed: {e}")
-            # Retry: save message only with a fresh session
-            for _retry in range(2):
-                logger.warning(f"Background save retry ({_retry + 1}/2)...")
-                await asyncio.sleep(1.0 * (_retry + 1))
-                try:
-                    async with AsyncSessionLocal() as retry_session:
-                        retry_msg = ChatMessage(
-                            session_id=session_id, role="assistant", content=final_content,
-                        )
-                        retry_session.add(retry_msg)
-                        await retry_session.commit()
-                    logger.info("Message saved on background retry %d", _retry + 1)
-                    return
-                except Exception as retry_exc:
-                    logger.warning(f"Background retry {_retry + 1} failed: {retry_exc}")
-            logger.error(f"All background save retries failed for session {session_id}")
+            # Phase 2 失败不影响消息可见性，仅记录告警
+            logger.warning(f"Background stats/billing save failed (message already persisted): {e}")
 
     # 启动后台保存任务，使用 asyncio.shield 保护任务不被请求取消影响
     try:

--- a/backend/services/tool_execution_logger.py
+++ b/backend/services/tool_execution_logger.py
@@ -41,8 +41,10 @@ def _sanitize_args(args: dict) -> dict:
     return {k: v for k, v in args.items() if k not in _SENSITIVE_KEYS}
 
 
-_MAX_RETRIES = 3
+_MAX_RETRIES = 5
 _RETRY_BASE_DELAY = 1.0  # seconds
+# 首次延迟较长，让主聊天流程的消息落库事务先完成，避免与主写者竞争
+_INITIAL_DELAY = 1.5
 
 
 async def _write_record(
@@ -56,13 +58,15 @@ async def _write_record(
     """Persist a ToolExecution record using an independent DB session.
 
     Retries on database-locked errors with exponential backoff.
+    首次延迟 1.5s 等主聊天事务提交；失败后按 1s, 2s, 4s, 8s 退避。
     """
     from models import ToolExecution
 
+    # 初始延迟：让主流程的消息保存事务先落地，减少写锁竞争
+    await asyncio.sleep(_INITIAL_DELAY)
+
     for attempt in range(_MAX_RETRIES):
         try:
-            # Small initial delay to reduce contention with the main chat flow
-            await asyncio.sleep(0.3 * (attempt + 1))
             async with AsyncSessionLocal() as session:
                 record = ToolExecution(
                     tool_name=tool_name,

--- a/backend/skills/active_skills/image_tools/SKILL.md
+++ b/backend/skills/active_skills/image_tools/SKILL.md
@@ -2,7 +2,7 @@
 name: image_tools
 description: "AI image generation and editing. Provides generate_image and edit_image tools for creating and modifying images."
 metadata:
-  builtin_skill_version: "1.1"
+  builtin_skill_version: "1.2"
 ---
 # Image Tools
 
@@ -51,7 +51,7 @@ Edit or generate an image **using one or more reference images as the visual bas
 - **Character consistency**: User wants to maintain a character's appearance across different scenes or poses.
 - **Style transfer**: Transform an image into a different art style while preserving the content.
 - **Inpainting / Partial edit**: Modify a specific region of an image while keeping everything else unchanged (e.g. "change the sofa color", "remove the person in the background").
-- **Multi-image composition**: Combine elements from multiple reference images into a new scene (e.g. "put the dress from image 1 on the person in image 2").
+- **Multi-image composition**: Combine elements from multiple reference images (up to 10) into a new scene (e.g. "put the dress from image 1 on the person in image 2").
 - **High-fidelity preservation**: Preserve critical details (face, logo, text) while making other changes.
 
 **Key decision rule**: Whenever a reference image exists (from canvas, chat history, or user upload) and the user wants the output to visually relate to it, use `edit_image`. Only use `generate_image` when creating from pure text with no visual reference.
@@ -61,7 +61,7 @@ Edit or generate an image **using one or more reference images as the visual bas
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `image_url` | string | No* | Single reference image URL/path (e.g. `/api/media/filename.jpg`). Do NOT pass base64. |
-| `image_urls` | string[] | No* | Multiple reference image URLs/paths (up to 5). Use for multi-image composition. |
+| `image_urls` | string[] | No* | Multiple reference image URLs/paths (up to 10). Use for multi-image composition. |
 | `prompt` | string | Yes | Description of the desired output. See [Edit Prompt Patterns](#edit-prompt-patterns) below for templates. |
 | `aspect_ratio` | string | No | Output aspect ratio. Single-image edit follows input; multi-image defaults to first image (can be overridden). |
 | `quality` | string | No | Output quality ("standard" or "hd"). Default uses global config. |
@@ -123,6 +123,30 @@ The tool returns the edited/generated image URL in markdown format.
 | "Put dress from image A on person from image B" | `edit_image` + `image_urls` | Multi-image composition |
 | "Add this logo to her t-shirt" (2 images) | `edit_image` + `image_urls` | High-fidelity detail merging |
 | "Refer to my original two character sheets" | `edit_image` + `image_urls` | Combining elements from multiple sources |
+
+---
+
+## Reference Image Categories (Gemini 3)
+
+Gemini 3 image models support mixing up to 10 reference images in a single `edit_image` call. Reference images fall into two semantic categories, and the model handles each differently:
+
+| Category | Purpose | Best For | Examples |
+|----------|---------|----------|----------|
+| **Object reference (high-fidelity)** | Preserve the exact appearance of a specific object | Products, logos, clothing, props, text, branding | "use the bag from image 1", "put this logo on the shirt", "place the product in the scene" |
+| **Character reference (consistency)** | Keep a character's identity consistent across scenes/poses | People, creatures, stylized characters — faces, hair, outfits | "the same woman from image 2 now in a forest", "these 3 people making funny faces" |
+
+**Recommended mix in a single call** (aligned with Gemini 3's internal routing):
+
+- Up to ~6 object-reference images for high-fidelity embedding (logos, products, outfits to preserve pixel-accurately)
+- Up to ~5 character-reference images for identity consistency (faces and features that must stay recognizable)
+- Combined total must stay within the `image_urls` cap of 10
+
+### Referencing Tips
+
+- **Be explicit about roles**: in the prompt, refer to each image by order, e.g. *"Take the dress from image 1, the handbag from image 2, and put them on the woman from image 3"*.
+- **Declare intent per image**: object-reference → use verbs like "use", "include", "place"; character-reference → use "the same person/character from image X".
+- **Group photos of multiple characters**: pass each character's reference separately (e.g. person1.png … person5.png) and describe the scene — e.g. *"An office group photo of these 5 people making funny faces"*.
+- **Aspect ratio**: defaults to the first image; pass `aspect_ratio` explicitly to override.
 
 ---
 
@@ -245,7 +269,7 @@ Generate a character reference sheet from a single image.
 - **Always write prompts in English** for best quality, even when the user speaks another language.
 - For `edit_image`, use the file path from canvas nodes or previous generations — never paste base64 data.
 - When multiple images are needed from the same prompt, set `n` parameter on `generate_image` instead of calling multiple times.
-- **Multi-image editing**: When the user references multiple images (e.g. "refer to the two character images I sent earlier"), use `image_urls` array. Up to 5 images supported.
+- **Multi-image editing**: When the user references multiple images (e.g. "refer to the two character images I sent earlier"), use `image_urls` array. Up to 10 images supported.
 - **Single vs multi aspect ratio**: Single-image edit always follows the input image's aspect ratio (cannot be overridden). Multi-image edit defaults to the first image but can be overridden with `aspect_ratio`.
 - **Iterative refinement**: Use each edit output as the input for the next edit to progressively refine — describe only the incremental changes needed.
 - **Accurate text in images**: To render text in generated images, put the desired text in quotes and describe its placement clearly (e.g. 'the word "HELLO" in bold serif font centered on the banner').

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -45736,9 +45736,9 @@
       }
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmmirror.com/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmmirror.com/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -93,5 +93,8 @@
     "tailwindcss": "^4",
     "ts-jest": "^29.4.6",
     "typescript": "^5"
+  },
+  "overrides": {
+    "handlebars": "^4.7.9"
   }
 }


### PR DESCRIPTION
- 管理员管理页面使用 react-i18next 实现文本内容动态翻译
- 动态构建表单验证 Schema，支持多语言验证提示信息
- 更新管理员列表、表格、弹窗、按钮等所有文字为多语言资源
- MCP 客户端管理页添加国际化支持，替换静态文本
- 提示词模板列表、编辑、新建页面全面国际化改造
- 优化提示词模板变量类型选择的国际化展示
- 统一调整所有成功/失败提示的多语言支持和友好展示
- 修正部分表单占位符、标签、按钮文本为多语言文案
- 保持功能逻辑不变，提升多语言环境下用户体验