### PR TITLE
fix(docker): 前端镜像补装 Alpine 平台原生依赖

### DIFF
--- a/deploy/frontend.Dockerfile
+++ b/deploy/frontend.Dockerfile
@@ -19,7 +19,10 @@ RUN npm config set registry ${NPM_REGISTRY} \
     && npm config set fetch-retry-mintimeout 20000 \
     && npm config set fetch-retry-maxtimeout 120000
 COPY frontend/package.json frontend/package-lock.json ./
-RUN npm ci --no-audit --no-fund
+RUN npm ci --no-audit --no-fund \
+    && npm install --no-save --no-audit --no-fund --ignore-scripts \
+        lightningcss-linux-x64-musl \
+        @next/swc-linux-x64-musl
 
 # ---------- Stage 2: 构建 ----------
 FROM node:22-alpine AS build


### PR DESCRIPTION
## 问题

生产 `update.sh` 构建前端镜像时 `npm run build` 失败（27 个错误），核心报错：

```
Error: Cannot find module '../lightningcss.linux-x64-musl.node'
Require stack:
 - /app/node_modules/@tailwindcss/postcss/node_modules/@tailwindcss/node/node_modules/lightningcss/node/index.js
```

另有警告：`⚠ Found lockfile missing swc dependencies, patching...`（Next.js 自己 patch 了 @next/swc，但 lightningcss 没有类似机制，直接 crash）。

## 根因

上一次通过 PR #116 在 **Windows** 上重建 `frontend/package-lock.json` 时，npm 只把 `win32-x64-msvc` 版本的 optional 原生依赖写入 lock；Alpine (musl) 生产容器执行 `npm ci` 时，根据 lock 只装 Windows 的二进制，缺失 `lightningcss-linux-x64-musl` 与 `@next/swc-linux-x64-musl` 这两个 Linux/musl 原生包。

- `@next/swc`：Next.js 内置 fallback，构建时会自动下载（日志 L89-L92 可见），不影响最终产物但会打印警告
- `lightningcss`（Tailwind v4 依赖）：**没有 fallback**，直接找不到 `.node` 文件导致 Turbopack build 崩溃

## 方案

`deploy/frontend.Dockerfile` 中，在 `npm ci` 之后显式补装两个平台原生包：

```dockerfile
RUN npm ci --no-audit --no-fund \
    && npm install --no-save --no-audit --no-fund --ignore-scripts \
        lightningcss-linux-x64-musl \
        @next/swc-linux-x64-musl
```

设计取舍：
- `--no-save`：不修改 `package-lock.json`，不污染本地 Windows 开发环境
- `--ignore-scripts`：跳过 postinstall，避免意外副作用（这俩包的 main 就是 `.node` 二进制本身，不需要脚本）
- 一并补装 `@next/swc-linux-x64-musl`：Next 虽能自动 patch，但一起装更稳定、避免每次 build 都重新下载
- Stage 2 `COPY --from=deps /app/node_modules` 会把补装结果带到 build 阶段

## 合入后验证

```bash
sudo bash deploy/scripts/update.sh
# 观察 [frontend build 5/5] RUN npm run build 应成功
# 不再出现 'Cannot find module lightningcss.linux-x64-musl.node'
```

## 相关 PR

- #116 重建 lock 文件（引入本问题）
- #117 backend pip 多源 fallback（已合）
