### PR TITLE
fix(migrations): 修正用户权限字段的布尔值类型

### DIFF
--- a/backend/migrations/versions/b5d7e2f8a1c3_player_to_user_auth.py
+++ b/backend/migrations/versions/b5d7e2f8a1c3_player_to_user_auth.py
@@ -67,7 +67,7 @@ def upgrade() -> None:
                 username,
                 :placeholder_hash,
                 'user',
-                1,
+                TRUE,
                 0, 0, 0, 0,
                 current_chapter, personality_profile, inventory, relationships,
                 created_at
@@ -85,7 +85,7 @@ def upgrade() -> None:
                 total_input_tokens, total_output_tokens, total_input_chars, total_output_chars,
                 current_chapter, created_at
             ) VALUES (
-                :id, :email, :nickname, :password_hash, 'admin', 1,
+                :id, :email, :nickname, :password_hash, 'admin', TRUE,
                 0, 0, 0, 0, 1, CURRENT_TIMESTAMP
             )
         """).bindparams(


### PR DESCRIPTION
- 将玩家到用户认证迁移脚本中的权限字段改为布尔类型 TRUE
- 修正普通用户权限值为 TRUE，替代原有整数 1
- 修正管理员权限值为 TRUE，替代原有整数 1
- 确保权限字段的类型一致性以避免潜在错误