### PR TITLE
feat(canvas): 添加图像标注功能组件与交互支持

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -49,6 +49,7 @@
         "framer-motion": "^12.34.3",
         "html-to-image": "^1.11.13",
         "i18next": "^26.0.3",
+        "konva": "^10.3.0",
         "lodash.debounce": "^4.0.8",
         "lodash.throttle": "^4.1.1",
         "lucide-react": "^1.8.0",
@@ -58,6 +59,7 @@
         "react-dom": "19.2.3",
         "react-hotkeys-hook": "^5.2.4",
         "react-i18next": "^17.0.2",
+        "react-konva": "^19.2.3",
         "react-markdown": "^9.1.0",
         "react-syntax-highlighter": "^15.6.1",
         "react-window": "^2.2.7",
@@ -6149,6 +6151,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmmirror.com/@types/react-reconciler/-/react-reconciler-0.33.0.tgz",
+      "integrity": "sha512-HZOXsKT0tGI9LlUw2LuedXsVeB88wFa536vVL0M6vE8zN63nI+sSr1ByxmPToP5K5bukaVscyeCJcF9guVNJ1g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/react-syntax-highlighter": {
@@ -46251,6 +46262,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/its-fine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/its-fine/-/its-fine-2.0.0.tgz",
+      "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.9"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "node_modules/its-fine/node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmmirror.com/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmmirror.com/jackspeak/-/jackspeak-3.4.3.tgz",
@@ -47275,6 +47307,26 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/konva": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmmirror.com/konva/-/konva-10.3.0.tgz",
+      "integrity": "sha512-gt19K2gzY4lHbnkvsku7eSmB+A9PTS2jG4F9coBMsdjM1UKfJNxJbDbXVpeCW1wjEGRwBD3nBamcHnqJhAeKlg==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/lavrton"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/konva"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/lavrton"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -49699,10 +49751,6 @@
         "react": "^19.2.3"
       }
     },
-    "node_modules/react-dom/node_modules/scheduler": {
-      "version": "0.27.0",
-      "license": "MIT"
-    },
     "node_modules/react-hotkeys-hook": {
       "version": "5.2.4",
       "resolved": "https://registry.npmmirror.com/react-hotkeys-hook/-/react-hotkeys-hook-5.2.4.tgz",
@@ -49746,6 +49794,37 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
+    "node_modules/react-konva": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmmirror.com/react-konva/-/react-konva-19.2.3.tgz",
+      "integrity": "sha512-VsO5CJZwUo12xFa33UEIDOQn6ZZBeE6jlkStGFvpR/3NiDA/9RPQTzw6Ri++C0Pnh3Arco1AehB8qJNv9YCRwg==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/lavrton"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/konva"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/lavrton"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.33.0",
+        "its-fine": "^2.0.0",
+        "react-reconciler": "0.33.0",
+        "scheduler": "0.27.0"
+      },
+      "peerDependencies": {
+        "konva": "^8.0.1 || ^7.2.5 || ^9.0.0 || ^10.0.0",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0"
+      }
+    },
     "node_modules/react-markdown": {
       "version": "9.1.0",
       "resolved": "https://registry.npmmirror.com/react-markdown/-/react-markdown-9.1.0.tgz",
@@ -49771,6 +49850,21 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmmirror.com/react-reconciler/-/react-reconciler-0.33.0.tgz",
+      "integrity": "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
       }
     },
     "node_modules/react-redux": {
@@ -50284,6 +50378,12 @@
       "engines": {
         "node": ">=v12.22.7"
       }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmmirror.com/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/scroll-into-view-if-needed": {
       "version": "3.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,6 +52,7 @@
     "framer-motion": "^12.34.3",
     "html-to-image": "^1.11.13",
     "i18next": "^26.0.3",
+    "konva": "^10.3.0",
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",
     "lucide-react": "^1.8.0",
@@ -61,6 +62,7 @@
     "react-dom": "19.2.3",
     "react-hotkeys-hook": "^5.2.4",
     "react-i18next": "^17.0.2",
+    "react-konva": "^19.2.3",
     "react-markdown": "^9.1.0",
     "react-syntax-highlighter": "^15.6.1",
     "react-window": "^2.2.7",
@@ -94,7 +96,6 @@
     "jest-environment-jsdom": "^30.2.0",
     "sass": "^1.98.0",
     "tailwindcss": "^4",
-
     "ts-jest": "^29.4.6",
     "typescript": "^5"
   },

--- a/frontend/src/components/canvas/ImageNode.tsx
+++ b/frontend/src/components/canvas/ImageNode.tsx
@@ -24,6 +24,7 @@ import { useImagePreview } from '@/hooks/useImagePreview';
 import { useImageNodeConnections } from '@/hooks/useImageNodeConnections';
 import { useImageGenerationApply } from '@/hooks/useImageGenerationApply';
 import { useQuickImageMode } from '@/hooks/useQuickImageMode';
+import { useAnnotationExport } from '@/hooks/useAnnotationExport';
 
 // ── 子组件 ──
 import { MAX_IMAGES } from './ImageNode/constants';
@@ -81,6 +82,14 @@ const CharacterNode = ({ id, data, selected }: NodeProps<Node<CharacterNodeData>
 
   // ── 图像预览 ──
   const preview = useImagePreview();
+
+  // ── 标注保存 ──
+  const annotationExport = useAnnotationExport(id, data);
+  const handleSaveAnnotation = useCallback(async (dataUrl: string | null) => {
+    const newUrl = await annotationExport.saveAnnotation(dataUrl);
+    newUrl && preview.setPreviewUrl(newUrl);
+    return newUrl;
+  }, [annotationExport, preview]);
 
   // ── 快捷模式切换 ──
   const quick = useQuickImageMode(id, data, imageList, normalizeImageUrl);
@@ -441,12 +450,19 @@ const CharacterNode = ({ id, data, selected }: NodeProps<Node<CharacterNodeData>
         scale={preview.scale}
         position={preview.position}
         isDragging={preview.isDragging}
+        mode={preview.mode}
         onClose={preview.closePreview}
         onZoomIn={preview.zoomIn}
         onZoomOut={preview.zoomOut}
         onPointerDown={preview.handlePointerDown}
         onPointerMove={preview.handlePointerMove}
         onPointerUp={preview.handlePointerUp}
+        annotationEnabled
+        isFull={annotationExport.isFull}
+        isSaving={annotationExport.isSaving}
+        onEnterAnnotate={preview.enterAnnotate}
+        onExitAnnotate={preview.exitAnnotate}
+        onSaveAnnotation={handleSaveAnnotation}
       />
     </>
   );

--- a/frontend/src/components/canvas/ImageNode/AnnotationCanvas.tsx
+++ b/frontend/src/components/canvas/ImageNode/AnnotationCanvas.tsx
@@ -1,0 +1,276 @@
+'use client';
+
+import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import { Stage, Layer, Image as KonvaImage, Line, Text as KonvaText } from 'react-konva';
+import type Konva from 'konva';
+import type { KonvaEventObject } from 'konva/lib/Node';
+import type { Stage as StageType } from 'konva/lib/Stage';
+import type { AnnotationStateApi, TextShape } from '@/hooks/useAnnotationState';
+
+export interface AnnotationCanvasHandle {
+  getMergedDataURL: (pixelRatio?: number) => string | null;
+  getNaturalSize: () => { width: number; height: number } | null;
+}
+
+interface Props {
+  url: string;
+  api: AnnotationStateApi;
+  /** 可视区域尺寸（在父级提供 contain 适配） */
+  viewportWidth: number;
+  viewportHeight: number;
+}
+
+/**
+ * 加载远端图片为 HTMLImageElement（带 crossOrigin），返回 [image, error]。
+ */
+function useImageElement(src: string): { image: HTMLImageElement | null; error: string | null } {
+  const [state, setState] = useState<{ image: HTMLImageElement | null; error: string | null; src: string }>({
+    image: null,
+    error: null,
+    src: '',
+  });
+
+  useEffect(() => {
+    if (!src) return;
+    let cancelled = false;
+    const img = new window.Image();
+    img.crossOrigin = 'anonymous';
+    img.onload = () => { cancelled || setState({ image: img, error: null, src }); };
+    img.onerror = () => { cancelled || setState({ image: null, error: 'Failed to load image', src }); };
+    img.src = src;
+    return () => {
+      cancelled = true;
+      img.onload = null;
+      img.onerror = null;
+    };
+  }, [src]);
+
+  // 当 src 变化但新图未加载完成时，返回空以避免显示旧图
+  const stale = state.src !== src;
+  return {
+    image: stale ? null : state.image,
+    error: stale ? null : state.error,
+  };
+}
+
+/**
+ * Konva 画板：底图（KonvaImage）+ 涂鸦层 + 文字层。
+ * - 内部坐标系基于图像原始分辨率（保证保存合成的清晰度）
+ * - 外部 contain 适配通过 Stage scale + size 实现
+ */
+const AnnotationCanvas = forwardRef<AnnotationCanvasHandle, Props>(function AnnotationCanvas(
+  { url, api, viewportWidth, viewportHeight },
+  ref,
+) {
+  const stageRef = useRef<StageType | null>(null);
+  const { image, error } = useImageElement(url);
+
+  // 文字编辑：双击文字进入 textarea；新增文本：点击空白
+  const [editingText, setEditingText] = useState<{ id: string | null; x: number; y: number; value: string } | null>(null);
+
+  // 计算 contain 缩放与偏移
+  const naturalW = image?.naturalWidth || 0;
+  const naturalH = image?.naturalHeight || 0;
+  const scale = (naturalW > 0 && naturalH > 0)
+    ? Math.min(viewportWidth / naturalW, viewportHeight / naturalH)
+    : 1;
+  const stageW = naturalW * scale;
+  const stageH = naturalH * scale;
+
+  useImperativeHandle(ref, () => ({
+    getMergedDataURL: (pixelRatio = 2) => {
+      const stage = stageRef.current;
+      if (!stage || !naturalW || !naturalH) return null;
+      // 使用 1/scale 把 stage 还原回原图分辨率，再乘以 pixelRatio 提升清晰度
+      return stage.toDataURL({
+        pixelRatio: (1 / scale) * pixelRatio,
+        mimeType: 'image/png',
+      });
+    },
+    getNaturalSize: () => (naturalW && naturalH ? { width: naturalW, height: naturalH } : null),
+  }), [naturalW, naturalH, scale]);
+
+  // ── Pointer handlers (in stage local coords, then divided by scale → image coords) ──
+  const toImageCoords = (e: KonvaEventObject<PointerEvent | MouseEvent | TouchEvent>) => {
+    const stage = e.target.getStage();
+    const p = stage?.getPointerPosition();
+    if (!p) return null;
+    return { x: p.x / scale, y: p.y / scale };
+  };
+
+  const isDrawingRef = useRef(false);
+
+  const onPointerDown = (e: KonvaEventObject<PointerEvent>) => {
+    const target = e.target;
+    const isOnText = target.getClassName() === 'Text';
+    const isOnLine = target.getClassName() === 'Line';
+
+    // Eraser: hit any shape → remove
+    if (api.tool === 'eraser') {
+      const id = (target.attrs as { id?: string })?.id;
+      id && (isOnText || isOnLine) && api.eraseAt(id);
+      return;
+    }
+
+    if (api.tool === 'pen') {
+      const p = toImageCoords(e);
+      p && (() => {
+        isDrawingRef.current = true;
+        api.beginStroke(p.x, p.y);
+      })();
+      return;
+    }
+
+    // text 模式由 onStageClick 处理（兼容性更好），此处不重复
+  };
+
+  const onStageClick = (e: KonvaEventObject<MouseEvent | TouchEvent>) => {
+    if (api.tool !== 'text') return;
+    // 编辑期间点击其它位置先提交当前编辑（由 textarea 的 onBlur 触发），随后再创建新文本
+    if (editingText) return;
+    const target = e.target;
+    const isOnText = target.getClassName() === 'Text';
+    if (isOnText) {
+      const id = (target.attrs as { id?: string })?.id;
+      const shape = api.shapes.find((s) => s.id === id) as TextShape | undefined;
+      shape && setEditingText({ id: shape.id, x: shape.x * scale, y: shape.y * scale, value: shape.text });
+      return;
+    }
+    const p = toImageCoords(e);
+    p && setEditingText({ id: null, x: p.x * scale, y: p.y * scale, value: '' });
+  };
+
+  const onPointerMove = (e: KonvaEventObject<PointerEvent>) => {
+    if (!isDrawingRef.current || api.tool !== 'pen') return;
+    const p = toImageCoords(e);
+    p && api.extendStroke(p.x, p.y);
+  };
+
+  const onPointerUp = () => {
+    if (!isDrawingRef.current) return;
+    isDrawingRef.current = false;
+    api.endStroke();
+  };
+
+  const commitEditingText = () => {
+    if (!editingText) return;
+    const ix = editingText.x / scale;
+    const iy = editingText.y / scale;
+    const trimmed = editingText.value;
+    if (editingText.id) {
+      trimmed.trim() === ''
+        ? api.eraseAt(editingText.id)
+        : api.updateText(editingText.id, { text: trimmed });
+    } else {
+      trimmed.trim() !== '' && api.addText(ix, iy, trimmed);
+    }
+    setEditingText(null);
+  };
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center w-full h-full text-white/70">
+        图片加载失败（可能是跨域限制）
+      </div>
+    );
+  }
+
+  if (!image) {
+    return (
+      <div className="flex items-center justify-center w-full h-full text-white/70">
+        加载中…
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="relative"
+      style={{ width: stageW, height: stageH, cursor: api.tool === 'pen' ? 'crosshair' : api.tool === 'text' ? 'text' : 'cell' }}
+    >
+      <Stage
+        ref={(node: Konva.Stage | null) => {
+          stageRef.current = node;
+        }}
+        width={stageW}
+        height={stageH}
+        scale={{ x: scale, y: scale }}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onMouseDown={onPointerDown as unknown as (e: KonvaEventObject<MouseEvent>) => void}
+        onClick={onStageClick as unknown as (e: KonvaEventObject<MouseEvent>) => void}
+        onTap={onStageClick as unknown as (e: KonvaEventObject<TouchEvent>) => void}
+      >
+        {/* 底图层：保持监听（listening 默认 true），让 Stage 在整张图区域都能稳定收到事件；KonvaImage 自身作为命中目标但不影响形状层。 */}
+        <Layer>
+          <KonvaImage image={image} width={naturalW} height={naturalH} />
+        </Layer>
+        <Layer>
+          {api.shapes.map((s) =>
+            s.type === 'stroke' ? (
+              <Line
+                key={s.id}
+                id={s.id}
+                points={s.points}
+                stroke={s.color}
+                strokeWidth={s.strokeWidth}
+                tension={0.4}
+                lineCap="round"
+                lineJoin="round"
+                globalCompositeOperation="source-over"
+                hitStrokeWidth={Math.max(s.strokeWidth + 8, 12)}
+              />
+            ) : (
+              <KonvaText
+                key={s.id}
+                id={s.id}
+                x={s.x}
+                y={s.y}
+                text={s.text}
+                fill={s.color}
+                fontSize={s.fontSize}
+                fontStyle="bold"
+                shadowColor="rgba(0,0,0,0.6)"
+                shadowBlur={2}
+                shadowOffset={{ x: 1, y: 1 }}
+                draggable={api.tool === 'text'}
+                onDragEnd={(e) => {
+                  api.updateText(s.id, { x: e.target.x(), y: e.target.y() });
+                }}
+              />
+            ),
+          )}
+        </Layer>
+      </Stage>
+
+      {editingText && (
+        <textarea
+          autoFocus
+          value={editingText.value}
+          onChange={(e) => setEditingText({ ...editingText, value: e.target.value })}
+          onBlur={commitEditingText}
+          onMouseDown={(e) => e.stopPropagation()}
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => {
+            (e.key === 'Enter' && !e.shiftKey) && (e.preventDefault(), commitEditingText());
+            e.key === 'Escape' && (e.preventDefault(), setEditingText(null));
+          }}
+          className="absolute z-50 outline-none border border-primary/60 bg-black/60 text-white p-1 rounded resize"
+          style={{
+            left: editingText.x,
+            top: editingText.y,
+            minWidth: 80,
+            minHeight: 28,
+            fontSize: api.fontSize * scale,
+            color: api.color,
+            fontWeight: 'bold',
+          }}
+        />
+      )}
+    </div>
+  );
+});
+
+export default AnnotationCanvas;

--- a/frontend/src/components/canvas/ImageNode/AnnotationToolbar.tsx
+++ b/frontend/src/components/canvas/ImageNode/AnnotationToolbar.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import {
+  Pencil,
+  Type,
+  Eraser,
+  Undo2,
+  Redo2,
+  Trash2,
+  Check,
+  Loader2,
+} from 'lucide-react';
+import type { AnnotationStateApi, AnnotationTool } from '@/hooks/useAnnotationState';
+
+interface Props {
+  api: AnnotationStateApi;
+  isSaving: boolean;
+  canSave: boolean;
+  saveDisabledReason?: string | null;
+  onSave: () => void;
+  onCancel: () => void;
+}
+
+const TOOL_ICON: Record<AnnotationTool, React.ComponentType<{ className?: string }>> = {
+  pen: Pencil,
+  text: Type,
+  eraser: Eraser,
+};
+
+/**
+ * 标注工具栏：模式切换 / 颜色 / 笔触粗细 / 字号 / 撤销重做 / 清空 / 保存。
+ */
+export function AnnotationToolbar({ api, isSaving, canSave, saveDisabledReason, onSave, onCancel }: Props) {
+  const { t } = useTranslation();
+  const tools: AnnotationTool[] = ['pen', 'text', 'eraser'];
+
+  return (
+    <div
+      className="flex items-center gap-3 bg-black/70 backdrop-blur-md text-white rounded-lg px-3 py-2 shadow-lg pointer-events-auto"
+      onClick={(e) => e.stopPropagation()}
+      onPointerDown={(e) => e.stopPropagation()}
+    >
+      {/* Tool group */}
+      <div className="flex items-center gap-1">
+        {tools.map((tool) => {
+          const Icon = TOOL_ICON[tool];
+          const active = api.tool === tool;
+          return (
+            <button
+              key={tool}
+              className={`w-8 h-8 flex items-center justify-center rounded transition-colors ${
+                active ? 'bg-white/20 text-white' : 'text-white/70 hover:bg-white/10'
+              }`}
+              onClick={() => api.setTool(tool)}
+              title={t(`canvas.node.annotation.tool.${tool}`)}
+            >
+              <Icon className="w-4 h-4" />
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="w-px h-6 bg-white/20" />
+
+      {/* Color preset */}
+      <div className="flex items-center gap-1">
+        {api.presetColors.map((c) => (
+          <button
+            key={c}
+            className={`w-5 h-5 rounded-full border-2 transition-transform ${
+              api.color === c ? 'border-white scale-110' : 'border-white/30 hover:scale-110'
+            }`}
+            style={{ background: c }}
+            onClick={() => api.setColor(c)}
+            title={c}
+          />
+        ))}
+        <input
+          type="color"
+          value={api.color}
+          onChange={(e) => api.setColor(e.target.value)}
+          className="w-5 h-5 rounded-full bg-transparent border border-white/30 cursor-pointer"
+          title={t('canvas.node.annotation.customColor')}
+        />
+      </div>
+
+      <div className="w-px h-6 bg-white/20" />
+
+      {/* Stroke width / Font size based on tool */}
+      {api.tool === 'text' ? (
+        <label className="flex items-center gap-2 text-xs">
+          <span className="opacity-70">{t('canvas.node.annotation.fontSize')}</span>
+          <input
+            type="range"
+            min={12}
+            max={96}
+            step={1}
+            value={api.fontSize}
+            onChange={(e) => api.setFontSize(Number(e.target.value))}
+            className="w-24 accent-primary"
+          />
+          <span className="w-7 text-right">{api.fontSize}</span>
+        </label>
+      ) : (
+        <label className="flex items-center gap-2 text-xs">
+          <span className="opacity-70">{t('canvas.node.annotation.strokeWidth')}</span>
+          <input
+            type="range"
+            min={1}
+            max={32}
+            step={1}
+            value={api.strokeWidth}
+            onChange={(e) => api.setStrokeWidth(Number(e.target.value))}
+            className="w-24 accent-primary"
+          />
+          <span className="w-7 text-right">{api.strokeWidth}</span>
+        </label>
+      )}
+
+      <div className="w-px h-6 bg-white/20" />
+
+      {/* History */}
+      <div className="flex items-center gap-1">
+        <button
+          className="w-8 h-8 flex items-center justify-center rounded text-white/70 hover:bg-white/10 disabled:opacity-30 disabled:hover:bg-transparent"
+          onClick={api.undo}
+          disabled={!api.canUndo}
+          title={t('canvas.node.annotation.undo')}
+        >
+          <Undo2 className="w-4 h-4" />
+        </button>
+        <button
+          className="w-8 h-8 flex items-center justify-center rounded text-white/70 hover:bg-white/10 disabled:opacity-30 disabled:hover:bg-transparent"
+          onClick={api.redo}
+          disabled={!api.canRedo}
+          title={t('canvas.node.annotation.redo')}
+        >
+          <Redo2 className="w-4 h-4" />
+        </button>
+        <button
+          className="w-8 h-8 flex items-center justify-center rounded text-white/70 hover:bg-white/10 disabled:opacity-30 disabled:hover:bg-transparent"
+          onClick={api.clear}
+          disabled={!api.isDirty}
+          title={t('canvas.node.annotation.clear')}
+        >
+          <Trash2 className="w-4 h-4" />
+        </button>
+      </div>
+
+      <div className="w-px h-6 bg-white/20" />
+
+      {/* Actions */}
+      <Button
+        variant="ghost"
+        size="sm"
+        className="text-white/80 hover:bg-white/10 hover:text-white h-8"
+        onClick={onCancel}
+        disabled={isSaving}
+      >
+        {t('canvas.node.annotation.exit')}
+      </Button>
+      <Button
+        variant="default"
+        size="sm"
+        className="h-8"
+        onClick={onSave}
+        disabled={!canSave || isSaving || !api.isDirty}
+        title={saveDisabledReason || ''}
+      >
+        {isSaving ? (
+          <Loader2 className="w-4 h-4 animate-spin mr-1" />
+        ) : (
+          <Check className="w-4 h-4 mr-1" />
+        )}
+        {t('canvas.node.annotation.save')}
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/components/canvas/ImageNode/ImagePreviewPortal.tsx
+++ b/frontend/src/components/canvas/ImageNode/ImagePreviewPortal.tsx
@@ -1,9 +1,18 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import dynamic from 'next/dynamic';
 import { Button } from '@/components/ui/button';
-import { ZoomIn, ZoomOut, X } from 'lucide-react';
+import { ZoomIn, ZoomOut, X, PencilLine } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import type { AnnotationCanvasHandle } from './AnnotationCanvas';
+import { AnnotationToolbar } from './AnnotationToolbar';
+import { useAnnotationState } from '@/hooks/useAnnotationState';
+import type { ImagePreviewMode } from '@/hooks/useImagePreview';
+
+// react-konva 不支持 SSR：动态导入并关闭 SSR。
+const AnnotationCanvas = dynamic(() => import('./AnnotationCanvas'), { ssr: false });
 
 interface Props {
   open: boolean;
@@ -12,16 +21,24 @@ interface Props {
   scale: number;
   position: { x: number; y: number };
   isDragging: boolean;
+  mode: ImagePreviewMode;
   onClose: () => void;
   onZoomIn: () => void;
   onZoomOut: () => void;
   onPointerDown: (e: React.PointerEvent) => void;
   onPointerMove: (e: React.PointerEvent) => void;
   onPointerUp: (e: React.PointerEvent) => void;
+  // 标注模式
+  annotationEnabled?: boolean;
+  isFull?: boolean;
+  isSaving?: boolean;
+  onEnterAnnotate: () => void;
+  onExitAnnotate: () => void;
+  onSaveAnnotation: (dataUrl: string | null) => Promise<string | null>;
 }
 
 /**
- * 全屏图像预览 Portal（缩放 / 拖拽 / 关闭按钮）
+ * 全屏图像预览 Portal：默认 view（缩放/拖拽）；annotate 模式下渲染 Konva 画板与工具栏。
  */
 export function ImagePreviewPortal({
   open,
@@ -30,66 +47,169 @@ export function ImagePreviewPortal({
   scale,
   position,
   isDragging,
+  mode,
   onClose,
   onZoomIn,
   onZoomOut,
   onPointerDown,
   onPointerMove,
   onPointerUp,
+  annotationEnabled = true,
+  isFull = false,
+  isSaving = false,
+  onEnterAnnotate,
+  onExitAnnotate,
+  onSaveAnnotation,
 }: Props) {
+  const { t } = useTranslation();
+  const annotationApi = useAnnotationState();
+  const canvasRef = useRef<AnnotationCanvasHandle | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [viewport, setViewport] = useState<{ w: number; h: number }>({ w: 0, h: 0 });
+
+  // 切换出标注模式或关闭时重置画板
+  useEffect(() => {
+    (mode !== 'annotate' || !open) && annotationApi.clear();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode, open]);
+
+  // 计算可用画布尺寸
+  useEffect(() => {
+    if (mode !== 'annotate' || !open) return;
+    const update = () => {
+      const el = containerRef.current;
+      el && setViewport({ w: el.clientWidth, h: el.clientHeight });
+    };
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, [mode, open]);
+
   if (!open || typeof document === 'undefined') return null;
+
+  const handleSave = async () => {
+    const dataUrl = canvasRef.current?.getMergedDataURL(2) || null;
+    const newUrl = await onSaveAnnotation(dataUrl);
+    newUrl && (annotationApi.clear(), onExitAnnotate());
+  };
+
+  const handleExit = () => {
+    if (annotationApi.isDirty && !window.confirm(t('canvas.node.annotation.confirmDiscard'))) return;
+    annotationApi.clear();
+    onExitAnnotate();
+  };
+
+  const handleClose = () => {
+    if (mode === 'annotate' && annotationApi.isDirty) {
+      if (!window.confirm(t('canvas.node.annotation.confirmDiscard'))) return;
+    }
+    onClose();
+  };
 
   return createPortal(
     <div
-      className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/80 backdrop-blur-sm animate-in fade-in duration-200"
-      onClick={onClose}
+      className="fixed inset-0 z-[9999] flex flex-col items-center justify-center bg-black/80 backdrop-blur-sm animate-in fade-in duration-200"
+      onClick={mode === 'view' ? onClose : undefined}
     >
-      <div className="absolute top-4 right-4 flex items-center gap-2 z-50">
-        <div className="bg-black/50 text-white px-3 py-1.5 rounded-md text-sm font-medium backdrop-blur-md" onClick={e => e.stopPropagation()}>
-          {Math.round(scale * 100)}%
-        </div>
+      {/* Top-right controls */}
+      <div className="absolute top-4 right-4 flex items-center gap-2 z-50" onClick={(e) => e.stopPropagation()}>
+        {mode === 'view' && (
+          <>
+            <div className="bg-black/50 text-white px-3 py-1.5 rounded-md text-sm font-medium backdrop-blur-md">
+              {Math.round(scale * 100)}%
+            </div>
+            <Button
+              variant="secondary"
+              size="icon"
+              className="bg-black/50 hover:bg-black/70 text-white border-none backdrop-blur-md"
+              onClick={(e) => { e.stopPropagation(); onZoomIn(); }}
+              title={t('canvas.node.preview.zoomIn', 'Zoom in')}
+            >
+              <ZoomIn className="h-5 w-5" />
+            </Button>
+            <Button
+              variant="secondary"
+              size="icon"
+              className="bg-black/50 hover:bg-black/70 text-white border-none backdrop-blur-md"
+              onClick={(e) => { e.stopPropagation(); onZoomOut(); }}
+              title={t('canvas.node.preview.zoomOut', 'Zoom out')}
+            >
+              <ZoomOut className="h-5 w-5" />
+            </Button>
+            {annotationEnabled && (
+              <Button
+                variant="secondary"
+                size="sm"
+                className="bg-black/50 hover:bg-black/70 text-white border-none backdrop-blur-md"
+                onClick={(e) => { e.stopPropagation(); onEnterAnnotate(); }}
+                title={t('canvas.node.annotation.enter')}
+              >
+                <PencilLine className="h-4 w-4 mr-1" />
+                {t('canvas.node.annotation.enter')}
+              </Button>
+            )}
+          </>
+        )}
         <Button
           variant="secondary"
           size="icon"
           className="bg-black/50 hover:bg-black/70 text-white border-none backdrop-blur-md"
-          onClick={(e) => { e.stopPropagation(); onZoomIn(); }}
-        >
-          <ZoomIn className="h-5 w-5" />
-        </Button>
-        <Button
-          variant="secondary"
-          size="icon"
-          className="bg-black/50 hover:bg-black/70 text-white border-none backdrop-blur-md"
-          onClick={(e) => { e.stopPropagation(); onZoomOut(); }}
-        >
-          <ZoomOut className="h-5 w-5" />
-        </Button>
-        <Button
-          variant="secondary"
-          size="icon"
-          className="bg-black/50 hover:bg-black/70 text-white border-none backdrop-blur-md"
-          onClick={(e) => { e.stopPropagation(); onClose(); }}
+          onClick={(e) => { e.stopPropagation(); handleClose(); }}
+          title={t('canvas.node.preview.close', 'Close')}
         >
           <X className="h-5 w-5" />
         </Button>
       </div>
 
-      <div id="preview-container" className="w-full h-full flex items-center justify-center overflow-hidden p-8">
-        <img
-          src={url || undefined}
-          alt={name}
-          className="max-w-full max-h-full object-contain transition-transform duration-75 ease-out select-none"
-          style={{
-            transform: `translate(${position.x}px, ${position.y}px) scale(${scale})`,
-            cursor: isDragging ? 'grabbing' : 'grab',
-          }}
-          draggable={false}
-          onPointerDown={onPointerDown}
-          onPointerMove={onPointerMove}
-          onPointerUp={onPointerUp}
-          onClick={(e) => e.stopPropagation()}
-        />
-      </div>
+      {/* Main area */}
+      {mode === 'view' && (
+        <div id="preview-container" className="w-full h-full flex items-center justify-center overflow-hidden p-8">
+          <img
+            src={url || undefined}
+            alt={name}
+            className="max-w-full max-h-full object-contain transition-transform duration-75 ease-out select-none"
+            style={{
+              transform: `translate(${position.x}px, ${position.y}px) scale(${scale})`,
+              cursor: isDragging ? 'grabbing' : 'grab',
+            }}
+            draggable={false}
+            onPointerDown={onPointerDown}
+            onPointerMove={onPointerMove}
+            onPointerUp={onPointerUp}
+            onClick={(e) => e.stopPropagation()}
+          />
+        </div>
+      )}
+
+      {mode === 'annotate' && (
+        <>
+          <div
+            ref={containerRef}
+            className="flex-1 w-full flex items-center justify-center overflow-hidden p-8 pb-28"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {viewport.w > 0 && viewport.h > 0 && (
+              <AnnotationCanvas
+                ref={canvasRef}
+                url={url}
+                api={annotationApi}
+                viewportWidth={viewport.w}
+                viewportHeight={viewport.h}
+              />
+            )}
+          </div>
+          <div className="absolute bottom-6 left-1/2 -translate-x-1/2 z-50">
+            <AnnotationToolbar
+              api={annotationApi}
+              isSaving={isSaving}
+              canSave={!isFull}
+              saveDisabledReason={isFull ? t('canvas.node.upload.maxReached', { max: 9 }) : null}
+              onSave={handleSave}
+              onCancel={handleExit}
+            />
+          </div>
+        </>
+      )}
     </div>,
     document.body,
   );

--- a/frontend/src/hooks/useAnnotationExport.ts
+++ b/frontend/src/hooks/useAnnotationExport.ts
@@ -1,0 +1,122 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  useCanvasStore,
+  type CharacterNodeData,
+  type ImageGenHistoryEntry,
+} from '@/store/useCanvasStore';
+
+const MAX_IMAGES = 9;
+
+interface SaveResult {
+  url: string;
+}
+
+/**
+ * 标注合成保存：dataURL → 上传 /api/media/upload → 追加到节点 images 与 generatedImages。
+ * - 不替换原图；满 9 张时拒绝并返回错误
+ * - 借鉴 useImageGridExport 的 XHR + token 注入范式
+ */
+export function useAnnotationExport(id: string, data: CharacterNodeData) {
+  const { t } = useTranslation();
+  const updateNodeData = useCanvasStore((s) => s.updateNodeData);
+
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const currentImages = data.images || (data.imageUrl ? [data.imageUrl] : []);
+  const isFull = currentImages.length >= MAX_IMAGES;
+
+  const uploadDataUrl = useCallback(async (dataUrl: string): Promise<SaveResult> => {
+    const resp = await fetch(dataUrl);
+    const blob = await resp.blob();
+    const file = new File([blob], `annotated-${Date.now()}.png`, { type: 'image/png' });
+
+    const formData = new FormData();
+    formData.append('file', file);
+
+    const xhr = new XMLHttpRequest();
+    xhr.open('POST', '/api/media/upload');
+    const token = localStorage.getItem('access_token');
+    token && xhr.setRequestHeader('Authorization', `Bearer ${token}`);
+
+    return new Promise<SaveResult>((resolve, reject) => {
+      xhr.onload = () => {
+        try {
+          const res = xhr.responseText ? JSON.parse(xhr.responseText) : {};
+          xhr.status >= 200 && xhr.status < 300
+            ? (res.url ? resolve({ url: res.url }) : reject(new Error('Server returned no url')))
+            : reject(new Error(res?.error || `HTTP ${xhr.status}`));
+        } catch {
+          reject(new Error(`Parse response failed: ${xhr.status}`));
+        }
+      };
+      xhr.onerror = () => reject(new Error('Network error'));
+      xhr.send(formData);
+    });
+  }, []);
+
+  /**
+   * 保存标注合成图。
+   * @returns 新增图片的 URL；失败时返回 null（错误存入 state）。
+   */
+  const saveAnnotation = useCallback(async (dataUrl: string | null): Promise<string | null> => {
+    if (!dataUrl) {
+      setError(t('canvas.node.annotation.exportFailed'));
+      return null;
+    }
+    if (isFull) {
+      setError(t('canvas.node.upload.maxReached', { max: MAX_IMAGES }));
+      return null;
+    }
+
+    setIsSaving(true);
+    setError(null);
+    try {
+      const { url } = await uploadDataUrl(dataUrl);
+
+      // 取最新的 store 数据，避免 stale closure
+      const latestNode = useCanvasStore.getState().nodes.find((n) => n.id === id);
+      const latestData = (latestNode?.data as CharacterNodeData) || data;
+      const latestImages = latestData.images || (latestData.imageUrl ? [latestData.imageUrl] : []);
+      const nextImages = [...latestImages, url].slice(0, MAX_IMAGES);
+
+      const entry: ImageGenHistoryEntry = {
+        url,
+        prompt: t('canvas.node.annotation.exportName', { name: latestData.name || '' }),
+        createdAt: new Date().toISOString(),
+        source: 'annotation',
+      };
+      const prevHist = latestData.generatedImages || [];
+      const merged = [entry, ...prevHist.filter((e) => e.url !== url)];
+
+      updateNodeData(id, {
+        images: nextImages,
+        imageUrl: nextImages[0] || url,
+        generatedImages: merged,
+        uploading: false,
+      } as Partial<CharacterNodeData>);
+
+      return url;
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : 'Unknown error';
+      console.error('Save annotation error:', e);
+      setError(msg);
+      return null;
+    } finally {
+      setIsSaving(false);
+    }
+  }, [id, data, isFull, t, updateNodeData, uploadDataUrl]);
+
+  const clearError = useCallback(() => setError(null), []);
+
+  return {
+    isSaving,
+    error,
+    isFull,
+    saveAnnotation,
+    clearError,
+  };
+}

--- a/frontend/src/hooks/useAnnotationState.ts
+++ b/frontend/src/hooks/useAnnotationState.ts
@@ -1,0 +1,201 @@
+'use client';
+
+import { useCallback, useMemo, useRef, useState } from 'react';
+
+// ── Shape types ─────────────────────────────────────────────────────────────
+
+export type AnnotationTool = 'pen' | 'text' | 'eraser';
+
+export interface StrokeShape {
+  type: 'stroke';
+  id: string;
+  points: number[]; // flat [x1,y1,x2,y2,...] in image natural coordinates
+  color: string;
+  strokeWidth: number;
+}
+
+export interface TextShape {
+  type: 'text';
+  id: string;
+  x: number;
+  y: number;
+  text: string;
+  color: string;
+  fontSize: number;
+}
+
+export type AnnotationShape = StrokeShape | TextShape;
+
+interface HistoryFrame {
+  shapes: AnnotationShape[];
+}
+
+const MAX_HISTORY = 50;
+
+const PRESET_COLORS = ['#ef4444', '#f59e0b', '#22c55e', '#3b82f6', '#a855f7', '#ffffff', '#000000'];
+
+const genId = () => `ann-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+/**
+ * 标注画板状态：图形栈 + 撤销/重做 + 工具/样式参数。
+ * 与 useCanvasStore 完全独立，避免污染节点画布历史。
+ */
+export function useAnnotationState() {
+  const [shapes, setShapes] = useState<AnnotationShape[]>([]);
+  const [tool, setTool] = useState<AnnotationTool>('pen');
+  const [color, setColor] = useState<string>('#ef4444');
+  const [strokeWidth, setStrokeWidth] = useState<number>(4);
+  const [fontSize, setFontSize] = useState<number>(24);
+
+  const historyRef = useRef<HistoryFrame[]>([{ shapes: [] }]);
+  const historyIndexRef = useRef<number>(0);
+  // 镜像状态供渲染使用（避免在渲染期间访问 ref.current）
+  const [historyIndex, setHistoryIndex] = useState<number>(0);
+  const [historyLength, setHistoryLength] = useState<number>(1);
+
+  const pushHistory = useCallback((next: AnnotationShape[]) => {
+    const idx = historyIndexRef.current;
+    const trimmed = historyRef.current.slice(0, idx + 1);
+    trimmed.push({ shapes: next });
+    trimmed.length > MAX_HISTORY && trimmed.shift();
+    historyRef.current = trimmed;
+    historyIndexRef.current = trimmed.length - 1;
+    setHistoryIndex(trimmed.length - 1);
+    setHistoryLength(trimmed.length);
+  }, []);
+
+  const commitShapes = useCallback((next: AnnotationShape[]) => {
+    setShapes(next);
+    pushHistory(next);
+  }, [pushHistory]);
+
+  // ── Pen drawing ──────────────────────────────────────────────────────────
+  const drawingRef = useRef<StrokeShape | null>(null);
+
+  const beginStroke = useCallback((x: number, y: number) => {
+    const s: StrokeShape = {
+      type: 'stroke',
+      id: genId(),
+      points: [x, y],
+      color,
+      strokeWidth,
+    };
+    drawingRef.current = s;
+    setShapes((prev) => [...prev, s]);
+  }, [color, strokeWidth]);
+
+  const extendStroke = useCallback((x: number, y: number) => {
+    const s = drawingRef.current;
+    s && (() => {
+      s.points = [...s.points, x, y];
+      setShapes((prev) => prev.map((sh) => (sh.id === s.id ? { ...s } : sh)));
+    })();
+  }, []);
+
+  const endStroke = useCallback(() => {
+    const s = drawingRef.current;
+    s && (() => {
+      drawingRef.current = null;
+      // commit current shapes snapshot to history
+      setShapes((prev) => {
+        pushHistory(prev);
+        return prev;
+      });
+    })();
+  }, [pushHistory]);
+
+  // ── Text ────────────────────────────────────────────────────────────────
+  const addText = useCallback((x: number, y: number, text: string) => {
+    text.trim() === '' && (() => {})();
+    if (text.trim() === '') return;
+    const t: TextShape = {
+      type: 'text',
+      id: genId(),
+      x,
+      y,
+      text,
+      color,
+      fontSize,
+    };
+    setShapes((prev) => {
+      const next = [...prev, t];
+      pushHistory(next);
+      return next;
+    });
+  }, [color, fontSize, pushHistory]);
+
+  const updateText = useCallback((id: string, patch: Partial<Omit<TextShape, 'type' | 'id'>>) => {
+    setShapes((prev) => {
+      const next = prev.map((sh) => (sh.id === id && sh.type === 'text' ? { ...sh, ...patch } : sh));
+      pushHistory(next);
+      return next;
+    });
+  }, [pushHistory]);
+
+  // ── Eraser: hit any shape, remove it ────────────────────────────────────
+  const eraseAt = useCallback((id: string) => {
+    setShapes((prev) => {
+      const next = prev.filter((sh) => sh.id !== id);
+      pushHistory(next);
+      return next;
+    });
+  }, [pushHistory]);
+
+  // ── Undo / Redo / Clear ─────────────────────────────────────────────────
+  const undo = useCallback(() => {
+    const idx = historyIndexRef.current;
+    idx > 0 && (() => {
+      historyIndexRef.current = idx - 1;
+      setShapes(historyRef.current[idx - 1].shapes);
+      setHistoryIndex(idx - 1);
+    })();
+  }, []);
+
+  const redo = useCallback(() => {
+    const idx = historyIndexRef.current;
+    const frames = historyRef.current;
+    idx < frames.length - 1 && (() => {
+      historyIndexRef.current = idx + 1;
+      setShapes(frames[idx + 1].shapes);
+      setHistoryIndex(idx + 1);
+    })();
+  }, []);
+
+  const clear = useCallback(() => {
+    shapes.length > 0 && commitShapes([]);
+  }, [shapes.length, commitShapes]);
+
+  const canUndo = historyIndex > 0;
+  const canRedo = historyIndex < historyLength - 1;
+  const isDirty = useMemo(() => shapes.length > 0, [shapes.length]);
+
+  return {
+    // state
+    shapes,
+    tool,
+    color,
+    strokeWidth,
+    fontSize,
+    canUndo,
+    canRedo,
+    isDirty,
+    presetColors: PRESET_COLORS,
+    // setters
+    setTool,
+    setColor,
+    setStrokeWidth,
+    setFontSize,
+    // ops
+    beginStroke,
+    extendStroke,
+    endStroke,
+    addText,
+    updateText,
+    eraseAt,
+    undo,
+    redo,
+    clear,
+  };
+}
+
+export type AnnotationStateApi = ReturnType<typeof useAnnotationState>;

--- a/frontend/src/hooks/useImagePreview.ts
+++ b/frontend/src/hooks/useImagePreview.ts
@@ -2,8 +2,11 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+export type ImagePreviewMode = 'view' | 'annotate';
+
 /**
  * 全屏图像预览：开关 + 缩放（wheel + 按钮）+ 拖拽 + ESC 关闭。
+ * 另提供 mode 切换 (view/annotate) 供标注画板复用同一 Portal。
  */
 export function useImagePreview() {
   const [open, setOpen] = useState(false);
@@ -11,11 +14,13 @@ export function useImagePreview() {
   const [scale, setScale] = useState(1);
   const [position, setPosition] = useState({ x: 0, y: 0 });
   const [isDragging, setIsDragging] = useState(false);
+  const [mode, setMode] = useState<ImagePreviewMode>('view');
   const dragStartPosRef = useRef({ x: 0, y: 0 });
 
   const openPreview = useCallback((u: string) => {
     setUrl(u);
     setOpen(true);
+    setMode('view');
   }, []);
 
   const closePreview = useCallback(() => {
@@ -23,7 +28,23 @@ export function useImagePreview() {
     setTimeout(() => {
       setScale(1);
       setPosition({ x: 0, y: 0 });
+      setMode('view');
     }, 300);
+  }, []);
+
+  const enterAnnotate = useCallback(() => {
+    setMode('annotate');
+    setScale(1);
+    setPosition({ x: 0, y: 0 });
+  }, []);
+
+  const exitAnnotate = useCallback(() => {
+    setMode('view');
+  }, []);
+
+  /** 外部完成保存后切换预览为新图 */
+  const setPreviewUrl = useCallback((u: string) => {
+    setUrl(u);
   }, []);
 
   const handleWheel = useCallback((e: WheelEvent) => {
@@ -59,26 +80,28 @@ export function useImagePreview() {
   const zoomIn = useCallback(() => setScale((p) => Math.min(5, p + 0.25)), []);
   const zoomOut = useCallback(() => setScale((p) => Math.max(0.1, p - 0.25)), []);
 
-  // Esc 关闭
+  // Esc 关闭：标注模式下优先退出标注而非关闭预览
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      e.key === 'Escape' && open && closePreview();
+      if (!open || e.key !== 'Escape') return;
+      mode === 'annotate' ? exitAnnotate() : closePreview();
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [open, closePreview]);
+  }, [open, mode, exitAnnotate, closePreview]);
 
-  // body overflow + wheel 绑定
+  // body overflow + wheel 绑定（仅在 view 模式）
   useEffect(() => {
     if (!open) return;
     document.body.style.overflow = 'hidden';
+    if (mode !== 'view') return () => { document.body.style.overflow = ''; };
     const container = document.getElementById('preview-container');
     container?.addEventListener('wheel', handleWheel, { passive: false });
     return () => {
       document.body.style.overflow = '';
       container?.removeEventListener('wheel', handleWheel);
     };
-  }, [open, handleWheel]);
+  }, [open, mode, handleWheel]);
 
   return {
     open,
@@ -86,8 +109,12 @@ export function useImagePreview() {
     scale,
     position,
     isDragging,
+    mode,
     openPreview,
     closePreview,
+    enterAnnotate,
+    exitAnnotate,
+    setPreviewUrl,
     handlePointerDown,
     handlePointerMove,
     handlePointerUp,

--- a/frontend/src/i18n/locales/en-US.json
+++ b/frontend/src/i18n/locales/en-US.json
@@ -265,7 +265,29 @@
         "exportRatioMax": "Maximum"
       },
       "preview": {
-        "dragOrFullscreen": "Drag to move / Double-click for fullscreen preview"
+        "dragOrFullscreen": "Drag to move / Double-click for fullscreen preview",
+        "zoomIn": "Zoom in",
+        "zoomOut": "Zoom out",
+        "close": "Close"
+      },
+      "annotation": {
+        "enter": "Annotate",
+        "exit": "Exit",
+        "save": "Save as new image",
+        "clear": "Clear",
+        "undo": "Undo",
+        "redo": "Redo",
+        "strokeWidth": "Stroke",
+        "fontSize": "Font size",
+        "customColor": "Custom color",
+        "confirmDiscard": "Unsaved annotations will be lost. Continue?",
+        "exportName": "{{name}} - Annotated",
+        "exportFailed": "Failed to compose annotated image",
+        "tool": {
+          "pen": "Pen",
+          "text": "Text",
+          "eraser": "Eraser"
+        }
       },
       "audio": {
         "showLyrics": "Show Lyrics",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -265,7 +265,29 @@
         "exportRatioMax": "极致"
       },
       "preview": {
-        "dragOrFullscreen": "拖拽移动节点 / 双击全屏预览"
+        "dragOrFullscreen": "拖拽移动节点 / 双击全屏预览",
+        "zoomIn": "放大",
+        "zoomOut": "缩小",
+        "close": "关闭"
+      },
+      "annotation": {
+        "enter": "标注",
+        "exit": "退出",
+        "save": "保存为新图",
+        "clear": "清空",
+        "undo": "撤销",
+        "redo": "重做",
+        "strokeWidth": "笔触",
+        "fontSize": "字号",
+        "customColor": "自定义颜色",
+        "confirmDiscard": "尚未保存的标注会丢失，是否继续？",
+        "exportName": "{{name}} - 标注",
+        "exportFailed": "合成标注图像失败",
+        "tool": {
+          "pen": "画笔",
+          "text": "文字",
+          "eraser": "橡皮擦"
+        }
       },
       "audio": {
         "showLyrics": "查看歌词",

--- a/frontend/src/store/useCanvasStore.ts
+++ b/frontend/src/store/useCanvasStore.ts
@@ -44,6 +44,8 @@ export type ImageGenHistoryEntry = {
   batch_count?: number;
   output_format?: string;
   createdAt?: string;
+  /** 来源分类：ai 生成 / 上传 / 标注合成 / 多宫格导出。旧数据缺省视为 'ai'。 */
+  source?: 'ai' | 'upload' | 'annotation' | 'export';
 };
 
 export type CharacterNodeData = {


### PR DESCRIPTION
- 新增 AnnotationCanvas 组件，实现图片上绘画与文本标注
- 新增 AnnotationToolbar 组件，支持工具切换、颜色选择、撤销重做、保存等操作
- 修改 ImageNode 组件，集成标注保存逻辑，支持标注数据上传及预览更新
- 修改 ImagePreviewPortal，支持标注模式下显示Konva画板及工具栏
- 新增 useAnnotationExport 钩子，实现标注图像上传及节点数据同步
- 在 package.json 中添加 konva 和 react-konva 依赖支持Konva绘图
- 处理标注模式切换时清理状态，防止遗留数据影响
- 支持标注模式下的画布尺寸动态计算，提升用户体验