### PR TITLE
fix(docker): backend 镜像增加 pip 多源 fallback，规避清华单源超时

### DIFF
--- a/deploy/backend.Dockerfile
+++ b/deploy/backend.Dockerfile
@@ -34,12 +34,17 @@ RUN apt-get update \
 
 WORKDIR /app
 
-# pip 镜像源（国内服务器默认用清华，外网环境可通过 --build-arg PIP_INDEX_URL=https://pypi.org/simple 覆盖）
+# pip 镜像源（主：清华；备：阿里云；兜底：PyPI 官方）
+# 清华单源抖动时通过 extra-index 自动回退，避免 "from versions: none" 假象
+# 外网环境可通过 --build-arg PIP_INDEX_URL=https://pypi.org/simple 覆盖
 ARG PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple
-ARG PIP_TRUSTED_HOST=pypi.tuna.tsinghua.edu.cn
+ARG PIP_EXTRA_INDEX_URL="https://mirrors.aliyun.com/pypi/simple https://pypi.org/simple"
+ARG PIP_TRUSTED_HOST="pypi.tuna.tsinghua.edu.cn mirrors.aliyun.com pypi.org files.pythonhosted.org"
 ENV PIP_INDEX_URL=${PIP_INDEX_URL} \
+    PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL} \
     PIP_TRUSTED_HOST=${PIP_TRUSTED_HOST} \
-    PIP_DEFAULT_TIMEOUT=120
+    PIP_DEFAULT_TIMEOUT=120 \
+    PIP_RETRIES=10
 
 # 先拷依赖清单以充分利用构建缓存
 COPY backend/requirements.txt /app/requirements.txt


### PR DESCRIPTION
## 现象

合并 PR #116 修好 lock 后，生产 `update.sh` 重跑又卡在 backend 镜像构建的 pip install 阶段：

```
38.03 Collecting fastapi>=0.129.0
42.23   Downloading fastapi-0.136.1-py3-none-any.whl
(中间静默 160 秒)
201.7 ERROR: Could not find a version that satisfies the requirement uvicorn>=0.41.0 (from versions: none)
201.7 ERROR: No matching distribution found for uvicorn>=0.41.0
```

## 根因

**不是 `uvicorn` 不存在，是清华镜像 `/simple` 索引接口在中间跳抖**。pip 单源依赖下，当索引请求超时时会报空版本集合，消息就表现为假 "package not found"，而不是重试或明确的网络错误。这类问题在国内镜像上偶发，无法通过客户端预防。

PR #116 里的 lock 重建成功修复了 `npm ci` 的问题——日志里 admin/frontend 的 `npm ci` 都跑到 202s 没报错，只是被 backend 失败拖累成 `CANCELED`。本 PR 解决的是另一条正交的失败路径。

## 本 PR 改动（`deploy/backend.Dockerfile`）

将单源清华改为三源 fallback：

```dockerfile
ARG PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple
ARG PIP_EXTRA_INDEX_URL="https://mirrors.aliyun.com/pypi/simple https://pypi.org/simple"
ARG PIP_TRUSTED_HOST="pypi.tuna.tsinghua.edu.cn mirrors.aliyun.com pypi.org files.pythonhosted.org"
ENV PIP_INDEX_URL=${PIP_INDEX_URL} \
    PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL} \
    PIP_TRUSTED_HOST=${PIP_TRUSTED_HOST} \
    PIP_DEFAULT_TIMEOUT=120 \
    PIP_RETRIES=10
```

- **主源**：清华（速度最快）
- **备源 1**：阿里云（国内 CDN，独立于清华基础设施）
- **备源 2**：官方 PyPI（全量带 SRI，兴国内可达）
- **PIP_RETRIES=10**：严重抖动时抽绳自动重试

pip 遇到 A 源响应不含某版本时会自动查 B、C，彻底消除“单源抖动 → 假点”这类伪错误。

## npm 那边为什么不同步改

`admin.Dockerfile` / `frontend.Dockerfile` 已配 `fetch-retries 5` + `fetch-retry-maxtimeout 120000`，npm 内置重试机制游刻有效，日志中也没见它们真正报错。保持最小改动原则，本 PR 只动 backend。

## 合入后验证

服务器重跑：

```bash
cd /opt/kunflix/deploy
sudo bash scripts/update.sh
```

预期 pip install 在約 1-3 分钟内完成，admin/frontend 镜像紧跟着 build 过，Step 5 healthcheck 轮询各服务 `healthy`。