### PR TITLE
fix(migrations): 解决players表删除时外键约束问题

### DIFF
--- a/backend/migrations/versions/b5d7e2f8a1c3_player_to_user_auth.py
+++ b/backend/migrations/versions/b5d7e2f8a1c3_player_to_user_auth.py
@@ -113,7 +113,15 @@ def upgrade() -> None:
             batch_op.create_index('ix_chat_sessions_user_id', ['user_id'])
 
     # 7. Drop players table
-    op.drop_table('players')
+    # 注：在 PostgreSQL 下，story_chapters 上的 player_id_fkey 外键约束不会因列
+    # 改名（第 4 步）自动消失，drop_table 会因依赖报错。用 CASCADE 连带移除
+    # 残留外键约束；SQLite 方言 batch_alter_table 已整表重建，直接 drop 即可。
+    bind = op.get_bind()
+    dialect_name = bind.dialect.name if bind is not None else ''
+    _drop_players = {
+        'postgresql': lambda: op.execute('DROP TABLE players CASCADE'),
+    }
+    _drop_players.get(dialect_name, lambda: op.drop_table('players'))()
 
 
 def downgrade() -> None:


### PR DESCRIPTION
- 针对PostgreSQL数据库，使用CASCADE参数删除players表以移除依赖外键约束
- 保持SQLite等其他数据库使用默认drop_table方法删除players表
- 增加数据库判断逻辑，确保跨数据库兼容删除操作
- 添加代码注释说明PostgreSQL下外键约束不会自动移除的原因
- 优化迁移脚本防止删除表时报错，提高迁移稳定性