### PR TITLE
fix(deploy): 修正 nginx 配置中 /admin 路径匹配规则

### DIFF
--- a/deploy/nginx/templates/kunflix.conf.template
+++ b/deploy/nginx/templates/kunflix.conf.template
@@ -75,12 +75,10 @@ server {
     }
 
     # -------------------------------------------------------------------------
-    # /admin/*  —— Admin Dashboard（Next.js basePath=/admin）
+    # /admin  —— Admin Dashboard（Next.js basePath=/admin）
+    # 不带尾斜杠的 prefix 匹配，同时覆盖 /admin、/admin/、/admin/xxx
     # -------------------------------------------------------------------------
-    location = /admin {
-        return 301 /admin/;
-    }
-    location /admin/ {
+    location /admin {
         proxy_pass         http://admin:3888;
         proxy_http_version 1.1;
 


### PR DESCRIPTION
- 修改 /admin 路径的注释，说明匹配不带尾斜杠的前缀
- 移除对 /admin 请求的重定向，统一采用 location /admin 代理转发
- 优化 nginx 配置，覆盖 /admin、/admin/ 及其子路径请求