### PR TITLE
feat(canvas): 实现画布连线合法性校验及智能注入功能

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -174,9 +174,12 @@ async def refresh(
     # 旧 refresh token 入黑名单（一次性轮换）
     await revoke_jti(payload.get("jti"), _remaining_ttl(payload))
 
+    # 同步颁发新的 refresh_token，避免前端持有被拉黑的旧 token 导致二次刷新失败
     access_token = create_access_token(user.id, user.role)
+    new_refresh_token = create_refresh_token(user.id)
     return AccessTokenResponse(
         access_token=access_token,
+        refresh_token=new_refresh_token,
         expires_in=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
     )
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -82,6 +82,8 @@ class TokenResponse(BaseModel):
 
 class AccessTokenResponse(BaseModel):
     access_token: str
+    # 一次性轮换模式下同步回传新的 refresh_token；未轮换的接口可省略
+    refresh_token: Optional[str] = None
     token_type: str = "bearer"
     expires_in: int
 

--- a/backend/services/tool_manager/providers/_canvas_edge_rules.py
+++ b/backend/services/tool_manager/providers/_canvas_edge_rules.py
@@ -1,0 +1,170 @@
+"""
+Canvas edge rules — mirror of frontend/src/lib/canvas/edgeRules.ts.
+
+规范来源：frontend/src/lib/canvas/edgeRules.md
+前端对应：frontend/src/lib/canvas/edgeRules.ts
+
+任何规范变更必须同时改动前端与本文件，否则前后端不一致会导致：
+ - 前端放行 → 后端拒绝：用户看到建边成功但 reload 后消失
+ - 前端拒绝 → 后端放行：Agent 工具绕过校验
+
+设计原则：
+ 1. 矩阵写死为纯常量；5x5 结构与前端逐字母一致。
+ 2. validate_edge 只判定合法性；不处理内容注入（后端当前版本仅做建边）。
+ 3. 所有检查走早返回，避免嵌套 if。
+"""
+from __future__ import annotations
+
+from typing import Iterable, Literal, Optional, TypedDict
+
+EdgeLegality = Literal["allow", "deferred", "forbid"]
+EdgeRejectReason = Literal[
+    "self_loop",
+    "same_polarity",
+    "duplicate_edge",
+    "cycle",
+    "forbidden_type_combination",
+    "not_supported_yet",
+    "unknown_type",
+]
+
+NODE_TYPES: tuple[str, ...] = ("text", "image", "video", "audio", "storyboard")
+
+# 5x5 合法性矩阵（Source → Target）——必须与 edgeRules.md 第 4 节逐格对齐。
+EDGE_LEGALITY_MATRIX: dict[str, dict[str, EdgeLegality]] = {
+    "text": {
+        "text": "allow", "image": "allow", "video": "allow", "audio": "allow", "storyboard": "allow",
+    },
+    "image": {
+        "text": "deferred", "image": "allow", "video": "allow", "audio": "forbid", "storyboard": "allow",
+    },
+    "video": {
+        "text": "deferred", "image": "allow", "video": "allow", "audio": "deferred", "storyboard": "allow",
+    },
+    "audio": {
+        "text": "deferred", "image": "forbid", "video": "allow", "audio": "deferred", "storyboard": "allow",
+    },
+    "storyboard": {
+        "text": "allow", "image": "allow", "video": "allow", "audio": "allow", "storyboard": "allow",
+    },
+}
+
+REJECT_MESSAGES: dict[EdgeRejectReason, str] = {
+    "self_loop": "Cannot connect a node to itself",
+    "same_polarity": "Invalid handle direction: both endpoints must be on different sides of the nodes",
+    "duplicate_edge": "Edge already exists between these nodes",
+    "cycle": "Connection would create a cycle",
+    "forbidden_type_combination": "This node type combination is not allowed",
+    "not_supported_yet": "This edge type is not yet supported",
+    "unknown_type": "Unknown node type",
+}
+
+
+class ExistingEdge(TypedDict, total=False):
+    """Minimal shape needed for validation (matches TheaterEdge columns)."""
+    source_node_id: str
+    target_node_id: str
+    source_handle: Optional[str]
+    target_handle: Optional[str]
+
+
+class EdgeValidationResult(TypedDict, total=False):
+    ok: bool
+    reason: EdgeRejectReason
+    message: str
+
+
+def _handle_side(h: Optional[str]) -> Optional[str]:
+    """Return 'left' / 'right' / None based on handle id prefix.
+
+    Frontend uses ConnectionMode.Loose with `{side}-source` and `{side}-target` stacked
+    at the same position; role suffix is unreliable. Polarity is judged by geometric side.
+    """
+    if not isinstance(h, str):
+        return None
+    if h.startswith("left-"):
+        return "left"
+    if h.startswith("right-"):
+        return "right"
+    return None
+
+
+def _has_cycle(edges: Iterable[ExistingEdge], new_source: str, new_target: str) -> bool:
+    """简单的 DFS 环检测：加上新边后从 new_target 能否回到 new_source。"""
+    adj: dict[str, list[str]] = {}
+    for e in edges:
+        adj.setdefault(e["source_node_id"], []).append(e["target_node_id"])
+    # 模拟加入新边
+    adj.setdefault(new_source, []).append(new_target)
+
+    stack = [new_target]
+    visited: set[str] = set()
+    while stack:
+        node = stack.pop()
+        if node == new_source:
+            return True
+        if node in visited:
+            continue
+        visited.add(node)
+        stack.extend(adj.get(node, []))
+    return False
+
+
+def validate_edge(
+    *,
+    source_id: str,
+    target_id: str,
+    source_type: Optional[str],
+    target_type: Optional[str],
+    source_handle: Optional[str],
+    target_handle: Optional[str],
+    existing_edges: Iterable[ExistingEdge],
+) -> EdgeValidationResult:
+    """按 self_loop → same_polarity → duplicate → cycle → matrix 顺序校验。"""
+    # 1. 自环
+    if source_id == target_id:
+        return {"ok": False, "reason": "self_loop", "message": REJECT_MESSAGES["self_loop"]}
+
+    # 2. 极性（两端都能识别出侧边时才校验，loose 模式下 role 后缀不可靠）
+    src_side = _handle_side(source_handle)
+    tgt_side = _handle_side(target_handle)
+    polarity_checkable = src_side is not None and tgt_side is not None
+    polarity_bad = polarity_checkable and src_side == tgt_side
+    if polarity_bad:
+        return {"ok": False, "reason": "same_polarity", "message": REJECT_MESSAGES["same_polarity"]}
+
+    # 3. 四元组去重
+    edges_list = list(existing_edges)
+    is_dup = any(
+        e.get("source_node_id") == source_id
+        and e.get("target_node_id") == target_id
+        and (e.get("source_handle") or None) == (source_handle or None)
+        and (e.get("target_handle") or None) == (target_handle or None)
+        for e in edges_list
+    )
+    if is_dup:
+        return {"ok": False, "reason": "duplicate_edge", "message": REJECT_MESSAGES["duplicate_edge"]}
+
+    # 4. 拓扑环
+    if _has_cycle(edges_list, source_id, target_id):
+        return {"ok": False, "reason": "cycle", "message": REJECT_MESSAGES["cycle"]}
+
+    # 5. 矩阵（类型未知时按 allow，兼容 ghost / streaming 等非规范类型）
+    both_known = source_type in NODE_TYPES and target_type in NODE_TYPES
+    legality: Optional[EdgeLegality] = (
+        EDGE_LEGALITY_MATRIX[source_type][target_type] if both_known else None
+    )
+    if legality == "forbid":
+        return {
+            "ok": False,
+            "reason": "forbidden_type_combination",
+            "message": f"{source_type} → {target_type} is not allowed",
+        }
+    if legality == "deferred":
+        return {
+            "ok": False,
+            "reason": "not_supported_yet",
+            "message": f"{source_type} → {target_type} is not supported yet",
+        }
+
+    return {"ok": True}

--- a/backend/services/tool_manager/providers/canvas.py
+++ b/backend/services/tool_manager/providers/canvas.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from models import TheaterNode, TheaterEdge
 from services.tool_manager.context import ToolContext
+from services.tool_manager.providers._canvas_edge_rules import validate_edge
 
 logger = logging.getLogger(__name__)
 
@@ -263,8 +264,10 @@ def _json_result(data: Any) -> str:
     return json.dumps(data, ensure_ascii=False, default=str)
 
 
-def _error_result(message: str) -> str:
-    return _json_result({"error": message})
+def _error_result(message: str, code: str | None = None) -> str:
+    payload: dict[str, Any] = {"error": message}
+    code and payload.update({"code": code})
+    return _json_result(payload)
 
 
 def _node_summary(node: TheaterNode) -> dict:
@@ -597,25 +600,42 @@ async def _exec_create_edge(
     target_node = target_result.scalar_one_or_none()
 
     if not source_node:
-        return _error_result(f"Source node not found: {source_node_id}")
+        return _error_result(f"Source node not found: {source_node_id}", code="source_not_found")
     if not target_node:
-        return _error_result(f"Target node not found: {target_node_id}")
+        return _error_result(f"Target node not found: {target_node_id}", code="target_not_found")
 
     if migrated_target_types:
         if source_node.node_type not in migrated_target_types:
-            return _error_result(f"Cannot connect from node of type '{source_node.node_type}'")
+            return _error_result(f"Cannot connect from node of type '{source_node.node_type}'", code="target_type_scope")
         if target_node.node_type not in migrated_target_types:
-            return _error_result(f"Cannot connect to node of type '{target_node.node_type}'")
+            return _error_result(f"Cannot connect to node of type '{target_node.node_type}'", code="target_type_scope")
 
-    # 检查是否已存在相同连线
-    existing_query = select(TheaterEdge).where(
-        TheaterEdge.theater_id == theater_id,
-        TheaterEdge.source_node_id == source_node_id,
-        TheaterEdge.target_node_id == target_node_id,
+    # 拉取当前剧场所有边，用于四元组去重与拓扑环检测
+    all_edges_q = select(TheaterEdge).where(TheaterEdge.theater_id == theater_id)
+    all_edges_r = await db.execute(all_edges_q)
+    existing_edges = [
+        {
+            "source_node_id": e.source_node_id,
+            "target_node_id": e.target_node_id,
+            "source_handle": e.source_handle,
+            "target_handle": e.target_handle,
+        }
+        for e in all_edges_r.scalars().all()
+    ]
+
+    validation = validate_edge(
+        source_id=source_node_id,
+        target_id=target_node_id,
+        source_type=source_node.node_type,
+        target_type=target_node.node_type,
+        source_handle=source_handle or None,
+        target_handle=target_handle or None,
+        existing_edges=existing_edges,
     )
-    existing_result = await db.execute(existing_query)
-    if existing_result.scalar_one_or_none():
-        return _error_result("Edge already exists between these nodes")
+    if not validation.get("ok"):
+        reason = validation.get("reason") or "unknown_type"
+        message = validation.get("message") or "Edge validation failed"
+        return _error_result(message, code=reason)
 
     # 创建连线
     edge = TheaterEdge(

--- a/backend/skills/active_skills/canvas_tools/SKILL.md
+++ b/backend/skills/active_skills/canvas_tools/SKILL.md
@@ -2,7 +2,7 @@
 name: canvas_tools
 description: "Canvas node and edge CRUD operations. Provides tools to manage theater canvas nodes and connections between them."
 metadata:
-  builtin_skill_version: "1.3"
+  builtin_skill_version: "1.4"
 ---
 # Canvas Tools
 
@@ -109,6 +109,42 @@ Edges connect nodes left-to-right. Always use the standard direction:
 - `target_handle`: `"left-target"` (default)
 
 Only deviate if the user explicitly requests a different flow direction.
+
+### Edge Compatibility Matrix (Source → Target)
+
+This matrix is the **single source of truth** for edge legality.
+It is mirrored on the frontend at `frontend/src/lib/canvas/edgeRules.md`.
+Both `create_canvas_edge` and the frontend `onConnect` handler MUST validate against it.
+
+| Source \\ Target | text | image | video | audio | storyboard |
+|---|---|---|---|---|---|
+| **text**       | allow (append/continue) | allow (fill prompt)         | allow (fill prompt)           | allow (fill lyrics/TTS)    | allow (append row / column text) |
+| **image**      | deferred (OCR/caption)  | allow (image-to-image ref)  | allow (first-frame / ref)     | forbid                     | allow (fill media column)        |
+| **video**      | deferred (subtitle)     | allow (frame extract)       | allow (style/continuation)    | deferred (audio extract)   | allow (fill media column)        |
+| **audio**      | deferred (ASR)          | forbid                      | allow (voiceover input)       | deferred (mix)             | allow (fill media column)        |
+| **storyboard** | allow (flatten rows)    | allow (batch generate)      | allow (batch generate)        | allow (batch generate)     | allow (append/merge rows)        |
+
+Legend:
+- **allow** — create the edge.
+- **forbid** — reject the edge and return an error with reason `"forbidden_type_combination"`.
+- **deferred** — phase-1 not supported; reject with reason `"not_supported_yet"` (UI tooltip: "coming soon").
+
+### Hard Constraints
+
+Always reject when any of these hold:
+1. Self-loop: `source_node_id == target_node_id`.
+2. Duplicate edge: same `(source_node_id, source_handle, target_node_id, target_handle)` already exists.
+3. Same-polarity handles: both endpoints are `*-source` or both are `*-target`.
+4. Matrix entry is `forbid` or `deferred`.
+
+### Content Injection Semantics (for reference)
+
+`create_canvas_edge` itself does NOT perform content injection — that is a frontend UX concern.
+However, when planning a workflow, keep the semantics in mind:
+- text → image/video: upstream text becomes the downstream generation prompt.
+- image → image/video: upstream media URL is appended as a reference image.
+- any media → storyboard: URL is written into the matching media column.
+- storyboard → image/video/audio: each row triggers one generation task (downstream app logic).
 
 ---
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -66,6 +66,7 @@
         "recharts": "^3.7.0",
         "remark-gfm": "^4.0.1",
         "socket.io-client": "^4.8.3",
+        "sonner": "^2.0.7",
         "swr": "^2.4.0",
         "tailwind-merge": "^3.5.0",
         "tailwindcss-animate": "^1.0.7",
@@ -50476,6 +50477,16 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmmirror.com/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -69,6 +69,7 @@
     "recharts": "^3.7.0",
     "remark-gfm": "^4.0.1",
     "socket.io-client": "^4.8.3",
+    "sonner": "^2.0.7",
     "swr": "^2.4.0",
     "tailwind-merge": "^3.5.0",
     "tailwindcss-animate": "^1.0.7",

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { AntdRegistry } from "@ant-design/nextjs-registry";
 import { AuthProvider } from "@/context/AuthContext";
 import { ThemeProvider } from "@/context/ThemeContext";
 import I18nProvider from "@/i18n/I18nProvider";
+import { Toaster } from "sonner";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -43,6 +44,7 @@ export default function RootLayout({
             </AuthProvider>
           </I18nProvider>
         </AntdRegistry>
+        <Toaster position="top-center" richColors closeButton />
       </body>
     </html>
   );

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -131,17 +131,18 @@ function FilmStripRow({ cards, duration, reverse, size = "small" }: {
 }
 
 // 表单字段配置（动态国际化）
+// autoComplete 语义对齐 WHATWG 规范：邮箱/用户名/当前密码/新密码，便于密码管理器识别与自动填充
 function getFormFields(t: (key: string) => string) {
   return {
     login: [
-      { name: "email", type: "email", label: t("login.email"), placeholder: t("login.emailPlaceholder"), icon: Mail, required: true },
-      { name: "password", type: "password", label: t("login.password"), placeholder: t("login.passwordPlaceholder"), icon: Lock, required: true },
+      { name: "email", type: "email", label: t("login.email"), placeholder: t("login.emailPlaceholder"), icon: Mail, required: true, autoComplete: "email" },
+      { name: "password", type: "password", label: t("login.password"), placeholder: t("login.passwordPlaceholder"), icon: Lock, required: true, autoComplete: "current-password" },
     ],
     register: [
-      { name: "email", type: "email", label: t("login.email"), placeholder: t("login.emailPlaceholder"), icon: Mail, required: true },
-      { name: "nickname", type: "text", label: t("login.nickname"), placeholder: t("login.nicknamePlaceholder"), icon: User, required: true },
-      { name: "password", type: "password", label: t("login.password"), placeholder: t("login.passwordMinPlaceholder"), icon: Lock, required: true, minLength: 6 },
-      { name: "confirmPassword", type: "password", label: t("login.confirmPassword"), placeholder: t("login.confirmPasswordPlaceholder"), icon: Lock, required: true },
+      { name: "email", type: "email", label: t("login.email"), placeholder: t("login.emailPlaceholder"), icon: Mail, required: true, autoComplete: "email" },
+      { name: "nickname", type: "text", label: t("login.nickname"), placeholder: t("login.nicknamePlaceholder"), icon: User, required: true, autoComplete: "username" },
+      { name: "password", type: "password", label: t("login.password"), placeholder: t("login.passwordMinPlaceholder"), icon: Lock, required: true, minLength: 6, autoComplete: "new-password" },
+      { name: "confirmPassword", type: "password", label: t("login.confirmPassword"), placeholder: t("login.confirmPasswordPlaceholder"), icon: Lock, required: true, autoComplete: "new-password" },
     ],
   };
 }
@@ -408,6 +409,8 @@ export default function LoginPage() {
                         <field.icon className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-muted-foreground" />
                         <input
                           type={field.type === "password" && showPassword[field.name] ? "text" : field.type}
+                          name={field.name}
+                          autoComplete={field.autoComplete}
                           value={formData[field.name] || ""}
                           onChange={(e) => handleInputChange(field.name, e.target.value)}
                           placeholder={field.placeholder}

--- a/frontend/src/app/theater/[id]/hooks/useQuickAddMenu.ts
+++ b/frontend/src/app/theater/[id]/hooks/useQuickAddMenu.ts
@@ -31,7 +31,7 @@ export interface QuickAddMenuState {
 
 export function useQuickAddMenu() {
   const { screenToFlowPosition } = useReactFlow();
-  const { addNode, onConnect } = useCanvasStore();
+  const { addNode, connectAndInject } = useCanvasStore();
 
   const [menuState, setMenuState] = useState<QuickAddMenuState>({
     show: false,
@@ -103,33 +103,21 @@ export function useQuickAddMenu() {
 
     addNode(newNode);
 
-    // Connect based on handle direction
-    let targetHandle = null;
-    let sourceHandle = menuState.sourceHandleId;
-    let connectionSource = menuState.sourceNodeId;
-    let connectionTarget = newNodeId;
+    // 根据拖拽起点 handle 的几何侧边决定连线方向：
+    // - 右侧拖出：原节点 = source，新节点 = target（正向，将原节点内容注入到新节点）
+    // - 左侧拖出：新节点 = source，原节点 = target（反向，新节点为空不会注入，符合几何语义）
+    // Loose 模式下拖拽起点 handle 始终是 `*-source`，因此只看前缀方向。
+    const srcHandle = menuState.sourceHandleId || '';
+    const isLeftEdge = srcHandle.startsWith('left-');
+    const connectionSource = isLeftEdge ? newNodeId : menuState.sourceNodeId;
+    const connectionTarget = isLeftEdge ? menuState.sourceNodeId : newNodeId;
+    const sourceHandle = 'right-source';
+    const targetHandle = 'left-target';
 
-    const handleConnections: Record<string, () => void> = {
-      'left-source': () => { targetHandle = 'right-target'; },
-      'right-source': () => { targetHandle = 'left-target'; },
-      'left-target': () => {
-        connectionSource = newNodeId;
-        connectionTarget = menuState.sourceNodeId!;
-        sourceHandle = 'right-source';
-        targetHandle = 'left-target';
-      },
-      'right-target': () => {
-        connectionSource = newNodeId;
-        connectionTarget = menuState.sourceNodeId!;
-        sourceHandle = 'left-source';
-        targetHandle = 'right-target';
-      },
-    };
-
-    const applyConnection = handleConnections[menuState.sourceHandleId || ''];
-    applyConnection?.();
-
-    onConnect({
+    // 建连线；若源节点有可注入内容，`connectAndInject` 内部会弹 confirm Toast
+    // 让用户选择是否注入。用户选“取消”：线已建立但不注入 = 空节点；
+    // 用户选“注入”：执行 doInject。源节点无内容时内部会提前 return，不弹。
+    connectAndInject({
       source: connectionSource,
       sourceHandle: sourceHandle,
       target: connectionTarget,
@@ -137,7 +125,7 @@ export function useQuickAddMenu() {
     });
 
     setMenuState((prev) => ({ ...prev, show: false }));
-  }, [menuState, screenToFlowPosition, addNode, onConnect]);
+  }, [menuState, screenToFlowPosition, addNode, connectAndInject]);
 
   // Close menu when clicking elsewhere
   useEffect(() => {

--- a/frontend/src/components/canvas/ImageGeneratePanel.tsx
+++ b/frontend/src/components/canvas/ImageGeneratePanel.tsx
@@ -1,11 +1,14 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { XCircle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useImagePanelForm } from '@/hooks/useImagePanelForm';
 import { useImagePanelReferences } from '@/hooks/useImagePanelReferences';
 import { usePanelResize } from '@/hooks/usePanelResize';
+import { onPanelInject, takePendingSmartInject, hasPendingSmartInject } from '@/lib/canvas/panelEvents';
+import { mediaUrlsToDataUrls, TEXT_PROMPT_MAX } from '@/lib/canvas/edgePayload';
+import { edgeToast } from '@/lib/canvas/toast';
 import { ReferenceImagesBar } from './ImageGeneratePanel/ReferenceImagesBar';
 import { PromptInput } from './ImageGeneratePanel/PromptInput';
 import { ModelSelector } from './ImageGeneratePanel/ModelSelector';
@@ -54,6 +57,71 @@ export default function ImageGeneratePanel(props: ImageGeneratePanelProps) {
 
   const [showConfig, setShowConfig] = useState(false);
 
+  // 智能图像注入 handler（提出以便订阅 + pending drain 共用）
+  const handleSmartImageInject = useCallback(
+    (event: { sourceNodeId: string; urls: string[]; name?: string }) => {
+      const urls = (event.urls || []).filter((u) => typeof u === 'string' && u.length > 0);
+      if (urls.length === 0) return;
+      // 1 张 → edit；多张 → reference_images
+      const targetMode = urls.length === 1 ? 'edit' : 'reference_images';
+      const modeLabel = targetMode === 'edit' ? '图像编辑' : '多图参考';
+      const supported = form.visibility.supportedModes.includes(targetMode);
+      if (!supported) {
+        edgeToast.warn(`当前模型不支持「${modeLabel}」模式，请先手动切换模型`);
+        return;
+      }
+      const baseLabel = event.name || t('canvas.node.image.refItem', '参考图');
+      const items = urls.map((url, i) => ({
+        url,
+        name: urls.length > 1 ? `${baseLabel} ${i + 1}` : baseLabel,
+        sourceNodeId: event.sourceNodeId,
+      }));
+      const { appliedCount, droppedCount } = refs.applySmartInject(targetMode, items);
+      droppedCount > 0 && edgeToast.info(`已截断为前 ${appliedCount} 张（「${modeLabel}」模式上限）`);
+    },
+    [form.visibility.supportedModes, refs, t],
+  );
+
+  // 订阅由上游连线触发的面板注入事件
+  useEffect(() => {
+    const handlers: Record<string, (event: any) => void> = {
+      'prompt-prefix': (event: { text: string }) => {
+        // 追加到 prompt 开头，已存在内容用双换行隔开
+        const current = form.prompt;
+        const prefix = event.text.trim();
+        const next = current.trim().length > 0 ? `${prefix}\n\n${current}` : prefix;
+        form.setPrompt(next.slice(0, TEXT_PROMPT_MAX));
+      },
+      'add-reference-image': (event: { sourceNodeId: string; url: string; name?: string }) => {
+        const result = refs.addRefExternal(event.sourceNodeId, event.url, event.name);
+        result.ok === false && result.reason === 'limit' && edgeToast.warn(
+          t('canvas.node.image.refLimitReached', '参考图已达上限，无法再添加'),
+        );
+      },
+      'smart-image-inject': handleSmartImageInject,
+    };
+    const unsubscribe = onPanelInject(nodeId, (ev) => {
+      handlers[ev.type]?.(ev as unknown as { text: string } & { sourceNodeId: string; url: string; urls: string[]; name?: string });
+    });
+    return unsubscribe;
+  }, [nodeId, form, refs, t, handleSmartImageInject]);
+
+  // capabilities 就绪后 drain pending smart-image-inject（涵盖 QuickAdd 时序不同步 + 模型未选场景）
+  useEffect(() => {
+    if (!form.capabilities) return;
+    const pending = takePendingSmartInject(nodeId);
+    pending && handleSmartImageInject(pending);
+  }, [nodeId, form.capabilities, handleSmartImageInject]);
+
+  // 有 pending 却还没选模型 → 自动选模型列表第一个（图像模型普遍支持 edit，动作安全）
+  // 触发链：flatModels 到达 → handleModelSelect → selectedModel 变化 → capabilities 到达 → drain effect
+  useEffect(() => {
+    const shouldAuto = !form.selectedModelKey
+      && form.flatModels.length > 0
+      && hasPendingSmartInject(nodeId);
+    shouldAuto && form.handleModelSelect(form.flatModels[0].key);
+  }, [nodeId, form.selectedModelKey, form.flatModels, form.handleModelSelect]);
+
   const canSubmit =
     !!form.selectedModel &&
     form.prompt.trim().length > 0 &&
@@ -62,16 +130,18 @@ export default function ImageGeneratePanel(props: ImageGeneratePanelProps) {
     form.enabled &&
     refs.refsOk;
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     const m = form.selectedModel;
-    m && onSubmit({
+    if (!m) return;
+    // 将 /api/media/ 本地 URL 转为 base64 data URL，保证 provider 可读
+    const refUrls = refs.referenceImages.map((r) => r.url);
+    const dataUrls = await mediaUrlsToDataUrls(refUrls);
+    onSubmit({
       provider_id: m.provider_id,
       model: m.model_name,
-      prompt: form.prompt.trim(),
+      prompt: form.prompt.trim().slice(0, TEXT_PROMPT_MAX),
       mode: form.mode,
-      reference_images: refs.referenceImages.length > 0
-        ? refs.referenceImages.map((r) => ({ url: r.url }))
-        : undefined,
+      reference_images: dataUrls.length > 0 ? dataUrls.map((url) => ({ url })) : undefined,
       config: {
         aspect_ratio: form.aspectRatio || undefined,
         quality: (form.quality as 'standard' | 'hd' | 'ultra') || undefined,

--- a/frontend/src/components/canvas/ImageNode/AnnotationToolbar.tsx
+++ b/frontend/src/components/canvas/ImageNode/AnnotationToolbar.tsx
@@ -12,6 +12,7 @@ import {
   Trash2,
   Check,
   Loader2,
+  Download,
 } from 'lucide-react';
 import type { AnnotationStateApi, AnnotationTool } from '@/hooks/useAnnotationState';
 
@@ -22,6 +23,7 @@ interface Props {
   saveDisabledReason?: string | null;
   onSave: () => void;
   onCancel: () => void;
+  onDownload?: () => void;
 }
 
 const TOOL_ICON: Record<AnnotationTool, React.ComponentType<{ className?: string }>> = {
@@ -33,7 +35,7 @@ const TOOL_ICON: Record<AnnotationTool, React.ComponentType<{ className?: string
 /**
  * 标注工具栏：模式切换 / 颜色 / 笔触粗细 / 字号 / 撤销重做 / 清空 / 保存。
  */
-export function AnnotationToolbar({ api, isSaving, canSave, saveDisabledReason, onSave, onCancel }: Props) {
+export function AnnotationToolbar({ api, isSaving, canSave, saveDisabledReason, onSave, onCancel, onDownload }: Props) {
   const { t } = useTranslation();
   const tools: AnnotationTool[] = ['pen', 'text', 'eraser'];
 
@@ -153,6 +155,15 @@ export function AnnotationToolbar({ api, isSaving, canSave, saveDisabledReason, 
       <div className="w-px h-6 bg-white/20" />
 
       {/* Actions */}
+      {onDownload && (
+        <button
+          className="w-8 h-8 flex items-center justify-center rounded text-white/70 hover:bg-white/10"
+          onClick={onDownload}
+          title={t('canvas.node.preview.download')}
+        >
+          <Download className="w-4 h-4" />
+        </button>
+      )}
       <Button
         variant="ghost"
         size="sm"

--- a/frontend/src/components/canvas/ImageNode/ImagePreviewPortal.tsx
+++ b/frontend/src/components/canvas/ImageNode/ImagePreviewPortal.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import dynamic from 'next/dynamic';
 import { Button } from '@/components/ui/button';
-import { ZoomIn, ZoomOut, X, PencilLine } from 'lucide-react';
+import { ZoomIn, ZoomOut, X, PencilLine, Download } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { AnnotationCanvasHandle } from './AnnotationCanvas';
 import { AnnotationToolbar } from './AnnotationToolbar';
@@ -73,12 +73,15 @@ export function ImagePreviewPortal({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode, open]);
 
-  // 计算可用画布尺寸
+  // 计算可用画布尺寸（与 view 模式保持一致，取容器的 70%）
   useEffect(() => {
     if (mode !== 'annotate' || !open) return;
     const update = () => {
       const el = containerRef.current;
-      el && setViewport({ w: el.clientWidth, h: el.clientHeight });
+      el && setViewport({
+        w: Math.floor(el.clientWidth * 0.7),
+        h: Math.floor(el.clientHeight * 0.7),
+      });
     };
     update();
     window.addEventListener('resize', update);
@@ -104,6 +107,28 @@ export function ImagePreviewPortal({
       if (!window.confirm(t('canvas.node.annotation.confirmDiscard'))) return;
     }
     onClose();
+  };
+
+  const handleDownload = async () => {
+    if (!url) return;
+    const fallback = () => window.open(url, '_blank');
+    try {
+      const resp = await fetch(url, { mode: 'cors' });
+      if (!resp.ok) return fallback();
+      const blob = await resp.blob();
+      const blobUrl = URL.createObjectURL(blob);
+      const ext = (blob.type.split('/')[1] || 'png').split(';')[0];
+      const safeName = (name || 'image').replace(/[\\/:*?"<>|]/g, '_');
+      const link = document.createElement('a');
+      link.href = blobUrl;
+      link.download = /\.[a-z0-9]+$/i.test(safeName) ? safeName : `${safeName}.${ext}`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      setTimeout(() => URL.revokeObjectURL(blobUrl), 1000);
+    } catch {
+      fallback();
+    }
   };
 
   return createPortal(
@@ -136,18 +161,6 @@ export function ImagePreviewPortal({
             >
               <ZoomOut className="h-5 w-5" />
             </Button>
-            {annotationEnabled && (
-              <Button
-                variant="secondary"
-                size="sm"
-                className="bg-black/50 hover:bg-black/70 text-white border-none backdrop-blur-md"
-                onClick={(e) => { e.stopPropagation(); onEnterAnnotate(); }}
-                title={t('canvas.node.annotation.enter')}
-              >
-                <PencilLine className="h-4 w-4 mr-1" />
-                {t('canvas.node.annotation.enter')}
-              </Button>
-            )}
           </>
         )}
         <Button
@@ -163,11 +176,11 @@ export function ImagePreviewPortal({
 
       {/* Main area */}
       {mode === 'view' && (
-        <div id="preview-container" className="w-full h-full flex items-center justify-center overflow-hidden p-8">
+        <div id="preview-container" className="w-full h-full flex items-center justify-center overflow-hidden p-8 pb-28">
           <img
             src={url || undefined}
             alt={name}
-            className="max-w-full max-h-full object-contain transition-transform duration-75 ease-out select-none"
+            className="max-w-[70%] max-h-[70%] object-contain transition-transform duration-75 ease-out select-none"
             style={{
               transform: `translate(${position.x}px, ${position.y}px) scale(${scale})`,
               cursor: isDragging ? 'grabbing' : 'grab',
@@ -178,6 +191,38 @@ export function ImagePreviewPortal({
             onPointerUp={onPointerUp}
             onClick={(e) => e.stopPropagation()}
           />
+        </div>
+      )}
+
+      {/* View-mode bottom toolbar: download + enter annotation (aligned with annotate mode toolbar) */}
+      {mode === 'view' && (
+        <div
+          className="absolute bottom-6 left-1/2 -translate-x-1/2 z-50"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="flex items-center gap-2 bg-black/70 backdrop-blur-md text-white rounded-lg px-3 py-2 shadow-lg pointer-events-auto">
+            <button
+              className="h-8 px-3 flex items-center gap-1.5 rounded text-white/90 hover:bg-white/10 text-sm"
+              onClick={handleDownload}
+              title={t('canvas.node.preview.download')}
+            >
+              <Download className="w-4 h-4" />
+              <span>{t('canvas.node.preview.download')}</span>
+            </button>
+            {annotationEnabled && (
+              <>
+                <div className="w-px h-6 bg-white/20" />
+                <button
+                  className="h-8 px-3 flex items-center gap-1.5 rounded text-white/90 hover:bg-white/10 text-sm"
+                  onClick={onEnterAnnotate}
+                  title={t('canvas.node.annotation.enter')}
+                >
+                  <PencilLine className="w-4 h-4" />
+                  <span>{t('canvas.node.annotation.enter')}</span>
+                </button>
+              </>
+            )}
+          </div>
         </div>
       )}
 
@@ -206,6 +251,7 @@ export function ImagePreviewPortal({
               saveDisabledReason={isFull ? t('canvas.node.upload.maxReached', { max: 9 }) : null}
               onSave={handleSave}
               onCancel={handleExit}
+              onDownload={handleDownload}
             />
           </div>
         </>

--- a/frontend/src/components/canvas/VideoGeneratePanel.tsx
+++ b/frontend/src/components/canvas/VideoGeneratePanel.tsx
@@ -1,11 +1,18 @@
 'use client';
 
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, useEffect, useCallback } from 'react';
 import { XCircle } from 'lucide-react';
 import { useDropdownOutside } from '@/hooks/useDropdownOutside';
 import { useVideoPanelForm } from '@/hooks/useVideoPanelForm';
 import { useVideoPanelReferences } from '@/hooks/useVideoPanelReferences';
 import { useVideoPanelResize } from '@/hooks/useVideoPanelResize';
+import { onPanelInject, takePendingSmartInject, hasPendingSmartInject } from '@/lib/canvas/panelEvents';
+import {
+  mediaUrlsToDataUrls,
+  mediaUrlToDataUrl,
+  TEXT_PROMPT_MAX,
+} from '@/lib/canvas/edgePayload';
+import { edgeToast } from '@/lib/canvas/toast';
 import { AttachmentPreviews } from './VideoGeneratePanel/AttachmentPreviews';
 import { PromptInputArea } from './VideoGeneratePanel/PromptInputArea';
 import { ModelSelector } from './VideoGeneratePanel/ModelSelector';
@@ -38,6 +45,7 @@ export default function VideoGeneratePanel(props: VideoGeneratePanelProps) {
     initialConfig,
     onLinkNode,
     onUnlinkNode,
+    nodeId,
   } = props;
 
   // ── 三大 hook ──
@@ -62,6 +70,82 @@ export default function VideoGeneratePanel(props: VideoGeneratePanelProps) {
 
   useDropdownOutside([[showConfig, configRef, setShowConfig]]);
 
+  // 智能图像注入 handler（提出以便订阅 + pending drain 共用）
+  const handleSmartImageInject = useCallback(
+    (event: { sourceNodeId: string; urls: string[]; name?: string }) => {
+      const urls = (event.urls || []).filter((u) => typeof u === 'string' && u.length > 0);
+      if (urls.length === 0) return;
+      // 1 张 → image_to_video；多张 → reference_images
+      const targetMode = urls.length === 1 ? 'image_to_video' : 'reference_images';
+      const modeLabel = targetMode === 'image_to_video' ? '图生视频' : '多模态参考';
+      const modes = form.capabilities?.modes || [];
+      const supported = modes.includes(targetMode);
+      if (!supported) {
+        edgeToast.warn(`当前模型不支持「${modeLabel}」模式，请先手动切换模型`);
+        return;
+      }
+      const baseLabel = event.name || '参考图';
+      const items = urls.map((url, i) => ({
+        url,
+        name: urls.length > 1 ? `${baseLabel} ${i + 1}` : baseLabel,
+        sourceNodeId: event.sourceNodeId,
+      }));
+      const { appliedCount, droppedCount } = refs.applySmartInject(targetMode, items);
+      droppedCount > 0 && edgeToast.info(`已截断为前 ${appliedCount} 张（「${modeLabel}」模式上限）`);
+    },
+    [form.capabilities, refs],
+  );
+
+  // 订阅上游连线触发的面板注入事件
+  useEffect(() => {
+    const warnLimit = () => edgeToast.warn('参考项已达上限，无法再添加');
+    const warnNoSlot = () => edgeToast.warn('当前模式不接受这种参考项');
+    const warnDup = () => edgeToast.info('该参考项已存在');
+    const handleAfter = (r: { ok: boolean; reason?: 'no_slot' | 'limit' | 'duplicate' }) => {
+      r.ok === false && r.reason === 'limit' && warnLimit();
+      r.ok === false && r.reason === 'no_slot' && warnNoSlot();
+      r.ok === false && r.reason === 'duplicate' && warnDup();
+    };
+    const handlers: Record<string, (event: any) => void> = {
+      'prompt-prefix': (event: { text: string }) => {
+        const current = form.prompt;
+        const prefix = event.text.trim();
+        const next = current.trim().length > 0 ? `${prefix}\n\n${current}` : prefix;
+        form.setPrompt(next.slice(0, TEXT_PROMPT_MAX));
+      },
+      'add-reference-image': (event: { sourceNodeId: string; url: string; name?: string; tag?: 'first-frame' }) => {
+        handleAfter(refs.addImageExternal(event.sourceNodeId, event.url, event.name, event.tag));
+      },
+      'add-reference-video': (event: { sourceNodeId: string; url: string; name?: string }) => {
+        handleAfter(refs.addVideoExternal(event.sourceNodeId, event.url, event.name));
+      },
+      'add-reference-audio': (event: { sourceNodeId: string; url: string; name?: string }) => {
+        handleAfter(refs.addAudioExternal(event.sourceNodeId, event.url, event.name));
+      },
+      'smart-image-inject': handleSmartImageInject,
+    };
+    const unsubscribe = onPanelInject(nodeId, (ev) => {
+      handlers[ev.type]?.(ev as unknown as { text: string } & { sourceNodeId: string; url: string; urls: string[]; name?: string; tag?: 'first-frame' });
+    });
+    return unsubscribe;
+  }, [nodeId, form, refs, handleSmartImageInject]);
+
+  // capabilities 就绪后 drain pending smart-image-inject（涵盖 QuickAdd 时序不同步 + 模型未选场景）
+  useEffect(() => {
+    if (!form.capabilities) return;
+    const pending = takePendingSmartInject(nodeId);
+    pending && handleSmartImageInject(pending);
+  }, [nodeId, form.capabilities, handleSmartImageInject]);
+
+  // 有 pending 却还没选模型 → 自动选模型列表第一个。视频模型不一定支持 image_to_video / reference_images，
+  // 不支持时 drain 分支将弹警告提醒用户手动换模型；首选可尽量视为“合理默认”。
+  useEffect(() => {
+    const shouldAuto = !form.selectedModelKey
+      && form.flatModels.length > 0
+      && hasPendingSmartInject(nodeId);
+    shouldAuto && form.handleModelChange(form.flatModels[0].key);
+  }, [nodeId, form.selectedModelKey, form.flatModels, form.handleModelChange]);
+
   const canSubmit =
     !!form.selectedModel &&
     form.prompt.trim().length > 0 &&
@@ -73,26 +157,34 @@ export default function VideoGeneratePanel(props: VideoGeneratePanelProps) {
     form.handleModelChange(key);
   };
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     const m = form.selectedModel;
+    if (!m) return;
     const isRef = form.videoMode === 'reference_images';
     const imgRefs = refs.referenceImages.filter((r) => r.refType === 'image');
     const vidRefs = refs.referenceImages.filter((r) => r.refType === 'video');
     const audRefs = refs.referenceImages.filter((r) => r.refType === 'audio');
-    m && onSubmit({
+    // 将所有本地 /api/media/ URL 转为 base64 data URL
+    const [imgUrls, vidUrls, audUrls, firstFrame, lastFrame, extVideo] = await Promise.all([
+      mediaUrlsToDataUrls(imgRefs.map((r) => r.url)),
+      mediaUrlsToDataUrls(vidRefs.map((r) => r.url)),
+      mediaUrlsToDataUrls(audRefs.map((r) => r.url)),
+      refs.imageUrl && form.visibility.showFirstFrame ? mediaUrlToDataUrl(refs.imageUrl) : Promise.resolve(''),
+      refs.lastFrameImageUrl && form.visibility.showLastFrame ? mediaUrlToDataUrl(refs.lastFrameImageUrl) : Promise.resolve(''),
+      refs.extensionVideoUrl && (form.videoMode === 'edit' || form.videoMode === 'video_extension')
+        ? mediaUrlToDataUrl(refs.extensionVideoUrl) : Promise.resolve(''),
+    ]);
+    onSubmit({
       provider_id: m.provider_id,
       model: m.model_name,
       video_mode: form.videoMode,
-      prompt: form.prompt.trim(),
-      image_url: form.visibility.showFirstFrame ? refs.imageUrl || undefined : undefined,
-      last_frame_image: form.visibility.showLastFrame ? refs.lastFrameImageUrl || undefined : undefined,
-      reference_images: isRef && imgRefs.length > 0 ? imgRefs.map((r) => ({ url: r.url })) : undefined,
-      reference_videos: isRef && vidRefs.length > 0 ? vidRefs.map((r) => ({ url: r.url })) : undefined,
-      reference_audios: isRef && audRefs.length > 0 ? audRefs.map((r) => ({ url: r.url })) : undefined,
-      extension_video_url:
-        (form.videoMode === 'edit' || form.videoMode === 'video_extension') && refs.extensionVideoUrl
-          ? refs.extensionVideoUrl
-          : undefined,
+      prompt: form.prompt.trim().slice(0, TEXT_PROMPT_MAX),
+      image_url: firstFrame || undefined,
+      last_frame_image: lastFrame || undefined,
+      reference_images: isRef && imgUrls.length > 0 ? imgUrls.map((url) => ({ url })) : undefined,
+      reference_videos: isRef && vidUrls.length > 0 ? vidUrls.map((url) => ({ url })) : undefined,
+      reference_audios: isRef && audUrls.length > 0 ? audUrls.map((url) => ({ url })) : undefined,
+      extension_video_url: extVideo || undefined,
       config: {
         duration: form.duration,
         quality: form.quality,

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -200,6 +200,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
 
       const data = await response.json();
       localStorage.setItem("access_token", data.access_token);
+      // 后端一次性轮换：同步写回新的 refresh_token，避免旧 token 被拉黑后二次刷新失败
+      data.refresh_token && localStorage.setItem("refresh_token", data.refresh_token);
       return true;
     } catch {
       logout();

--- a/frontend/src/hooks/useImageNodeConnections.ts
+++ b/frontend/src/hooks/useImageNodeConnections.ts
@@ -15,12 +15,14 @@ export function useImageNodeConnections(targetId: string) {
   const linkNode = useCallback((sourceNodeId: string) => {
     const edges = getEdges();
     const alreadyLinked = edges.some((e) => e.source === sourceNodeId && e.target === targetId);
-    alreadyLinked || useCanvasStore.getState().onConnect({
+    // 面板内选取已隐含用户同意且已有 ref 挂载，不重复弹注入确认。
+    // 校验失败用 silent 模式（避免打断面板交互）
+    alreadyLinked || useCanvasStore.getState().connectAndInject({
       source: sourceNodeId,
       sourceHandle: 'right-source',
       target: targetId,
       targetHandle: 'left-target',
-    });
+    }, { fromQuickAdd: true, silent: true });
   }, [targetId, getEdges]);
 
   const unlinkNode = useCallback((sourceNodeId: string) => {

--- a/frontend/src/hooks/useImagePanelReferences.ts
+++ b/frontend/src/hooks/useImagePanelReferences.ts
@@ -43,8 +43,14 @@ export function useImagePanelReferences({
 
   // mode 切换时：清空参考图并解除已建立的连线
   const prevModeRef = useRef<ImageMode>(mode);
+  // 智能注入：标记下一次 mode 切换 effect 跳过清空副作用
+  const skipNextClearRef = useRef(false);
   useEffect(() => {
-    prevModeRef.current !== mode && (() => {
+    const skip = skipNextClearRef.current;
+    skip && (skipNextClearRef.current = false);
+    skip && (prevModeRef.current = mode);
+    const shouldClear = !skip && prevModeRef.current !== mode;
+    shouldClear && (() => {
       referenceImages.forEach((r) => r.sourceNodeId !== nodeId && onUnlinkNode?.(r.sourceNodeId));
       setReferenceImages([]);
       prevModeRef.current = mode;
@@ -89,12 +95,53 @@ export function useImagePanelReferences({
     return maxRefs === 1; // 提示调用方可关闭 picker
   }, [referenceImages.length, maxRefs, onLinkNode, nodeId, t]);
 
+  /**
+   * 外部添加一项参考图（例如来自上游节点连线注入）。
+   * 返回 { ok, reason }，ok=false 时 reason='limit'|'duplicate'。
+   */
+  const addRefExternal = useCallback(
+    (sourceNodeId: string, url: string, name?: string): { ok: boolean; reason?: 'limit' | 'duplicate' } => {
+      const duplicate = referenceImages.some((r) => r.sourceNodeId === sourceNodeId);
+      if (duplicate) return { ok: false, reason: 'duplicate' };
+      const reached = referenceImages.length >= maxRefs;
+      if (reached) return { ok: false, reason: 'limit' };
+      const label = name || t('canvas.node.image.refItem', '参考图');
+      setReferenceImages((prev) => [...prev, { url, name: label, sourceNodeId }]);
+      return { ok: true };
+    },
+    [referenceImages, maxRefs, t],
+  );
+
   // 先 unlink 再 setState（避免在 updater 中调用外部 setState）
   const removeRef = useCallback((idx: number) => {
     const target = referenceImages[idx];
     target && target.sourceNodeId !== nodeId && onUnlinkNode?.(target.sourceNodeId);
     setReferenceImages((prev) => prev.filter((_, i) => i !== idx));
   }, [referenceImages, onUnlinkNode, nodeId]);
+
+  /**
+   * 智能注入：一次性切换模式并填入参考图，跳过 mode 切换的自动清空副作用。
+   * 返回 {appliedCount, droppedCount}；droppedCount > 0 意味着因模式上限被截断。
+   */
+  const applySmartInject = useCallback(
+    (targetMode: ImageMode, items: { url: string; name: string; sourceNodeId: string }[]) => {
+      // 先解除当前已连接的外部源
+      referenceImages.forEach((r) => r.sourceNodeId !== nodeId && onUnlinkNode?.(r.sourceNodeId));
+      // 模式将变 → 跳过一次清空 effect
+      const modeWillChange = targetMode !== mode;
+      modeWillChange && (skipNextClearRef.current = true);
+      setMode(targetMode);
+      const limit = IMAGE_MODE_MAX_REFS[targetMode] || 0;
+      const truncated = limit > 0 ? items.slice(0, limit) : [];
+      setReferenceImages(truncated);
+      truncated.forEach((it) => it.sourceNodeId !== nodeId && onLinkNode?.(it.sourceNodeId));
+      return {
+        appliedCount: truncated.length,
+        droppedCount: Math.max(0, items.length - truncated.length),
+      };
+    },
+    [referenceImages, nodeId, mode, setMode, onLinkNode, onUnlinkNode],
+  );
 
   // 参考图数量校验
   const refsOk =
@@ -109,5 +156,7 @@ export function useImagePanelReferences({
     refsOk,
     selectNode,
     removeRef,
+    addRefExternal,
+    applySmartInject,
   };
 }

--- a/frontend/src/hooks/useVideoNodeConnections.ts
+++ b/frontend/src/hooks/useVideoNodeConnections.ts
@@ -15,12 +15,13 @@ export function useVideoNodeConnections(targetId: string) {
   const linkNode = useCallback((sourceNodeId: string) => {
     const edges = getEdges();
     const alreadyLinked = edges.some((e) => e.source === sourceNodeId && e.target === targetId);
-    alreadyLinked || useCanvasStore.getState().onConnect({
+    // 面板内选取已隐含用户同意且已有 ref 挂载，不重复弹注入确认。
+    alreadyLinked || useCanvasStore.getState().connectAndInject({
       source: sourceNodeId,
       sourceHandle: 'right-source',
       target: targetId,
       targetHandle: 'left-target',
-    });
+    }, { fromQuickAdd: true, silent: true });
   }, [targetId, getEdges]);
 
   const unlinkNode = useCallback((sourceNodeId: string) => {

--- a/frontend/src/hooks/useVideoPanelReferences.ts
+++ b/frontend/src/hooks/useVideoPanelReferences.ts
@@ -87,12 +87,16 @@ export function useVideoPanelReferences({
   const unlinkAll = useCallback(() => unlinkAllRef.current(), []);
 
   // ── 模式变更时清空对应字段并解除连线 ──
+  // 智能注入：标记下一次 videoMode 变更 effect 跳过清空副作用
+  const skipNextClearRef = useRef(false);
   useEffect(() => {
-    unlinkAll();
-    videoMode === 'text_to_video' && (setImageUrl(''), setLastFrameImageUrl(''), setReferenceImages([]), setExtensionVideoUrl(''));
-    videoMode === 'image_to_video' && (setReferenceImages([]), setExtensionVideoUrl(''));
-    videoMode === 'reference_images' && (setImageUrl(''), setLastFrameImageUrl(''), setExtensionVideoUrl(''));
-    (videoMode === 'edit' || videoMode === 'video_extension') && (setReferenceImages([]), setImageUrl(''), setLastFrameImageUrl(''));
+    const skip = skipNextClearRef.current;
+    skip && (skipNextClearRef.current = false);
+    !skip && unlinkAll();
+    !skip && videoMode === 'text_to_video' && (setImageUrl(''), setLastFrameImageUrl(''), setReferenceImages([]), setExtensionVideoUrl(''));
+    !skip && videoMode === 'image_to_video' && (setReferenceImages([]), setExtensionVideoUrl(''));
+    !skip && videoMode === 'reference_images' && (setImageUrl(''), setLastFrameImageUrl(''), setExtensionVideoUrl(''));
+    !skip && (videoMode === 'edit' || videoMode === 'video_extension') && (setReferenceImages([]), setImageUrl(''), setLastFrameImageUrl(''));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [videoMode]);
 
@@ -296,6 +300,147 @@ export function useVideoPanelReferences({
     setExtensionVideoUrl('');
   }, [unlinkNode]);
 
+  // ── 外部注入（上游连线触发） ──
+  type ExternalRejectReason = 'no_slot' | 'limit' | 'duplicate';
+  type ExternalResult = { ok: boolean; reason?: ExternalRejectReason };
+
+  /** 由上游 image 节点或 video 首帧注入一张参考图 */
+  const addImageExternal = useCallback(
+    (sourceNodeId: string, url: string, name?: string, tag?: 'first-frame'): ExternalResult => {
+      const label = name || sourceNodeId.slice(0, 8);
+      // 1）single_image / first_last_frame：首选首帧槽位（特别是 tag='first-frame'）
+      const singleSlotAvailable =
+        (pickerMode === 'single_image' || pickerMode === 'first_last_frame') && !imageUrl;
+      const lastSlotAvailable =
+        pickerMode === 'first_last_frame' && !!imageUrl && !lastFrameImageUrl;
+      const putSingle = () => {
+        setImageUrl(url);
+        imageNodeIdRef.current = sourceNodeId;
+      };
+      const putLast = () => {
+        setLastFrameImageUrl(url);
+        lastFrameNodeIdRef.current = sourceNodeId;
+      };
+      singleSlotAvailable && putSingle();
+      !singleSlotAvailable && lastSlotAvailable && putLast();
+      const usedSingleSlot = singleSlotAvailable || lastSlotAvailable;
+      if (usedSingleSlot) return { ok: true };
+      // 2）multi_image：往 referenceImages 追加
+      const isMulti = pickerMode === 'multi_image';
+      const duplicate = referenceImages.some((r) => r.sourceNodeId === sourceNodeId && r.refType === 'image');
+      const reached = imageRefCount >= maxRefImages;
+      const canAddMulti = isMulti && !duplicate && !reached;
+      canAddMulti && (() => {
+        setReferenceImages((prev) => [...prev, { url, name: label, refType: 'image' as RefType, sourceNodeId }]);
+        inputRef.current?.insertTag(imageRefCount + 1, label, 'image');
+      })();
+      if (canAddMulti) return { ok: true };
+      const failReason: ExternalRejectReason = !isMulti ? 'no_slot' : duplicate ? 'duplicate' : 'limit';
+      void tag;
+      return { ok: false, reason: failReason };
+    },
+    [pickerMode, imageUrl, lastFrameImageUrl, referenceImages, imageRefCount, maxRefImages],
+  );
+
+  /** 由上游 video 节点注入一个视频参考 */
+  const addVideoExternal = useCallback(
+    (sourceNodeId: string, url: string, name?: string): ExternalResult => {
+      const label = name || sourceNodeId.slice(0, 8);
+      // 1）video pickerMode（edit / video_extension）：填延展视频
+      const videoSlotAvailable = pickerMode === 'video' && !extensionVideoUrl;
+      videoSlotAvailable && (() => {
+        setExtensionVideoUrl(url);
+        extensionVideoNodeIdRef.current = sourceNodeId;
+      })();
+      if (videoSlotAvailable) return { ok: true };
+      // 2）multi_image：追加为 video 参考
+      const isMulti = pickerMode === 'multi_image';
+      const canAddVideoMulti = isMulti && supportsRefVideos;
+      const duplicate = referenceImages.some((r) => r.sourceNodeId === sourceNodeId && r.refType === 'video');
+      const reached = videoRefCount >= maxRefVideos;
+      const canAdd = canAddVideoMulti && !duplicate && !reached;
+      canAdd && (() => {
+        setReferenceImages((prev) => [...prev, { url, name: label, refType: 'video' as RefType, sourceNodeId }]);
+        inputRef.current?.insertTag(videoRefCount + 1, label, 'video');
+      })();
+      if (canAdd) return { ok: true };
+      const failReason: ExternalRejectReason = !canAddVideoMulti ? 'no_slot' : duplicate ? 'duplicate' : 'limit';
+      return { ok: false, reason: failReason };
+    },
+    [pickerMode, extensionVideoUrl, supportsRefVideos, referenceImages, videoRefCount, maxRefVideos],
+  );
+
+  /** 由上游 audio 节点注入一个音频参考（仅 multi_image 且支持 audio） */
+  const addAudioExternal = useCallback(
+    (sourceNodeId: string, url: string, name?: string): ExternalResult => {
+      const label = name || sourceNodeId.slice(0, 8);
+      const isMulti = pickerMode === 'multi_image';
+      const canAddAudioMulti = isMulti && supportsRefAudios;
+      const duplicate = referenceImages.some((r) => r.sourceNodeId === sourceNodeId && r.refType === 'audio');
+      const reached = audioRefCount >= maxRefAudios;
+      const canAdd = canAddAudioMulti && !duplicate && !reached;
+      canAdd && (() => {
+        setReferenceImages((prev) => [...prev, { url, name: label, refType: 'audio' as RefType, sourceNodeId }]);
+        inputRef.current?.insertTag(audioRefCount + 1, label, 'audio');
+      })();
+      if (canAdd) return { ok: true };
+      const failReason: ExternalRejectReason = !canAddAudioMulti ? 'no_slot' : duplicate ? 'duplicate' : 'limit';
+      return { ok: false, reason: failReason };
+    },
+    [pickerMode, supportsRefAudios, referenceImages, audioRefCount, maxRefAudios],
+  );
+
+  /**
+   * 智能注入：一次性切换 videoMode 并填入图像参考，跳过 mode 切换的自动清空副作用。
+   * - targetMode = 'image_to_video'：填第一张到首帧槽（imageUrl）
+   * - targetMode = 'reference_images'：按 maxRefImages 截断填入 referenceImages
+   */
+  const applySmartInject = useCallback(
+    (
+      targetMode: 'image_to_video' | 'reference_images',
+      items: { url: string; name: string; sourceNodeId: string }[],
+    ) => {
+      // 1) 先清理旧连线
+      unlinkAll();
+      const modeWillChange = targetMode !== videoMode;
+      modeWillChange && (skipNextClearRef.current = true);
+      setVideoMode(targetMode);
+      // 2) 重置所有槽位
+      setImageUrl('');
+      setLastFrameImageUrl('');
+      setExtensionVideoUrl('');
+      setReferenceImages([]);
+      // 3) image_to_video：取第一张填首帧
+      const i2v = targetMode === 'image_to_video';
+      const firstItem = items[0];
+      i2v && firstItem && (() => {
+        setImageUrl(firstItem.url);
+        imageNodeIdRef.current = firstItem.sourceNodeId;
+        firstItem.sourceNodeId && onLinkNode?.(firstItem.sourceNodeId);
+      })();
+      if (i2v) {
+        return { appliedCount: firstItem ? 1 : 0, droppedCount: Math.max(0, items.length - 1) };
+      }
+      // 4) reference_images：按上限截断填入
+      const limit = maxRefImages;
+      const truncated = items.slice(0, limit);
+      const nextRefs: RefImage[] = truncated.map((it) => ({
+        url: it.url,
+        name: it.name,
+        refType: 'image' as RefType,
+        sourceNodeId: it.sourceNodeId,
+      }));
+      setReferenceImages(nextRefs);
+      truncated.forEach((it) => it.sourceNodeId && onLinkNode?.(it.sourceNodeId));
+      // 延后插入 prompt tag（等待 setState 射出后的 DOM 就绪）
+      setTimeout(() => {
+        truncated.forEach((it, idx) => inputRef.current?.insertTag(idx + 1, it.name, 'image'));
+      }, 0);
+      return { appliedCount: truncated.length, droppedCount: Math.max(0, items.length - limit) };
+    },
+    [videoMode, maxRefImages, onLinkNode, setVideoMode],
+  );
+
   return {
     // 状态
     imageUrl,
@@ -331,6 +476,11 @@ export function useVideoPanelReferences({
     clearFirstLastFrames,
     clearLastFrame,
     clearExtensionVideo,
+    // 外部注入
+    addImageExternal,
+    addVideoExternal,
+    addAudioExternal,
+    applySmartInject,
   };
 }
 

--- a/frontend/src/i18n/locales/en-US.json
+++ b/frontend/src/i18n/locales/en-US.json
@@ -268,7 +268,9 @@
         "dragOrFullscreen": "Drag to move / Double-click for fullscreen preview",
         "zoomIn": "Zoom in",
         "zoomOut": "Zoom out",
-        "close": "Close"
+        "close": "Close",
+        "download": "Download",
+        "downloadFailed": "Download failed"
       },
       "annotation": {
         "enter": "Annotate",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -268,7 +268,9 @@
         "dragOrFullscreen": "拖拽移动节点 / 双击全屏预览",
         "zoomIn": "放大",
         "zoomOut": "缩小",
-        "close": "关闭"
+        "close": "关闭",
+        "download": "下载",
+        "downloadFailed": "下载失败"
       },
       "annotation": {
         "enter": "标注",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -66,6 +66,8 @@ api.interceptors.response.use(
         refresh_token: refreshToken,
       });
       localStorage.setItem("access_token", data.access_token);
+      // 后端采用一次性轮换：必须同步写回新的 refresh_token，否则下次刷新必挂
+      data.refresh_token && localStorage.setItem("refresh_token", data.refresh_token);
       original.headers.set("Authorization", `Bearer ${data.access_token}`);
       processQueue(null, data.access_token);
       return api(original);

--- a/frontend/src/lib/canvas/__tests__/edgeRules.test.ts
+++ b/frontend/src/lib/canvas/__tests__/edgeRules.test.ts
@@ -1,0 +1,174 @@
+/**
+ * edgeRules.ts 矩阵与 validateEdge 的单元测试。
+ * 测试覆盖：
+ *  - 5x5 矩阵字面值与 edgeRules.md 第 4 节一致
+ *  - validateEdge 早返回顺序（self_loop → same_polarity → duplicate_edge → cycle → matrix）
+ */
+import type { Edge } from '@xyflow/react';
+import {
+  EDGE_LEGALITY_MATRIX,
+  validateEdge,
+  getEdgeLegality,
+  type NodeType,
+} from '../edgeRules';
+
+const noEdges: Edge[] = [];
+
+const mkEdge = (source: string, target: string, sh = 'right-source', th = 'left-target'): Edge => ({
+  id: `${source}->${target}`,
+  source,
+  target,
+  sourceHandle: sh,
+  targetHandle: th,
+});
+
+describe('EDGE_LEGALITY_MATRIX 字面值锁定', () => {
+  it('text 行：全 allow', () => {
+    expect(EDGE_LEGALITY_MATRIX.text).toEqual({
+      text: 'allow', image: 'allow', video: 'allow', audio: 'allow', storyboard: 'allow',
+    });
+  });
+
+  it('image 行：→audio=forbid, →text=deferred，其余 allow', () => {
+    expect(EDGE_LEGALITY_MATRIX.image).toEqual({
+      text: 'deferred', image: 'allow', video: 'allow', audio: 'forbid', storyboard: 'allow',
+    });
+  });
+
+  it('video 行：→text=deferred, →audio=deferred，其余 allow', () => {
+    expect(EDGE_LEGALITY_MATRIX.video).toEqual({
+      text: 'deferred', image: 'allow', video: 'allow', audio: 'deferred', storyboard: 'allow',
+    });
+  });
+
+  it('audio 行：→image=forbid, →text=deferred, →audio=deferred，其余 allow', () => {
+    expect(EDGE_LEGALITY_MATRIX.audio).toEqual({
+      text: 'deferred', image: 'forbid', video: 'allow', audio: 'deferred', storyboard: 'allow',
+    });
+  });
+
+  it('storyboard 行：全 allow', () => {
+    expect(EDGE_LEGALITY_MATRIX.storyboard).toEqual({
+      text: 'allow', image: 'allow', video: 'allow', audio: 'allow', storyboard: 'allow',
+    });
+  });
+});
+
+describe('validateEdge 硬约束', () => {
+  it('self_loop：拒绝自环', () => {
+    const r = validateEdge({
+      sourceId: 'n1', targetId: 'n1',
+      sourceType: 'text', targetType: 'text',
+      sourceHandle: 'right-source', targetHandle: 'left-target',
+      existingEdges: noEdges,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('self_loop');
+  });
+
+  it('same_polarity：同侧 handle（都在 right）拒绝', () => {
+    const r = validateEdge({
+      sourceId: 'a', targetId: 'b',
+      sourceType: 'text', targetType: 'text',
+      sourceHandle: 'right-source', targetHandle: 'right-source',
+      existingEdges: noEdges,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('same_polarity');
+  });
+
+  it('same_polarity：异侧 source→source 放行（Loose 模式典型场景）', () => {
+    // 回归用例：ReactFlow ConnectionMode.Loose 下，*-source 覆盖在 *-target 上层，
+    // 图像右边 → 视频左边的拖拽两端都会命中 *-source，但几何上属于异侧，应放行。
+    const r = validateEdge({
+      sourceId: 'a', targetId: 'b',
+      sourceType: 'image', targetType: 'video',
+      sourceHandle: 'right-source', targetHandle: 'left-source',
+      existingEdges: noEdges,
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it('duplicate_edge：完全相同四元组拒绝', () => {
+    const existing: Edge[] = [mkEdge('a', 'b')];
+    const r = validateEdge({
+      sourceId: 'a', targetId: 'b',
+      sourceType: 'text', targetType: 'text',
+      sourceHandle: 'right-source', targetHandle: 'left-target',
+      existingEdges: existing,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('duplicate_edge');
+  });
+
+  it('cycle：A→B 存在时 B→A 拒绝', () => {
+    const existing: Edge[] = [mkEdge('A', 'B')];
+    const r = validateEdge({
+      sourceId: 'B', targetId: 'A',
+      sourceType: 'text', targetType: 'text',
+      sourceHandle: 'right-source', targetHandle: 'left-target',
+      existingEdges: existing,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('cycle');
+  });
+});
+
+describe('validateEdge 矩阵', () => {
+  const base = {
+    sourceId: 'a', targetId: 'b',
+    sourceHandle: 'right-source', targetHandle: 'left-target',
+    existingEdges: noEdges,
+  } as const;
+
+  it('image→audio：forbid', () => {
+    const r = validateEdge({ ...base, sourceType: 'image', targetType: 'audio' });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('forbidden_type_combination');
+  });
+
+  it('audio→image：forbid', () => {
+    const r = validateEdge({ ...base, sourceType: 'audio', targetType: 'image' });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('forbidden_type_combination');
+  });
+
+  it('image→text：deferred → not_supported_yet', () => {
+    const r = validateEdge({ ...base, sourceType: 'image', targetType: 'text' });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('not_supported_yet');
+  });
+
+  it('video→audio：deferred → not_supported_yet', () => {
+    const r = validateEdge({ ...base, sourceType: 'video', targetType: 'audio' });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('not_supported_yet');
+  });
+
+  it('text→image：allow', () => {
+    const r = validateEdge({ ...base, sourceType: 'text', targetType: 'image' });
+    expect(r.ok).toBe(true);
+  });
+
+  it('storyboard→video：allow', () => {
+    const r = validateEdge({ ...base, sourceType: 'storyboard', targetType: 'video' });
+    expect(r.ok).toBe(true);
+  });
+
+  it('未知类型：按 allow 处理', () => {
+    const r = validateEdge({ ...base, sourceType: 'ghost' as unknown as NodeType, targetType: 'text' });
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('getEdgeLegality', () => {
+  it('image→audio = forbid', () => {
+    expect(getEdgeLegality('image', 'audio')).toBe('forbid');
+  });
+  it('video→text = deferred', () => {
+    expect(getEdgeLegality('video', 'text')).toBe('deferred');
+  });
+  it('text→storyboard = allow', () => {
+    expect(getEdgeLegality('text', 'storyboard')).toBe('allow');
+  });
+});

--- a/frontend/src/lib/canvas/edgePayload.ts
+++ b/frontend/src/lib/canvas/edgePayload.ts
@@ -1,0 +1,403 @@
+'use client';
+
+/**
+ * 画布连线的载荷构建与注入分发器。
+ *
+ * 规范来源：`frontend/src/lib/canvas/edgeRules.md` 第 5、7 节。
+ * 调用方：
+ * - `useCanvasStore.connectAndInject`（QuickAddMenu 立即注入 / 已存在节点确认后注入）
+ * - 生成面板（ImageGeneratePanel / VideoGeneratePanel）订阅 panelEvents
+ *
+ * 设计：
+ * - buildPayload：只抽取语义内容，文本 trim+slice(0,50000)，媒体用 URL 引用（不拷贝二进制）。
+ * - injectPayload：按"下游节点类型 + 载荷 kind"派发；返回 { dataPatch, panelEvents, toasts }。
+ *   调用方根据返回值决定是否 updateNodeData / emitPanelInject / edgeToast.xxx。
+ */
+import type {
+  CanvasNode,
+  ScriptNodeData,
+  CharacterNodeData,
+  VideoNodeData,
+  AudioNodeData,
+  StoryboardNodeData,
+} from '@/store/useCanvasStore';
+import { extractPlainTextFromTiptap } from '@/lib/nodeAttachmentUtils';
+import type { PanelInjectEvent } from './panelEvents';
+
+// ── 常量 ──
+export const TEXT_PROMPT_MAX = 50000;
+export const DESCRIPTION_COL_KEY = 'description';
+
+// ── EdgePayload（与 edgeRules.md 第 7 节对齐） ──
+
+export type ColumnDef = { key: string; label: string; type?: 'text' | 'number' | 'image' | 'video' | 'audio' };
+
+export type EdgePayload =
+  | { kind: 'text'; content: string; format: 'plain' | 'markdown'; doc?: TiptapDoc | null }
+  | { kind: 'image'; url: string; urls: string[]; width?: number; height?: number; mime?: string }
+  | { kind: 'video'; url: string; poster?: string; duration?: number }
+  | { kind: 'audio'; url: string; duration?: number; lyrics?: string }
+  | { kind: 'table'; rows: Record<string, unknown>[]; columns: ColumnDef[] };
+
+// Tiptap JSON 最小类型（保留 mark 和 block 全量元数据）
+export type TiptapDoc = { type: 'doc'; content?: TiptapNode[] };
+export type TiptapNode = { type: string; content?: TiptapNode[]; marks?: unknown[]; text?: string; attrs?: Record<string, unknown> };
+
+// ── 注入结果 ──
+
+export type InjectionResult = {
+  /** 直接应用到下游节点 data 的增量 */
+  dataPatch?: Record<string, unknown>;
+  /** 要发送给目标节点面板的事件（由调用方 emitPanelInject 实际派发） */
+  panelEvents?: PanelInjectEvent[];
+  /** 文案提示（warn 级别，非致命） */
+  warnings?: string[];
+  /** 是否需要调用方弹确认（当前仅 storyboard 新建媒体列用） */
+  pendingConfirm?: { message: string; apply: () => InjectionResult };
+};
+
+// ── 辅助函数 ──
+
+const emptyResult: InjectionResult = {};
+
+/**
+ * 收集图像节点的所有 URL（用于智能注入 urls[]）。
+ * 优先 images 数组；空数组时回落 imageUrl；最后去重。
+ */
+function getImageUrls(node: CanvasNode): string[] {
+  const data = node.data as CharacterNodeData;
+  const arr = Array.isArray(data.images) ? data.images.filter((u): u is string => typeof u === 'string' && u.length > 0) : [];
+  const fallback = arr.length === 0 && data.imageUrl ? [data.imageUrl] : [];
+  return Array.from(new Set([...arr, ...fallback]));
+}
+
+function getVideoUrl(node: CanvasNode): string | null {
+  const data = node.data as VideoNodeData;
+  return data.videoUrl || null;
+}
+
+function getAudioUrl(node: CanvasNode): string | null {
+  const data = node.data as AudioNodeData;
+  return data.audioUrl || null;
+}
+
+function getAudioLyrics(node: CanvasNode): string | undefined {
+  const data = node.data as AudioNodeData;
+  return data.lyrics;
+}
+
+function getTextContent(node: CanvasNode): string {
+  const data = node.data as ScriptNodeData;
+  const raw = data.content;
+  const asString = typeof raw === 'string' ? raw : extractPlainTextFromTiptap(raw, Infinity);
+  return asString.trim().slice(0, TEXT_PROMPT_MAX);
+}
+
+/** 读取节点 `data.content` 中的 Tiptap JSON；字符串或非合法 doc 返回 null。*/
+function getTextDoc(node: CanvasNode): TiptapDoc | null {
+  const data = node.data as ScriptNodeData;
+  const raw = data.content;
+  const isDoc = raw !== null && typeof raw === 'object' && (raw as TiptapDoc).type === 'doc';
+  return isDoc ? (raw as TiptapDoc) : null;
+}
+
+/**
+ * 合并两个 Tiptap doc：源 doc 的 content 追加到目标 doc 末尾，
+ * 两段均非空时插入空段落做视觉分隔。任一侧缺失时返回另一侧。
+ */
+function mergeTiptapDocs(targetDoc: TiptapDoc | null, sourceDoc: TiptapDoc | null): TiptapDoc | null {
+  if (!sourceDoc) return targetDoc;
+  if (!targetDoc) return sourceDoc;
+  const targetContent = Array.isArray(targetDoc.content) ? targetDoc.content : [];
+  const sourceContent = Array.isArray(sourceDoc.content) ? sourceDoc.content : [];
+  const targetHasText = extractPlainTextFromTiptap(targetDoc, Infinity).trim().length > 0;
+  const separator: TiptapNode[] = targetHasText ? [{ type: 'paragraph' }] : [];
+  return { type: 'doc', content: [...targetContent, ...separator, ...sourceContent] };
+}
+
+// ── buildPayload ──
+
+/**
+ * 从源节点构建 EdgePayload。返回 null 表示该节点无可用内容（例如图像节点尚未上传）。
+ */
+export function buildPayload(sourceNode: CanvasNode): EdgePayload | null {
+  const builders: Record<string, () => EdgePayload | null> = {
+    text: () => {
+      const content = getTextContent(sourceNode);
+      const doc = getTextDoc(sourceNode);
+      // 无任何字符内容时视为空节点，不触发注入
+      return content.length > 0 ? { kind: 'text', content, format: 'plain', doc } : null;
+    },
+    image: () => {
+      const urls = getImageUrls(sourceNode);
+      return urls.length > 0 ? { kind: 'image', url: urls[0], urls } : null;
+    },
+    video: () => {
+      const url = getVideoUrl(sourceNode);
+      return url ? { kind: 'video', url } : null;
+    },
+    audio: () => {
+      const url = getAudioUrl(sourceNode);
+      return url ? { kind: 'audio', url, lyrics: getAudioLyrics(sourceNode) } : null;
+    },
+    storyboard: () => {
+      const data = sourceNode.data as StoryboardNodeData;
+      const rows = data.tableData ?? [];
+      const columns: ColumnDef[] = (data.tableColumns ?? []) as ColumnDef[];
+      return { kind: 'table', rows, columns };
+    },
+  };
+  const build = sourceNode.type ? builders[sourceNode.type] : null;
+  return build ? build() : null;
+}
+
+// ── 下游派发器 ──
+
+/** 下游 text：接受 text / table，其余由矩阵拦截 */
+function injectToText(targetNode: CanvasNode, payload: EdgePayload): InjectionResult {
+  const data = targetNode.data as ScriptNodeData;
+  const existingDoc = getTextDoc(targetNode);
+  const existingStr = typeof data.content === 'string' ? data.content : extractPlainTextFromTiptap(data.content, Infinity);
+
+  const handlers: Partial<Record<EdgePayload['kind'], () => InjectionResult>> = {
+    text: () => {
+      const p = payload as Extract<EdgePayload, { kind: 'text' }>;
+      // 优先走 Tiptap JSON 合并以保留格式（源或目标任一侧为纯字符串时降级为字符拼接）
+      const canMergeDoc = !!p.doc && typeof data.content !== 'string';
+      if (canMergeDoc) {
+        const merged = mergeTiptapDocs(existingDoc, p.doc ?? null);
+        return { dataPatch: { content: merged } };
+      }
+      const next = existingStr.trim().length > 0 ? `${existingStr}\n\n${p.content}` : p.content;
+      return { dataPatch: { content: next.slice(0, TEXT_PROMPT_MAX) } };
+    },
+    table: () => {
+      const p = payload as Extract<EdgePayload, { kind: 'table' }>;
+      const lines = p.rows
+        .map((r) => {
+          const descVal = r[DESCRIPTION_COL_KEY];
+          return typeof descVal === 'string' && descVal.trim().length > 0 ? `- ${descVal}` : '';
+        })
+        .filter(Boolean);
+      const appended = lines.length > 0 ? lines.join('\n') : '';
+      const next = existingStr.trim().length > 0 ? `${existingStr}\n\n${appended}` : appended;
+      return appended.length > 0 ? { dataPatch: { content: next.slice(0, TEXT_PROMPT_MAX) } } : emptyResult;
+    },
+  };
+  const handler = handlers[payload.kind];
+  return handler ? handler() : emptyResult;
+}
+
+/** 下游 image：text→prompt-prefix；image/video→add-reference-image */
+function injectToImage(targetNode: CanvasNode, payload: EdgePayload, sourceNodeId: string): InjectionResult {
+  const handlers: Partial<Record<EdgePayload['kind'], () => InjectionResult>> = {
+    text: () => {
+      const p = payload as Extract<EdgePayload, { kind: 'text' }>;
+      return { panelEvents: [{ type: 'prompt-prefix', text: p.content }] };
+    },
+    image: () => {
+      const p = payload as Extract<EdgePayload, { kind: 'image' }>;
+      // 改派 smart-image-inject：面板根据 urls.length 自选目标模式（edit / reference_images）
+      return {
+        panelEvents: [{
+          type: 'smart-image-inject',
+          sourceNodeId,
+          urls: p.urls,
+        }],
+      };
+    },
+    video: () => {
+      const p = payload as Extract<EdgePayload, { kind: 'video' }>;
+      // 视频 → 图像：一期仅支持首帧/封面作为参考图
+      const url = p.poster || p.url;
+      return {
+        panelEvents: [{
+          type: 'add-reference-image',
+          sourceNodeId,
+          url,
+          tag: 'first-frame',
+        }],
+      };
+    },
+  };
+  const handler = handlers[payload.kind];
+  return handler ? handler() : emptyResult;
+}
+
+/** 下游 video：text→prompt-prefix；image→智能注入（image_to_video/reference_images）；video→参考视频；audio→参考音频 */
+function injectToVideo(_targetNode: CanvasNode, payload: EdgePayload, sourceNodeId: string): InjectionResult {
+  const handlers: Partial<Record<EdgePayload['kind'], () => InjectionResult>> = {
+    text: () => {
+      const p = payload as Extract<EdgePayload, { kind: 'text' }>;
+      return { panelEvents: [{ type: 'prompt-prefix', text: p.content }] };
+    },
+    image: () => {
+      const p = payload as Extract<EdgePayload, { kind: 'image' }>;
+      // 改派 smart-image-inject：面板根据 urls.length 自选目标模式（image_to_video / reference_images）
+      return {
+        panelEvents: [{
+          type: 'smart-image-inject',
+          sourceNodeId,
+          urls: p.urls,
+        }],
+      };
+    },
+    video: () => {
+      const p = payload as Extract<EdgePayload, { kind: 'video' }>;
+      return {
+        panelEvents: [{
+          type: 'add-reference-video',
+          sourceNodeId,
+          url: p.url,
+        }],
+      };
+    },
+    audio: () => {
+      const p = payload as Extract<EdgePayload, { kind: 'audio' }>;
+      return {
+        panelEvents: [{
+          type: 'add-reference-audio',
+          sourceNodeId,
+          url: p.url,
+        }],
+      };
+    },
+  };
+  const handler = handlers[payload.kind];
+  return handler ? handler() : emptyResult;
+}
+
+/** 下游 audio：text→lyrics 追加；image 由矩阵拦截；video/audio 为 deferred */
+function injectToAudio(targetNode: CanvasNode, payload: EdgePayload): InjectionResult {
+  const data = targetNode.data as AudioNodeData;
+  const handlers: Partial<Record<EdgePayload['kind'], () => InjectionResult>> = {
+    text: () => {
+      const p = payload as Extract<EdgePayload, { kind: 'text' }>;
+      const existing = data.lyrics || '';
+      const next = existing.trim().length > 0 ? `${existing}\n\n${p.content}` : p.content;
+      return { dataPatch: { lyrics: next.slice(0, TEXT_PROMPT_MAX) } };
+    },
+  };
+  const handler = handlers[payload.kind];
+  return handler ? handler() : emptyResult;
+}
+
+/** 下游 storyboard：text → 追加一行；image/video/audio → 追加到匹配媒体列；table → 行级合并 */
+function injectToStoryboard(targetNode: CanvasNode, payload: EdgePayload): InjectionResult {
+  const data = targetNode.data as StoryboardNodeData;
+  const rows: Record<string, unknown>[] = Array.isArray(data.tableData) ? [...data.tableData] : [];
+  const columns: ColumnDef[] = Array.isArray(data.tableColumns) ? [...(data.tableColumns as ColumnDef[])] : [];
+
+  const appendTextRow = (): InjectionResult => {
+    const p = payload as Extract<EdgePayload, { kind: 'text' }>;
+    const hasDescCol = columns.some((c) => c.key === DESCRIPTION_COL_KEY);
+    const nextColumns: ColumnDef[] = hasDescCol
+      ? columns
+      : [...columns, { key: DESCRIPTION_COL_KEY, label: '描述', type: 'text' }];
+    const nextRows = [...rows, { [DESCRIPTION_COL_KEY]: p.content }];
+    return { dataPatch: { tableData: nextRows, tableColumns: nextColumns } };
+  };
+
+  const appendMediaRow = (kind: 'image' | 'video' | 'audio', url: string): InjectionResult => {
+    const matchedCol = columns.find((c) => c.type === kind);
+    const doAppend = (colKey: string, extraColumns?: ColumnDef[]): InjectionResult => {
+      const nextRows = [...rows, { [colKey]: url }];
+      return {
+        dataPatch: {
+          tableData: nextRows,
+          ...(extraColumns ? { tableColumns: extraColumns } : {}),
+        },
+      };
+    };
+
+    const colExists = !!matchedCol;
+    const colExistsResult: InjectionResult | null = colExists ? doAppend(matchedCol!.key) : null;
+    if (colExistsResult) return colExistsResult;
+
+    // 无匹配媒体列 → 弹确认由调用方决定是否新建列
+    const newColKey = kind;
+    const newColLabel = kind === 'image' ? '图像' : kind === 'video' ? '视频' : '音频';
+    const newColumns: ColumnDef[] = [...columns, { key: newColKey, label: newColLabel, type: kind }];
+    return {
+      pendingConfirm: {
+        message: `未找到 ${newColLabel} 列，是否新建「${newColLabel}」列并追加？`,
+        apply: () => doAppend(newColKey, newColumns),
+      },
+    };
+  };
+
+  const handlers: Partial<Record<EdgePayload['kind'], () => InjectionResult>> = {
+    text: appendTextRow,
+    image: () => appendMediaRow('image', (payload as Extract<EdgePayload, { kind: 'image' }>).url),
+    video: () => appendMediaRow('video', (payload as Extract<EdgePayload, { kind: 'video' }>).url),
+    audio: () => appendMediaRow('audio', (payload as Extract<EdgePayload, { kind: 'audio' }>).url),
+    table: () => {
+      const p = payload as Extract<EdgePayload, { kind: 'table' }>;
+      // 列定义合并去重（按 key）
+      const mergedColumns: ColumnDef[] = [...columns];
+      p.columns.forEach((c) => {
+        const exists = mergedColumns.some((m) => m.key === c.key);
+        !exists && mergedColumns.push(c);
+      });
+      const nextRows = [...rows, ...p.rows];
+      return { dataPatch: { tableData: nextRows, tableColumns: mergedColumns } };
+    },
+  };
+  const handler = handlers[payload.kind];
+  return handler ? handler() : emptyResult;
+}
+
+// ── 主分发器 ──
+
+/**
+ * 根据下游节点类型将 payload 派发到对应处理器。
+ * 不实际执行 updateNodeData / emitPanelInject——调用方依据返回值自行处理。
+ */
+export function injectPayload(
+  targetNode: CanvasNode,
+  payload: EdgePayload,
+  sourceNodeId: string,
+): InjectionResult {
+  const dispatch: Record<string, () => InjectionResult> = {
+    text: () => injectToText(targetNode, payload),
+    image: () => injectToImage(targetNode, payload, sourceNodeId),
+    video: () => injectToVideo(targetNode, payload, sourceNodeId),
+    audio: () => injectToAudio(targetNode, payload),
+    storyboard: () => injectToStoryboard(targetNode, payload),
+  };
+  const handler = targetNode.type ? dispatch[targetNode.type] : null;
+  return handler ? handler() : emptyResult;
+}
+
+// ── 媒体 URL 转换 ──
+
+/**
+ * 将 /api/media/... 本地路径转换为 base64 data URL。
+ * - 已是 data: → 直接返回
+ * - http(s) → 直接返回（不拉取外网避免 CORS/配额）
+ * - 其他（含 /api/media/）→ fetch 并 FileReader 转 data URL
+ */
+export async function mediaUrlToDataUrl(url: string): Promise<string> {
+  if (!url) return url;
+  if (url.startsWith('data:')) return url;
+  if (url.startsWith('http://') || url.startsWith('https://')) return url;
+
+  const response = await fetch(url);
+  const blob = await response.blob();
+  return await new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(typeof reader.result === 'string' ? reader.result : '');
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(blob);
+  });
+}
+
+/**
+ * 批量把 URL 转为 data URL；失败项回退为原 URL（不中断其他项）。
+ */
+export async function mediaUrlsToDataUrls(urls: string[]): Promise<string[]> {
+  return Promise.all(urls.map(async (u) => {
+    try { return await mediaUrlToDataUrl(u); }
+    catch { return u; }
+  }));
+}

--- a/frontend/src/lib/canvas/edgeRules.ts
+++ b/frontend/src/lib/canvas/edgeRules.ts
@@ -1,0 +1,180 @@
+/**
+ * 画布连线合法性矩阵 + 校验函数（前端 Single Source of Truth）。
+ *
+ * 规范来源：`frontend/src/lib/canvas/edgeRules.md`
+ * 后端对齐：`backend/services/tool_manager/providers/_canvas_edge_rules.py`
+ *
+ * 设计原则：
+ * 1. 5x5 矩阵写死为纯常量，任何规范变更都必须同时改动前后端两个文件。
+ * 2. validateEdge 只做合法性判定，不做内容注入（那属于 edgePayload.ts）。
+ * 3. 所有检查走早返回，避免嵌套 if（遵循项目 style.md 规范）。
+ */
+import type { Edge } from '@xyflow/react';
+import { hasCycle } from '@/lib/graphUtils';
+
+export type NodeType = 'text' | 'image' | 'video' | 'audio' | 'storyboard';
+
+export type EdgeLegality = 'allow' | 'deferred' | 'forbid';
+
+export type EdgeRejectReason =
+  | 'self_loop'
+  | 'same_polarity'
+  | 'duplicate_edge'
+  | 'cycle'
+  | 'forbidden_type_combination'
+  | 'not_supported_yet'
+  | 'unknown_type';
+
+export interface EdgeValidationResult {
+  ok: boolean;
+  reason?: EdgeRejectReason;
+  message?: string;
+}
+
+/**
+ * 5x5 合法性矩阵（Source → Target）。
+ * 必须与 edgeRules.md 第 4 节、SKILL.md Edge Compatibility Matrix 三方对齐。
+ */
+export const EDGE_LEGALITY_MATRIX: Record<NodeType, Record<NodeType, EdgeLegality>> = {
+  text: {
+    text: 'allow',
+    image: 'allow',
+    video: 'allow',
+    audio: 'allow',
+    storyboard: 'allow',
+  },
+  image: {
+    text: 'deferred',
+    image: 'allow',
+    video: 'allow',
+    audio: 'forbid',
+    storyboard: 'allow',
+  },
+  video: {
+    text: 'deferred',
+    image: 'allow',
+    video: 'allow',
+    audio: 'deferred',
+    storyboard: 'allow',
+  },
+  audio: {
+    text: 'deferred',
+    image: 'forbid',
+    video: 'allow',
+    audio: 'deferred',
+    storyboard: 'allow',
+  },
+  storyboard: {
+    text: 'allow',
+    image: 'allow',
+    video: 'allow',
+    audio: 'allow',
+    storyboard: 'allow',
+  },
+};
+
+export const REJECT_MESSAGES: Record<EdgeRejectReason, string> = {
+  self_loop: '不允许连接到自身',
+  same_polarity: '连接端口方向错误：连线两端需要分别位于节点的不同侧边',
+  duplicate_edge: '该连线已存在',
+  cycle: '会形成循环依赖，已阻止',
+  forbidden_type_combination: '此类型组合不允许连线',
+  not_supported_yet: '该连线类型即将支持',
+  unknown_type: '未知的节点类型',
+};
+
+const isNodeType = (x: unknown): x is NodeType =>
+  typeof x === 'string' && ['text', 'image', 'video', 'audio', 'storyboard'].includes(x);
+
+/**
+ * 读取 Handle 所在的几何侧边（基于 id 前缀）。
+ *
+ * 注意：画布使用 `ConnectionMode.Loose`，且每个边缘同位置叠加了 `{side}-source` 与 `{side}-target`
+ * 两个 Handle，DOM 后渲染的 `*-source` 覆盖在上层，导致拖拽起止两端都会命中 `*-source`。
+ * 因此 role 后缀（source/target）在 loose 模式下**不具备方向语义**，极性校验只能看几何侧边。
+ */
+const getHandleSide = (h: string | null | undefined): 'left' | 'right' | null => {
+  if (typeof h !== 'string') return null;
+  if (h.startsWith('left-')) return 'left';
+  if (h.startsWith('right-')) return 'right';
+  return null;
+};
+
+export interface ValidateEdgeParams {
+  sourceId: string;
+  targetId: string;
+  sourceType: string | undefined;
+  targetType: string | undefined;
+  sourceHandle?: string | null;
+  targetHandle?: string | null;
+  /** 画布现有边集合，用于四元组去重与拓扑环检测 */
+  existingEdges: Edge[];
+}
+
+/**
+ * 连线合法性校验：按顺序检查硬约束与矩阵。
+ * 检查顺序：self_loop → same_polarity → duplicate_edge → cycle → matrix。
+ */
+export function validateEdge(params: ValidateEdgeParams): EdgeValidationResult {
+  const {
+    sourceId, targetId, sourceType, targetType,
+    sourceHandle, targetHandle, existingEdges,
+  } = params;
+
+  // 1. 自环
+  const isSelfLoop = sourceId === targetId;
+  const selfLoopResult: EdgeValidationResult | null = isSelfLoop
+    ? { ok: false, reason: 'self_loop', message: REJECT_MESSAGES.self_loop }
+    : null;
+  if (selfLoopResult) return selfLoopResult;
+
+  // 2. 极性（两端同时提供 handle 且都能识别出侧边时才校验；ReactFlow 内部有部分路径 handle 为 null）
+  // Loose 模式下 role 后缀不可靠，改为判定几何侧边：两端必须位于节点**不同侧**。
+  const srcSide = getHandleSide(sourceHandle);
+  const tgtSide = getHandleSide(targetHandle);
+  const polarityCheckable = srcSide !== null && tgtSide !== null;
+  const polarityBad = polarityCheckable && srcSide === tgtSide;
+  const polarityResult: EdgeValidationResult | null = polarityBad
+    ? { ok: false, reason: 'same_polarity', message: REJECT_MESSAGES.same_polarity }
+    : null;
+  if (polarityResult) return polarityResult;
+
+  // 3. 四元组去重
+  const isDuplicate = existingEdges.some((e) =>
+    e.source === sourceId &&
+    e.target === targetId &&
+    (e.sourceHandle ?? null) === (sourceHandle ?? null) &&
+    (e.targetHandle ?? null) === (targetHandle ?? null),
+  );
+  const dupResult: EdgeValidationResult | null = isDuplicate
+    ? { ok: false, reason: 'duplicate_edge', message: REJECT_MESSAGES.duplicate_edge }
+    : null;
+  if (dupResult) return dupResult;
+
+  // 4. 拓扑环
+  const cycleBad = hasCycle(existingEdges, sourceId, targetId);
+  const cycleResult: EdgeValidationResult | null = cycleBad
+    ? { ok: false, reason: 'cycle', message: REJECT_MESSAGES.cycle }
+    : null;
+  if (cycleResult) return cycleResult;
+
+  // 5. 矩阵查表（类型未知按放行处理，以兼容 ghost / streaming 等非规范类型）
+  const bothTypesKnown = isNodeType(sourceType) && isNodeType(targetType);
+  const legality: EdgeLegality | undefined = bothTypesKnown
+    ? EDGE_LEGALITY_MATRIX[sourceType as NodeType][targetType as NodeType]
+    : undefined;
+
+  const matrixReject: EdgeValidationResult | null =
+    legality === 'forbid' ? { ok: false, reason: 'forbidden_type_combination', message: `${sourceType} → ${targetType} 不允许连线` } :
+    legality === 'deferred' ? { ok: false, reason: 'not_supported_yet', message: `${sourceType} → ${targetType} 即将支持` } :
+    null;
+  if (matrixReject) return matrixReject;
+
+  return { ok: true };
+}
+
+/** 获取矩阵中的合法性（未知类型返回 'allow'，用于 tooltip 展示） */
+export function getEdgeLegality(sourceType: string | undefined, targetType: string | undefined): EdgeLegality {
+  const bothKnown = isNodeType(sourceType) && isNodeType(targetType);
+  return bothKnown ? EDGE_LEGALITY_MATRIX[sourceType as NodeType][targetType as NodeType] : 'allow';
+}

--- a/frontend/src/lib/canvas/panelEvents.ts
+++ b/frontend/src/lib/canvas/panelEvents.ts
@@ -1,0 +1,139 @@
+'use client';
+
+/**
+ * 画布节点面板注入事件总线。
+ *
+ * 用途：当上游节点通过连线向下游生成面板（ImageGeneratePanel / VideoGeneratePanel 等）
+ *       注入内容时，面板以 mount 阶段订阅事件的方式接收 prompt / 参考图等载荷。
+ *
+ * 为什么不直接通过 props 或 store：
+ * - 面板内部状态（prompt、refs）由自身 hook 管理，避免将注入源耦合进 store。
+ * - 事件总线天然支持"多个面板同时在场"场景，消费方按 nodeId 过滤即可。
+ *
+ * 实现：基于浏览器原生 EventTarget，无第三方依赖。SSR 兼容：typeof window 判空。
+ */
+
+/** 注入事件：向 prompt 输入框前缀插入文本 */
+export interface PromptPrefixEvent {
+  type: 'prompt-prefix';
+  /** 要插入的文本（已 trim + 截断） */
+  text: string;
+}
+
+/** 注入事件：向 reference_images 追加一项 */
+export interface AddReferenceImageEvent {
+  type: 'add-reference-image';
+  /** 来源节点 ID，用于后续 unlink */
+  sourceNodeId: string;
+  /** 图像 URL（可以是 /api/media/ 或 http(s) 或 data:） */
+  url: string;
+  /** 展示名称 */
+  name?: string;
+  /** 标签：image-to-video 场景的首帧 */
+  tag?: 'first-frame';
+}
+
+/** 注入事件：向视频面板参考视频追加 */
+export interface AddReferenceVideoEvent {
+  type: 'add-reference-video';
+  sourceNodeId: string;
+  url: string;
+  name?: string;
+}
+
+/** 注入事件：向视频面板参考音频追加 */
+export interface AddReferenceAudioEvent {
+  type: 'add-reference-audio';
+  sourceNodeId: string;
+  url: string;
+  name?: string;
+}
+
+/**
+ * 注入事件：智能图像注入 —— 由图像源节点连入图像/视频面板时派发。
+ *
+ * 面板依据 `urls.length` 决定目标模式：
+ * - 1 张 → 图像：edit；视频：image_to_video
+ * - N 张 → 图像：reference_images；视频：reference_images
+ *
+ * 若当前模型不支持该模式，面板仅弹出警告 Toast（不自动换模型）。
+ * 若超过当前模式上限 N，截断前 N 张并提示。
+ */
+export interface SmartImageInjectEvent {
+  type: 'smart-image-inject';
+  sourceNodeId: string;
+  urls: string[];
+  name?: string;
+}
+
+export type PanelInjectEvent =
+  | PromptPrefixEvent
+  | AddReferenceImageEvent
+  | AddReferenceVideoEvent
+  | AddReferenceAudioEvent
+  | SmartImageInjectEvent;
+
+const EVENT_NAME = 'canvas:panel:inject';
+
+interface PanelInjectDetail {
+  nodeId: string;
+  event: PanelInjectEvent;
+}
+
+/** 获取事件总线：浏览器端使用 window，SSR 下返回 null（短路）。 */
+function getBus(): EventTarget | null {
+  return typeof window === 'undefined' ? null : window;
+}
+
+// ── smart-image-inject 的 pending 缓存 ──
+//
+// 场景：QuickAddMenu 创建新节点后同步派发 smart-image-inject，新面板尚未 mount
+//       订阅也未建立。此外，新节点初始无模型选择（capabilities=null），
+//       supportedModes 仅为 fallback，无法判断是否能执行目标模式。
+// 策略：事件派发同时写入 pending；面板在 capabilities 就绪后 drain 一次。
+const pendingSmartInject: Record<string, SmartImageInjectEvent> = {};
+
+/** 写入 pending smart-image-inject（同 nodeId 的后来者覆盖）。 */
+export function setPendingSmartInject(nodeId: string, ev: SmartImageInjectEvent): void {
+  pendingSmartInject[nodeId] = ev;
+}
+
+/** 读出并清除 pending smart-image-inject；无则返回 null。 */
+export function takePendingSmartInject(nodeId: string | undefined): SmartImageInjectEvent | null {
+  if (!nodeId) return null;
+  const ev = pendingSmartInject[nodeId];
+  delete pendingSmartInject[nodeId];
+  return ev ?? null;
+}
+
+/** 只读探测：该节点是否有 pending smart-image-inject（不消费）。 */
+export function hasPendingSmartInject(nodeId: string | undefined): boolean {
+  return !!nodeId && !!pendingSmartInject[nodeId];
+}
+
+/** 向目标节点 ID 的面板发送一个注入事件 */
+export function emitPanelInject(nodeId: string, event: PanelInjectEvent): void {
+  const bus = getBus();
+  bus && bus.dispatchEvent(
+    new CustomEvent<PanelInjectDetail>(EVENT_NAME, { detail: { nodeId, event } }),
+  );
+}
+
+/**
+ * 订阅目标节点 ID 的注入事件。
+ * 返回 unsubscribe 函数；面板 useEffect 里直接用即可。
+ */
+export function onPanelInject(
+  nodeId: string | undefined,
+  handler: (event: PanelInjectEvent) => void,
+): () => void {
+  const bus = getBus();
+  const listener = (e: Event) => {
+    const detail = (e as CustomEvent<PanelInjectDetail>).detail;
+    detail && detail.nodeId === nodeId && handler(detail.event);
+  };
+  bus && nodeId && bus.addEventListener(EVENT_NAME, listener);
+  return () => {
+    bus && nodeId && bus.removeEventListener(EVENT_NAME, listener);
+  };
+}

--- a/frontend/src/lib/canvas/toast.tsx
+++ b/frontend/src/lib/canvas/toast.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+/**
+ * Canvas 状态提示 Toast 封装（仅状态、不含交互）。
+ *
+ * - error：硬禁止（矩阵 forbid、自环、极性、重复边、拓扑环）
+ * - info：一期未开放（矩阵 deferred）——文案提示「即将支持」
+ * - warn：软约束（参考图上限、provider 能力不足等）
+ * - success：操作完成提示
+ *
+ * 交互类二次确认（confirm）已移除 —— 连线注入默认直接执行，
+ * 不再要求用户二次确认（参见 edgeRules.md 1.1.9）。
+ * Toast 仅作为单向状态提示。
+ */
+import { toast } from 'sonner';
+
+function showError(message: string) {
+  toast.error(message, { duration: 3000 });
+}
+
+function showInfo(message: string) {
+  toast.info(message, { duration: 2500 });
+}
+
+function showWarn(message: string) {
+  toast.warning(message, { duration: 3000 });
+}
+
+function showSuccess(message: string) {
+  toast.success(message, { duration: 2000 });
+}
+
+export const edgeToast = {
+  error: showError,
+  info: showInfo,
+  warn: showWarn,
+  success: showSuccess,
+};

--- a/frontend/src/store/useCanvasStore.ts
+++ b/frontend/src/store/useCanvasStore.ts
@@ -15,7 +15,10 @@ import {
   OnConnect,
   Viewport,
 } from '@xyflow/react';
-import { hasCycle } from '@/lib/graphUtils';
+import { validateEdge, REJECT_MESSAGES, type EdgeRejectReason } from '@/lib/canvas/edgeRules';
+import { buildPayload, injectPayload } from '@/lib/canvas/edgePayload';
+import { emitPanelInject, setPendingSmartInject } from '@/lib/canvas/panelEvents';
+import { edgeToast } from '@/lib/canvas/toast';
 import {
   theaterApi,
   type TheaterNodeCreate,
@@ -152,6 +155,17 @@ interface CanvasState {
   onNodesChange: OnNodesChange;
   onEdgesChange: OnEdgesChange;
   onConnect: OnConnect;
+  /**
+   * 校验后建边并立即注入下游载荷。
+   * @param connection - ReactFlow 连接对象
+   * @param options.fromQuickAdd - 来自 QuickAddMenu，已隐含用户同意，跳过确认
+   * @param options.silent - 校验失败不弹 Toast（hook 侧批量处理时用）
+   * @returns { ok, reason } 指示是否成功
+   */
+  connectAndInject: (
+    connection: Connection,
+    options?: { fromQuickAdd?: boolean; silent?: boolean },
+  ) => { ok: boolean; reason?: EdgeRejectReason };
   addNode: (node: CanvasNode) => void;
   deleteNode: (id: string) => void;
   deleteEdge: (id: string) => void;
@@ -321,21 +335,79 @@ export const useCanvasStore = create<CanvasState>()(
       },
 
       onConnect: (connection: Connection) => {
-        const { edges } = get();
-        
-        // Prevent self-loops
-        if (connection.source === connection.target) return;
+        // 统一走 connectAndInject；已存在节点间连线会弹确认
+        get().connectAndInject(connection);
+      },
 
-        // Prevent cycles
-        if (hasCycle(edges, connection.source, connection.target)) {
-          console.warn('Cycle detected! Connection blocked.');
-          return;
-        }
+      connectAndInject: (connection: Connection, options?: { fromQuickAdd?: boolean; silent?: boolean }) => {
+        const { edges, nodes } = get();
+        const sourceNode = nodes.find((n) => n.id === connection.source);
+        const targetNode = nodes.find((n) => n.id === connection.target);
 
+        // 节点不存在直接返回（可能是幽灵节点残留）
+        const missing = !sourceNode || !targetNode || !connection.source || !connection.target;
+        if (missing) return { ok: false, reason: 'unknown_type' as EdgeRejectReason };
+
+        // 1. 合法性校验
+        const validation = validateEdge({
+          sourceId: connection.source!,
+          targetId: connection.target!,
+          sourceType: sourceNode.type,
+          targetType: targetNode.type,
+          sourceHandle: connection.sourceHandle,
+          targetHandle: connection.targetHandle,
+          existingEdges: edges,
+        });
+
+        const rejectHandlers: Partial<Record<EdgeRejectReason, (msg: string) => void>> = {
+          self_loop: (msg) => edgeToast.error(msg),
+          same_polarity: (msg) => edgeToast.error(msg),
+          duplicate_edge: (msg) => edgeToast.error(msg),
+          cycle: (msg) => edgeToast.error(msg),
+          forbidden_type_combination: (msg) => edgeToast.error(msg),
+          not_supported_yet: (msg) => edgeToast.info(msg),
+          unknown_type: (msg) => edgeToast.error(msg),
+        };
+        const rejectedSilently = !validation.ok && options?.silent;
+        const rejectedNoisily = !validation.ok && !options?.silent;
+        rejectedNoisily && rejectHandlers[validation.reason!]?.(
+          validation.message || REJECT_MESSAGES[validation.reason!],
+        );
+        if (!validation.ok) return { ok: false, reason: validation.reason };
+        void rejectedSilently;
+
+        // 2. 建边
         const newEdges = addEdge({ ...connection, type: 'custom', animated: true }, edges);
-        
         set({ edges: newEdges, isDirty: true });
         get().takeSnapshot();
+
+        // 3. 构建 payload（空则不注入，但连线已建立）
+        const payload = buildPayload(sourceNode);
+        if (!payload) return { ok: true };
+
+        // 4. 默认直接注入（不弹二次确认）
+        const result = injectPayload(targetNode, payload, sourceNode.id);
+        const applyPatch = (patch: Record<string, unknown> | undefined) => {
+          patch && get().updateNodeData(
+            targetNode.id,
+            patch as Partial<ScriptNodeData | CharacterNodeData | StoryboardNodeData | VideoNodeData | AudioNodeData>,
+          );
+        };
+        applyPatch(result.dataPatch);
+        (result.panelEvents || []).forEach((e) => {
+          emitPanelInject(targetNode.id, e);
+          // smart-image-inject 额外写入 pending，覆盖订阅时序丢失 + 新节点模型未就绪的场景
+          e.type === 'smart-image-inject' && setPendingSmartInject(targetNode.id, e);
+        });
+        (result.warnings || []).forEach((w) => edgeToast.warn(w));
+        // storyboard 媒体列也直接 apply，不再二次确认
+        if (result.pendingConfirm) {
+          const applied = result.pendingConfirm.apply();
+          applyPatch(applied.dataPatch);
+        }
+        void options;
+
+        return { ok: true };
       },
 
       addNode: (node: CanvasNode) => {


### PR DESCRIPTION
- 在后端新增画布边合法性校验模块，实现自环、极性、重复边、环路和类型矩阵校验
- 修改 canvasProvider，集成边合法性校验并返回详细错误码，保证建边合法性
- 同步后端访问令牌刷新逻辑，支持一次性轮换模式同时返回新的 refresh_token
- 增强前端 Canvas 快速添加功能，优化连线方向判定和注入逻辑
- 图像和视频生成面板新增智能图像注入事件处理，支持批量参考图和单图编辑模式切换
- 优化面板提交时将本地媒体 URL 转为 base64，保证后端可读性
- ImagePreviewPortal 组件新增图片下载按钮与功能，支持无侵入的本地图片下载
- 登录页面表单字段增加符合 WHATWG 标准的 autoComplete 属性，提升密码管理器兼容性
- 前端依赖新增 Sonner，用于统一丰富的 Toast 通知展示