### PR TITLE
fix(image-panel): 调整智能图像注入处理逻辑，解耦连线与UI展示

### DIFF
--- a/frontend/src/components/canvas/ImageGeneratePanel.tsx
+++ b/frontend/src/components/canvas/ImageGeneratePanel.tsx
@@ -57,29 +57,28 @@ export default function ImageGeneratePanel(props: ImageGeneratePanelProps) {
 
   const [showConfig, setShowConfig] = useState(false);
 
-  // 智能图像注入 handler（提出以便订阅 + pending drain 共用）
+  // 图像节点连线到图像节点的注入处理：
+  // 设计原则：连线 == 「源节点加入参考图列表」，**不**主动切换生成模式，由用户手动选择。
+  // - 源节点可能有多张图，这里只取第一张作为该源对应的参考图（一个源节点 → 一个参考图条目）。
+  // - 当前模式不接受参考图（text_to_image 容量=0）或已达上限时，toast 提示用户切模式
+  //   （用户切到 edit/reference_images 后，useImagePanelReferences 的 mode-change effect 会
+  //   从已有的 incoming edges 自动回填参考图）。
   const handleSmartImageInject = useCallback(
     (event: { sourceNodeId: string; urls: string[]; name?: string }) => {
       const urls = (event.urls || []).filter((u) => typeof u === 'string' && u.length > 0);
       if (urls.length === 0) return;
-      // 1 张 → edit；多张 → reference_images
-      const targetMode = urls.length === 1 ? 'edit' : 'reference_images';
-      const modeLabel = targetMode === 'edit' ? '图像编辑' : '多图参考';
-      const supported = form.visibility.supportedModes.includes(targetMode);
-      if (!supported) {
-        edgeToast.warn(`当前模型不支持「${modeLabel}」模式，请先手动切换模型`);
-        return;
-      }
-      const baseLabel = event.name || t('canvas.node.image.refItem', '参考图');
-      const items = urls.map((url, i) => ({
-        url,
-        name: urls.length > 1 ? `${baseLabel} ${i + 1}` : baseLabel,
-        sourceNodeId: event.sourceNodeId,
-      }));
-      const { appliedCount, droppedCount } = refs.applySmartInject(targetMode, items);
-      droppedCount > 0 && edgeToast.info(`已截断为前 ${appliedCount} 张（「${modeLabel}」模式上限）`);
+      const url = urls[0];
+      const name = event.name || t('canvas.node.image.refItem', '参考图');
+      const result = refs.addRefExternal(event.sourceNodeId, url, name);
+      // duplicate 静默（重复连线等常见无害场景）；limit 时给出可操作提示
+      result.ok === false && result.reason === 'limit' && edgeToast.warn(
+        t(
+          'canvas.node.image.refLimitReached',
+          '当前模式不接受更多参考图，请切换到「图像编辑」或「多图参考」模式',
+        ),
+      );
     },
-    [form.visibility.supportedModes, refs, t],
+    [refs, t],
   );
 
   // 订阅由上游连线触发的面板注入事件

--- a/frontend/src/hooks/useImagePanelReferences.ts
+++ b/frontend/src/hooks/useImagePanelReferences.ts
@@ -1,12 +1,13 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { useTranslation } from 'react-i18next';
 import {
   IMAGE_MODE_MAX_REFS,
   type ImageMode,
 } from '@/hooks/useImageGeneration';
-import { selectNodesByUpdatedDesc, type CanvasNode, type CharacterNodeData } from '@/store/useCanvasStore';
+import { selectNodesByUpdatedDesc, useCanvasStore, type CanvasNode, type CharacterNodeData } from '@/store/useCanvasStore';
 import { getImageNodeUrl } from '@/components/canvas/ImageGeneratePanel/utils';
 import type { ImageRef, ImagePanelModeRequest } from '@/components/canvas/ImageGeneratePanel/types';
 
@@ -22,9 +23,11 @@ interface Options {
 
 /**
  * 参考图状态管理：
- * - 受控 referenceImages 数组
- * - mode 切换时清空并解除连线
- * - 响应外部 modeRequest（token 驱动）
+ * - 受控 referenceImages 数组（面板 UI 层）
+ * - mode 切换时：仅按新容量截断 UI 列表；容量变大时从已连线的上游图像节点自动回填。
+ *   连线（edges）== 节点间的拓扑关系；参考图 == 当前模式下的 UI 展示。二者解耦，
+ *   模式切换不会删除连线（规避「切模式导致连线丢失」的 bug）。
+ * - 响应外部 modeRequest（token 驱动，快捷模式按钮）
  * - 筛选可选的画布节点（按 updatedAt 倒序）
  */
 export function useImagePanelReferences({
@@ -41,18 +44,51 @@ export function useImagePanelReferences({
   const [referenceImages, setReferenceImages] = useState<ImageRef[]>([]);
   const maxRefs = IMAGE_MODE_MAX_REFS[mode] || 0;
 
-  // mode 切换时：清空参考图并解除已建立的连线
+  // 订阅 incoming edges 的 source 节点 id（仅依赖图像节点间的拓扑）
+  // 连线 ≠ 参考图展示：连线是节点间的数据流拓扑，生成模式只决定 UI 如何展示这些来源。
+  // 性能：用 useShallow 浅比较结果数组，仅当 incoming source id 列表实际变化才触发重渲染（
+  // 拖动节点/其他变更导致 edges 引用波动时不会重新渲染所有已挂载的面板）。
+  const incomingSourceIds = useCanvasStore(
+    useShallow((s) => (nodeId ? s.edges.filter((e) => e.target === nodeId).map((e) => e.source) : [])),
+  );
+
+  // mode 切换时：
+  // - 仅按新 mode 容量「截断」面板 UI 层的参考图列表；不再删除底层连线
+  //   （连线代表「节点已关联」，不应随 edit/reference_images/text_to_image 的容量变化而破坏拓扑）
+  // - 若容量变大且存在已连线但未展示的源节点，按 incoming 顺序自动回填，保证 UX 连续性
+  // - 切换到 text_to_image（容量=0）时面板不显示任何参考图，但连线保留
   const prevModeRef = useRef<ImageMode>(mode);
-  // 智能注入：标记下一次 mode 切换 effect 跳过清空副作用
+  // 智能注入：标记下一次 mode 切换 effect 跳过副作用（applySmartInject 已自行处理）
   const skipNextClearRef = useRef(false);
   useEffect(() => {
     const skip = skipNextClearRef.current;
     skip && (skipNextClearRef.current = false);
     skip && (prevModeRef.current = mode);
-    const shouldClear = !skip && prevModeRef.current !== mode;
-    shouldClear && (() => {
-      referenceImages.forEach((r) => r.sourceNodeId !== nodeId && onUnlinkNode?.(r.sourceNodeId));
-      setReferenceImages([]);
+    const shouldAdjust = !skip && prevModeRef.current !== mode;
+    shouldAdjust && (() => {
+      const limit = IMAGE_MODE_MAX_REFS[mode] || 0;
+      const truncated = referenceImages.slice(0, limit);
+      // 自动回填：从已连线的上游图像节点中选取尚未出现在参考图中的源，补齐到容量上限
+      const existing = new Set(truncated.map((r) => r.sourceNodeId));
+      const filled: ImageRef[] = [];
+      incomingSourceIds.forEach((sid) => {
+        const canFill = filled.length + truncated.length < limit
+          && !existing.has(sid)
+          && sid !== nodeId;
+        canFill && (() => {
+          const src = canvasNodes.find((n) => n.id === sid);
+          const url = src ? getImageNodeUrl(src) : null;
+          url && (() => {
+            const data = (src as CanvasNode).data as CharacterNodeData;
+            const name = data.name || t('canvas.node.image.refItem', '参考图');
+            filled.push({ url, name, sourceNodeId: sid });
+          })();
+        })();
+      });
+      const next = [...truncated, ...filled];
+      const changed = next.length !== referenceImages.length
+        || next.some((r, i) => r.sourceNodeId !== referenceImages[i]?.sourceNodeId);
+      changed && setReferenceImages(next);
       prevModeRef.current = mode;
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/lib/canvas/panelEvents.ts
+++ b/frontend/src/lib/canvas/panelEvents.ts
@@ -50,14 +50,16 @@ export interface AddReferenceAudioEvent {
 }
 
 /**
- * 注入事件：智能图像注入 —— 由图像源节点连入图像/视频面板时派发。
+ * 注入事件：图像源节点连线注入 —— 由图像源节点连入图像面板 / 视频面板时派发。
  *
- * 面板依据 `urls.length` 决定目标模式：
- * - 1 张 → 图像：edit；视频：image_to_video
- * - N 张 → 图像：reference_images；视频：reference_images
+ * 面板处理策略（因面板而异）：
+ * - ImageGeneratePanel：**不**切换生成模式，仅将源节点追加到参考图列表（取 urls[0]）。
+ *   若当前模式不接受参考图（text_to_image）或已达上限，toast 提示用户切模式。
+ *   模式切换由用户手动完成，切后会从已有 incoming edges 自动回填。
+ * - VideoGeneratePanel：依据 urls.length 自选视频相关模式（1张 → image_to_video，N张 → reference_images）。
  *
- * 若当前模型不支持该模式，面板仅弹出警告 Toast（不自动换模型）。
- * 若超过当前模式上限 N，截断前 N 张并提示。
+ * pending 机制：QuickAdd 新建节点时面板尚未 mount，事件会先写入 pending，
+ * 面板在 capabilities 就绪后 drain 一次。
  */
 export interface SmartImageInjectEvent {
   type: 'smart-image-inject';


### PR DESCRIPTION
- 修改 ImageGeneratePanel 逻辑，智能图像注入改为只添加第一张参考图
- 取消注入时自动切换模式及支持模式检查，改为提示用户手动切换
- useImagePanelReferences hook 优化参考图状态管理，模式切换时不再清空连线，只截断参考图数量
- 增加自动回填已连线的上游图像节点至参考图，提升切换模式的用户体验
- 订阅面板注入事件兼容新注入策略，保持对旧逻辑的兼容性
- 优化对画布节点连线的监听，使用浅比较减少不必要重渲染
- 保留连线数据不随模式切换而丢失，解决切换模式导致连线丢失的bug