### PR TITLE
refactor(drag-drop): 优化文件拖拽上传逻辑并统一节点ID格式

### DIFF
--- a/backend/migrations/versions/x4y5z6a7b8c9_relax_theater_id_length.py
+++ b/backend/migrations/versions/x4y5z6a7b8c9_relax_theater_id_length.py
@@ -1,0 +1,83 @@
+"""relax theater_nodes/edges id length from 36 to 64
+
+Revision ID: x4y5z6a7b8c9
+Revises: w3x4y5z6a7b8
+Create Date: 2026-05-09 00:00:00.000000
+
+放宽 theater_nodes.id、theater_edges.id/source_node_id/target_node_id 的长度上限
+从 VARCHAR(36) 增加到 VARCHAR(64)，以兼容前端 localStorage 中残留的带前缀 UUID
+（如 image-<uuid>、xy-edge__<source>-<target> 等 >36 字符的 ID），避免生产
+PostgreSQL 报 "value too long for type character varying(36)" 导致 canvas 保存
+500 错误、图像数据丢失。
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "x4y5z6a7b8c9"
+down_revision = "w3x4y5z6a7b8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # theater_edges 有外键引用 theater_nodes.id，先放宽被引用列，再放宽引用列
+    with op.batch_alter_table("theater_nodes") as batch_op:
+        batch_op.alter_column(
+            "id",
+            existing_type=sa.String(length=36),
+            type_=sa.String(length=64),
+            existing_nullable=False,
+        )
+
+    with op.batch_alter_table("theater_edges") as batch_op:
+        batch_op.alter_column(
+            "id",
+            existing_type=sa.String(length=36),
+            type_=sa.String(length=64),
+            existing_nullable=False,
+        )
+        batch_op.alter_column(
+            "source_node_id",
+            existing_type=sa.String(length=36),
+            type_=sa.String(length=64),
+            existing_nullable=False,
+        )
+        batch_op.alter_column(
+            "target_node_id",
+            existing_type=sa.String(length=36),
+            type_=sa.String(length=64),
+            existing_nullable=False,
+        )
+
+
+def downgrade() -> None:
+    # 回滚顺序与 upgrade 相反：先收紧引用列，再收紧被引用列
+    with op.batch_alter_table("theater_edges") as batch_op:
+        batch_op.alter_column(
+            "target_node_id",
+            existing_type=sa.String(length=64),
+            type_=sa.String(length=36),
+            existing_nullable=False,
+        )
+        batch_op.alter_column(
+            "source_node_id",
+            existing_type=sa.String(length=64),
+            type_=sa.String(length=36),
+            existing_nullable=False,
+        )
+        batch_op.alter_column(
+            "id",
+            existing_type=sa.String(length=64),
+            type_=sa.String(length=36),
+            existing_nullable=False,
+        )
+
+    with op.batch_alter_table("theater_nodes") as batch_op:
+        batch_op.alter_column(
+            "id",
+            existing_type=sa.String(length=64),
+            type_=sa.String(length=36),
+            existing_nullable=False,
+        )

--- a/backend/models.py
+++ b/backend/models.py
@@ -117,7 +117,8 @@ class TheaterNode(Base):
         Index("ix_theater_nodes_theater_type", "theater_id", "node_type"),
     )
 
-    id = Column(String(36), primary_key=True, default=generate_uuid, index=True)
+    # id 放宽至 64，兼容前端 localStorage 残留的带前缀 UUID（如 image-<uuid> 达 41+）
+    id = Column(String(64), primary_key=True, default=generate_uuid, index=True)
     theater_id = Column(String(36), ForeignKey("theaters.id", ondelete="CASCADE"), nullable=False, index=True)
     node_type = Column(String(20), nullable=False)  # script | character | storyboard | video
     position_x = Column(Float, default=0)
@@ -138,10 +139,11 @@ class TheaterEdge(Base):
     """剧场边表 - 节点之间的连接"""
     __tablename__ = "theater_edges"
 
-    id = Column(String(36), primary_key=True, default=generate_uuid, index=True)
+    # id / source_node_id / target_node_id 放宽至 64，与 theater_nodes.id 保持一致
+    id = Column(String(64), primary_key=True, default=generate_uuid, index=True)
     theater_id = Column(String(36), ForeignKey("theaters.id", ondelete="CASCADE"), nullable=False, index=True)
-    source_node_id = Column(String(36), ForeignKey("theater_nodes.id", ondelete="CASCADE"), nullable=False)
-    target_node_id = Column(String(36), ForeignKey("theater_nodes.id", ondelete="CASCADE"), nullable=False)
+    source_node_id = Column(String(64), ForeignKey("theater_nodes.id", ondelete="CASCADE"), nullable=False)
+    target_node_id = Column(String(64), ForeignKey("theater_nodes.id", ondelete="CASCADE"), nullable=False)
     source_handle = Column(String(50), nullable=True)
     target_handle = Column(String(50), nullable=True)
     edge_type = Column(String(20), default="custom")

--- a/frontend/src/app/theater/[id]/hooks/useFileDragDrop.ts
+++ b/frontend/src/app/theater/[id]/hooks/useFileDragDrop.ts
@@ -138,7 +138,7 @@ const NODE_CREATORS: Record<string, (file: File, position: { x: number; y: numbe
     const fileName = file.name.replace(/\.[^/.]+$/, '');
     const dims = NODE_DIMENSIONS.text;
     const newNode: CanvasNode = {
-      id: `text-${uuidv4()}`,
+      id: uuidv4(),
       type: 'text',
       position,
       width: dims.width,
@@ -164,7 +164,7 @@ const NODE_CREATORS: Record<string, (file: File, position: { x: number; y: numbe
     const objectUrl = URL.createObjectURL(file);
     const dims = NODE_DIMENSIONS.image;
     const newNode: CanvasNode = {
-      id: `image-${uuidv4()}`,
+      id: uuidv4(),
       type: 'image',
       position,
       width: dims.width,
@@ -184,7 +184,7 @@ const NODE_CREATORS: Record<string, (file: File, position: { x: number; y: numbe
     const objectUrl = URL.createObjectURL(file);
     const dims = NODE_DIMENSIONS.video;
     const newNode: CanvasNode = {
-      id: `video-${uuidv4()}`,
+      id: uuidv4(),
       type: 'video',
       position,
       width: dims.width,
@@ -204,7 +204,7 @@ const NODE_CREATORS: Record<string, (file: File, position: { x: number; y: numbe
     const objectUrl = URL.createObjectURL(file);
     const dims = NODE_DIMENSIONS.audio;
     const newNode: CanvasNode = {
-      id: `audio-${uuidv4()}`,
+      id: uuidv4(),
       type: 'audio',
       position,
       width: dims.width,
@@ -239,7 +239,7 @@ const NODE_CREATORS: Record<string, (file: File, position: { x: number; y: numbe
     }));
     const dims = NODE_DIMENSIONS.spreadsheet;
     const newNode: CanvasNode = {
-      id: `storyboard-${uuidv4()}`,
+      id: uuidv4(),
       type: 'storyboard',
       position,
       width: dims.width,

--- a/frontend/src/components/canvas/AudioNode.tsx
+++ b/frontend/src/components/canvas/AudioNode.tsx
@@ -88,7 +88,7 @@ const AudioNode = ({ id, data, selected }: NodeProps<Node<AudioNodeData>>) => {
       const currentName = currentData.name || t('canvas.node.unnamedAudioCard');
       const newNode: CanvasNode = {
         ...(node as CanvasNode),
-        id: `audio-${uuidv4()}`,
+        id: uuidv4(),
         position: {
           x: node.position.x + 50,
           y: node.position.y + 50,

--- a/frontend/src/components/canvas/ImageNode.tsx
+++ b/frontend/src/components/canvas/ImageNode.tsx
@@ -154,7 +154,7 @@ const CharacterNode = ({ id, data, selected }: NodeProps<Node<CharacterNodeData>
       const currentName = currentData.name || t('canvas.node.unnamedImageCard');
       const newNode: CanvasNode = {
         ...(node as CanvasNode),
-        id: `character-${uuidv4()}`,
+        id: uuidv4(),
         position: { x: node.position.x + 50, y: node.position.y + 50 },
         selected: false,
         data: {
@@ -246,7 +246,7 @@ const CharacterNode = ({ id, data, selected }: NodeProps<Node<CharacterNodeData>
     droppedOnSelf || (() => {
       const pos = screenToFlowPosition({ x: e.clientX, y: e.clientY });
       const newNode: CanvasNode = {
-        id: `image-${uuidv4()}`,
+        id: uuidv4(),
         type: 'image',
         position: { x: pos.x - 128, y: pos.y - 96 },
         width: 512,

--- a/frontend/src/components/canvas/StoryboardNode.tsx
+++ b/frontend/src/components/canvas/StoryboardNode.tsx
@@ -73,7 +73,7 @@ const StoryboardNode = ({ id, data, selected }: NodeProps<Node<StoryboardNodeDat
     if (node) {
       const newNode = {
         ...(node as CanvasNode),
-        id: `storyboard-${uuidv4()}`,
+        id: uuidv4(),
         position: {
           x: node.position.x + 50,
           y: node.position.y + 50,

--- a/frontend/src/components/canvas/TextNode.tsx
+++ b/frontend/src/components/canvas/TextNode.tsx
@@ -93,7 +93,7 @@ const ScriptNode = ({ id, data, selected }: NodeProps<Node<ScriptNodeData>>) => 
       const currentTitle = currentData.title || t('canvas.node.unnamedTextCard');
       const newNode: CanvasNode = {
         ...(node as CanvasNode),
-        id: `script-${uuidv4()}`,
+        id: uuidv4(),
         position: {
           x: node.position.x + 50,
           y: node.position.y + 50,

--- a/frontend/src/components/canvas/VideoNode.tsx
+++ b/frontend/src/components/canvas/VideoNode.tsx
@@ -106,7 +106,7 @@ const VideoNode = ({ id, data, selected }: NodeProps<Node<VideoNodeData>>) => {
       const currentName = currentData.name || t('canvas.node.unnamedVideoCard');
       const newNode: CanvasNode = {
         ...(node as CanvasNode),
-        id: `video-${uuidv4()}`,
+        id: uuidv4(),
         position: { x: node.position.x + 50, y: node.position.y + 50 },
         selected: false,
         data: {
@@ -206,7 +206,7 @@ const VideoNode = ({ id, data, selected }: NodeProps<Node<VideoNodeData>>) => {
     droppedOnSelf || (() => {
       const pos = screenToFlowPosition({ x: e.clientX, y: e.clientY });
       const newNode: CanvasNode = {
-        id: `video-${uuidv4()}`,
+        id: uuidv4(),
         type: 'video',
         position: { x: pos.x - 128, y: pos.y - 96 },
         data: {

--- a/frontend/src/hooks/useImageGenerationApply.ts
+++ b/frontend/src/hooks/useImageGenerationApply.ts
@@ -112,7 +112,7 @@ export function useImageGenerationApply(id: string, data: CharacterNodeData) {
       const targetNode = outEdge ? getNode(outEdge.target) : null;
       const isCharTarget = targetNode?.type === 'image';
 
-      const targetId = isCharTarget ? targetNode!.id : `image-${uuidv4()}`;
+      const targetId = isCharTarget ? targetNode!.id : uuidv4();
       const existingImgs = (isCharTarget ? (targetNode!.data as CharacterNodeData)?.images : []) || [];
       const slotsAvailable = MAX_IMAGES - existingImgs.length;
       const urlsToApply = urls.slice(0, Math.max(0, slotsAvailable));

--- a/frontend/src/store/useCanvasStore.ts
+++ b/frontend/src/store/useCanvasStore.ts
@@ -1,6 +1,7 @@
 
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
+import { v4 as uuidv4 } from 'uuid';
 import {
   Connection,
   Edge,
@@ -376,8 +377,8 @@ export const useCanvasStore = create<CanvasState>()(
         if (!validation.ok) return { ok: false, reason: validation.reason };
         void rejectedSilently;
 
-        // 2. 建边
-        const newEdges = addEdge({ ...connection, type: 'custom', animated: true }, edges);
+        // 2. 建边（显式指定短 UUID，避免 xyflow 默认生成 xy-edge__xxx 超长 ID 超过后端 VARCHAR 限制）
+        const newEdges = addEdge({ ...connection, id: uuidv4(), type: 'custom', animated: true }, edges);
         set({ edges: newEdges, isDirty: true });
         get().takeSnapshot();
 
@@ -656,9 +657,36 @@ export const useCanvasStore = create<CanvasState>()(
           // Update title if changed
           await theaterApi.updateTheater(theaterId, { title: theaterTitle });
 
+          // ① 过滤掉临时节点（ghost / streaming / local-前缀）
+          const savableNodes = nodes.filter(
+            (n) => n.type !== 'ghost'
+              && !n.id.startsWith('streaming-')
+              && !n.id.startsWith('local-'),
+          );
+
+          // ② ID 归一化兜底：超过 36 字符的旧 ID（如 localStorage 残留的 image-<uuid>）重映射为纯 UUID，避免后端 VARCHAR 长度越界
+          const nodeIdRemap = new Map<string, string>();
+          const normalizedNodes = savableNodes.map((n) => {
+            if (n.id.length <= 36) return n;
+            const newId = uuidv4();
+            nodeIdRemap.set(n.id, newId);
+            return { ...n, id: newId };
+          });
+          const normalizedNodeIds = new Set(normalizedNodes.map((n) => n.id));
+
+          // ③ 同步过滤孤儿边，并重映射边的 source/target；超长边 ID 一并归一化
+          const savableEdges = edges
+            .map((e) => {
+              const source = nodeIdRemap.get(e.source) ?? e.source;
+              const target = nodeIdRemap.get(e.target) ?? e.target;
+              const id = e.id.length <= 36 ? e.id : uuidv4();
+              return { ...e, id, source, target };
+            })
+            .filter((e) => normalizedNodeIds.has(e.source) && normalizedNodeIds.has(e.target));
+
           const detail = await theaterApi.saveCanvas(theaterId, {
-            nodes: nodes.filter((n) => n.type !== 'ghost' && !n.id.startsWith('streaming-') && !n.id.startsWith('local-')).map(nodeToApi),
-            edges: edges.map(edgeToApi),
+            nodes: normalizedNodes.map(nodeToApi),
+            edges: savableEdges.map(edgeToApi),
             canvas_viewport: viewport as Record<string, number>,
           });
           set({


### PR DESCRIPTION
- 放宽 theater_nodes 和 theater_edges 表中相关 ID 字段长度至 64 字符
- 兼容前端 localStorage 中带前缀的 UUID，如 image-<uuid>
- 避免 canvas 保存时报错，防止图像数据丢失
- 优化文件拖拽钩子 useFileDragDrop 的节点 ID 生成方式，去除前缀，只用纯 uuid
- 调整文件上传与节点数据更新逻辑
- 保持批量上传限制和文件类型检测不变
- 提升代码一致性和可维护性