### PR TITLE
feat(video): 优化视频面板智能图像注入及模式切换处理

### DIFF
--- a/frontend/src/components/canvas/ImageGeneratePanel.tsx
+++ b/frontend/src/components/canvas/ImageGeneratePanel.tsx
@@ -97,7 +97,11 @@ export default function ImageGeneratePanel(props: ImageGeneratePanelProps) {
           t('canvas.node.image.refLimitReached', '参考图已达上限，无法再添加'),
         );
       },
-      'smart-image-inject': handleSmartImageInject,
+      'smart-image-inject': (event: { sourceNodeId: string; urls: string[]; name?: string }) => {
+        // 消费可能已写入的 pending，避免 drain effect 因 refs 引用变化而重复触发同一事件
+        takePendingSmartInject(nodeId);
+        handleSmartImageInject(event);
+      },
     };
     const unsubscribe = onPanelInject(nodeId, (ev) => {
       handlers[ev.type]?.(ev as unknown as { text: string } & { sourceNodeId: string; url: string; urls: string[]; name?: string });

--- a/frontend/src/components/canvas/VideoGeneratePanel.tsx
+++ b/frontend/src/components/canvas/VideoGeneratePanel.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import React, { useRef, useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { XCircle } from 'lucide-react';
-import { useDropdownOutside } from '@/hooks/useDropdownOutside';
 import { useVideoPanelForm } from '@/hooks/useVideoPanelForm';
 import { useVideoPanelReferences } from '@/hooks/useVideoPanelReferences';
 import { useVideoPanelResize } from '@/hooks/useVideoPanelResize';
@@ -63,19 +62,58 @@ export default function VideoGeneratePanel(props: VideoGeneratePanelProps) {
   });
   const { inputContainerRef, inputMaxHeight, resizeHandlers } = useVideoPanelResize();
 
-  // ── 展开配置区（仅主文件自己管） ──
+  // ── 展开配置区（与图像面板对齐：仅由按钮 toggle，不因点击外部（输入框等）而自动关闭）──
   const [showConfig, setShowConfig] = useState(false);
-  const configRef = useRef<HTMLDivElement>(null);
   const [showNodePicker, setShowNodePicker] = useState(false);
 
-  useDropdownOutside([[showConfig, configRef, setShowConfig]]);
-
-  // 智能图像注入 handler（提出以便订阅 + pending drain 共用）
+  // 智能图像注入 handler（订阅 + pending drain 共用）
+  //
+  // 规则（尊重用户已选模式，不强制切换）：
+  //   - 当前 pickerMode 能接受图像（first_last_frame / multi_image / single_image），
+  //     或面板已有参考素材 → 仅「追加」到当前模式，不切换 videoMode。
+  //     这修复了「已切到多模态参考但素材为空时，再拖连线会被强制切回图生视频」的 bug。
+  //     失败时 toast 提示用户手动切模式。
+  //   - 当前 pickerMode 不接受图像（text_to_video / edit / video_extension）且面板空态
+  //     （QuickAdd 新建节点的典型场景）：按 url 数量自选模式
+  //     （1 张 → image_to_video；多张 → reference_images）。
   const handleSmartImageInject = useCallback(
     (event: { sourceNodeId: string; urls: string[]; name?: string }) => {
       const urls = (event.urls || []).filter((u) => typeof u === 'string' && u.length > 0);
       if (urls.length === 0) return;
-      // 1 张 → image_to_video；多张 → reference_images
+      const baseLabel = event.name || '参考图';
+
+      // 当前 pickerMode 是否能接受图像类型
+      const pickerAcceptsImage =
+        refs.pickerMode === 'single_image' ||
+        refs.pickerMode === 'first_last_frame' ||
+        refs.pickerMode === 'multi_image';
+
+      const hasExistingContent =
+        !!refs.imageUrl ||
+        !!refs.lastFrameImageUrl ||
+        !!refs.extensionVideoUrl ||
+        refs.referenceImages.length > 0;
+
+      // 1) 当前模式能接受图像 OR 面板已有素材 → 仅追加，不切模式
+      const appendOnly = pickerAcceptsImage || hasExistingContent;
+      if (appendOnly) {
+        const results = urls.map((url, i) => {
+          const name = urls.length > 1 ? `${baseLabel} ${i + 1}` : baseLabel;
+          return refs.addImageExternal(event.sourceNodeId, url, name);
+        });
+        const okCount = results.filter((r) => r.ok).length;
+        const noSlotHit = results.some((r) => r.ok === false && r.reason === 'no_slot');
+        const limitHit = results.some((r) => r.ok === false && r.reason === 'limit');
+        const dupHit = results.some((r) => r.ok === false && r.reason === 'duplicate');
+        okCount === 0 && noSlotHit && edgeToast.warn('当前模式不接受该参考图，请手动切换模式');
+        okCount === 0 && !noSlotHit && limitHit && edgeToast.warn('参考图已达当前模式上限');
+        okCount === 0 && !noSlotHit && !limitHit && dupHit && edgeToast.info('该参考项已存在');
+        okCount > 0 && (noSlotHit || limitHit) &&
+          edgeToast.info(`已追加 ${okCount} 张，其余因容量/类型不匹配被跳过`);
+        return;
+      }
+
+      // 2) 当前模式不接受图像且空态 → 按数量自选模式（QuickAdd 新节点场景）
       const targetMode = urls.length === 1 ? 'image_to_video' : 'reference_images';
       const modeLabel = targetMode === 'image_to_video' ? '图生视频' : '多模态参考';
       const modes = form.capabilities?.modes || [];
@@ -84,7 +122,6 @@ export default function VideoGeneratePanel(props: VideoGeneratePanelProps) {
         edgeToast.warn(`当前模型不支持「${modeLabel}」模式，请先手动切换模型`);
         return;
       }
-      const baseLabel = event.name || '参考图';
       const items = urls.map((url, i) => ({
         url,
         name: urls.length > 1 ? `${baseLabel} ${i + 1}` : baseLabel,
@@ -122,7 +159,11 @@ export default function VideoGeneratePanel(props: VideoGeneratePanelProps) {
       'add-reference-audio': (event: { sourceNodeId: string; url: string; name?: string }) => {
         handleAfter(refs.addAudioExternal(event.sourceNodeId, event.url, event.name));
       },
-      'smart-image-inject': handleSmartImageInject,
+      'smart-image-inject': (event: { sourceNodeId: string; urls: string[]; name?: string }) => {
+        // 消费可能已写入的 pending，避免 drain effect 因 refs 引用变化而重复触发同一事件
+        takePendingSmartInject(nodeId);
+        handleSmartImageInject(event);
+      },
     };
     const unsubscribe = onPanelInject(nodeId, (ev) => {
       handlers[ev.type]?.(ev as unknown as { text: string } & { sourceNodeId: string; url: string; urls: string[]; name?: string; tag?: 'first-frame' });
@@ -310,7 +351,6 @@ export default function VideoGeneratePanel(props: VideoGeneratePanelProps) {
       {/* 展开配置区 */}
       {showConfig && form.selectedModel && (
         <ConfigPanel
-          containerRef={configRef}
           capabilities={form.capabilities}
           visibility={form.visibility}
           videoMode={form.videoMode}

--- a/frontend/src/components/canvas/VideoGeneratePanel/ConfigPanel.tsx
+++ b/frontend/src/components/canvas/VideoGeneratePanel/ConfigPanel.tsx
@@ -41,7 +41,6 @@ interface Props {
   setPromptOptimizer: (v: boolean) => void;
   fastPretreatment: boolean;
   setFastPretreatment: (v: boolean) => void;
-  containerRef: React.RefObject<HTMLDivElement | null>;
 }
 
 /** 展开式配置面板：mode / duration / quality / aspect / toggles */
@@ -60,7 +59,6 @@ export function ConfigPanel({
   setPromptOptimizer,
   fastPretreatment,
   setFastPretreatment,
-  containerRef,
 }: Props) {
   const { t } = useTranslation();
 
@@ -82,7 +80,6 @@ export function ConfigPanel({
 
   return (
     <div
-      ref={containerRef}
       className="rounded-lg border border-border/50 bg-card p-2.5 space-y-2.5 text-xs animate-in fade-in slide-in-from-top-1 duration-150"
     >
       {/* Mode */}

--- a/frontend/src/hooks/useImageGridExport.ts
+++ b/frontend/src/hooks/useImageGridExport.ts
@@ -64,7 +64,8 @@ export function useImageGridExport({ id, gridContainerRef, imageList, data, setU
 
       const currentNode = getNode(id);
       const nodeWidth = currentNode?.width ?? 512;
-      const newNodeId = `image-${uuidv4()}`;
+      // 裸 UUID：避免 `image-<uuid>` 42 字符 ID 被 saveToBackend 重映射导致节点持久化漂移
+      const newNodeId = uuidv4();
       const exportName = t('canvas.node.upload.exportName', {
         name: data.name || t('canvas.node.unnamedImageCard'),
       });

--- a/frontend/src/hooks/useImageNodeConnections.ts
+++ b/frontend/src/hooks/useImageNodeConnections.ts
@@ -17,12 +17,14 @@ export function useImageNodeConnections(targetId: string) {
     const alreadyLinked = edges.some((e) => e.source === sourceNodeId && e.target === targetId);
     // 面板内选取已隐含用户同意且已有 ref 挂载，不重复弹注入确认。
     // 校验失败用 silent 模式（避免打断面板交互）
+    // suppressPanelInject：调用侧（useImagePanelReferences 的 selectNode / applySmartInject）已手动更新 UI，
+    // 跳过 smart-image-inject 等面板事件，避免「UI 写一次 + 事件再写一次」的双添加。
     alreadyLinked || useCanvasStore.getState().connectAndInject({
       source: sourceNodeId,
       sourceHandle: 'right-source',
       target: targetId,
       targetHandle: 'left-target',
-    }, { fromQuickAdd: true, silent: true });
+    }, { fromQuickAdd: true, silent: true, suppressPanelInject: true });
   }, [targetId, getEdges]);
 
   const unlinkNode = useCallback((sourceNodeId: string) => {

--- a/frontend/src/hooks/useVideoGenerationApply.ts
+++ b/frontend/src/hooks/useVideoGenerationApply.ts
@@ -83,7 +83,9 @@ export function useVideoGenerationApply(id: string, data: VideoNodeData) {
       const outEdge = edges.find((e) => e.source === id);
       const targetNode = outEdge ? getNode(outEdge.target) : null;
       const isVideoTarget = targetNode?.type === 'video';
-      const targetId = isVideoTarget ? targetNode!.id : `video-${uuidv4()}`;
+      // 统一使用裸 UUID，避免 `video-<uuid>` 这种带前缀的 42 字符 ID 触发 saveToBackend 的随机重映射，
+      // 进而引发节点/边在同事务内 DELETE+INSERT 错位，产生 theater_edges_target_node_id_fkey 违反。
+      const targetId = isVideoTarget ? targetNode!.id : uuidv4();
 
       isVideoTarget
         ? updateNodeData(targetId, { videoUrl: generatedUrl } as Partial<VideoNodeData>)

--- a/frontend/src/hooks/useVideoNodeConnections.ts
+++ b/frontend/src/hooks/useVideoNodeConnections.ts
@@ -16,12 +16,14 @@ export function useVideoNodeConnections(targetId: string) {
     const edges = getEdges();
     const alreadyLinked = edges.some((e) => e.source === sourceNodeId && e.target === targetId);
     // 面板内选取已隐含用户同意且已有 ref 挂载，不重复弹注入确认。
+    // suppressPanelInject：调用侧（useVideoPanelReferences 的 handleSelectNode / applySmartInject）已手动更新 UI，
+    // 跳过 smart-image-inject 等面板事件，避免「UI 写一次 + 事件再写一次」的双添加。
     alreadyLinked || useCanvasStore.getState().connectAndInject({
       source: sourceNodeId,
       sourceHandle: 'right-source',
       target: targetId,
       targetHandle: 'left-target',
-    }, { fromQuickAdd: true, silent: true });
+    }, { fromQuickAdd: true, silent: true, suppressPanelInject: true });
   }, [targetId, getEdges]);
 
   const unlinkNode = useCallback((sourceNodeId: string) => {

--- a/frontend/src/hooks/useVideoPanelReferences.ts
+++ b/frontend/src/hooks/useVideoPanelReferences.ts
@@ -86,17 +86,78 @@ export function useVideoPanelReferences({
   };
   const unlinkAll = useCallback(() => unlinkAllRef.current(), []);
 
-  // ── 模式变更时清空对应字段并解除连线 ──
-  // 智能注入：标记下一次 videoMode 变更 effect 跳过清空副作用
+  // ── 模式变更时按新模式的槽位形态「迁移」已有参考项，而不是清空+解除连线 ──
+  // 设计与图像面板（useImagePanelReferences）保持一致：
+  //   1) 连线（edges）== 节点间的拓扑关系；参考图/参考视频/参考音频 == 当前模式下的 UI 展示。二者解耦。
+  //   2) 切换 videoMode 不应破坏已有连线，也不应无条件清空参考素材。
+  //   3) 收集现有槽位中所有参考项到一个「池」，按目标模式重新布局：
+  //      - text_to_video      —— 无参考槽位，清空 UI（连线保留以便切回时手动重接）
+  //      - image_to_video     —— 池中首张 image → imageUrl；次张 image → lastFrameImageUrl
+  //      - reference_images   —— 池中所有类型按各自上限截断后合并到 referenceImages
+  //      - edit / video_extension —— 池中首个 video → extensionVideoUrl
+  // 智能注入：标记下一次 videoMode 变更 effect 跳过迁移副作用（applySmartInject 自行处理）
   const skipNextClearRef = useRef(false);
+  const prevModeRef = useRef<string>(videoMode);
   useEffect(() => {
     const skip = skipNextClearRef.current;
     skip && (skipNextClearRef.current = false);
-    !skip && unlinkAll();
-    !skip && videoMode === 'text_to_video' && (setImageUrl(''), setLastFrameImageUrl(''), setReferenceImages([]), setExtensionVideoUrl(''));
-    !skip && videoMode === 'image_to_video' && (setReferenceImages([]), setExtensionVideoUrl(''));
-    !skip && videoMode === 'reference_images' && (setImageUrl(''), setLastFrameImageUrl(''), setExtensionVideoUrl(''));
-    !skip && (videoMode === 'edit' || videoMode === 'video_extension') && (setReferenceImages([]), setImageUrl(''), setLastFrameImageUrl(''));
+    const modeChanged = prevModeRef.current !== videoMode;
+    const needMigrate = !skip && modeChanged;
+    type PoolItem = { url: string; sourceNodeId: string | null; name: string; refType: RefType };
+    needMigrate && (() => {
+      // 1) 汇聚现有参考项到池
+      const pool: PoolItem[] = [];
+      imageUrl && pool.push({ url: imageUrl, sourceNodeId: imageNodeIdRef.current, name: '首帧参考', refType: 'image' });
+      lastFrameImageUrl && pool.push({ url: lastFrameImageUrl, sourceNodeId: lastFrameNodeIdRef.current, name: '尾帧参考', refType: 'image' });
+      extensionVideoUrl && pool.push({ url: extensionVideoUrl, sourceNodeId: extensionVideoNodeIdRef.current, name: '延展视频', refType: 'video' });
+      referenceImages.forEach((r) => pool.push({
+        url: r.url,
+        sourceNodeId: r.sourceNodeId ?? null,
+        name: r.name,
+        refType: r.refType,
+      }));
+      // 2) 清 UI 槽位（注意：不调用 unlinkNode —— 连线作为拓扑关系保留）
+      setImageUrl('');
+      setLastFrameImageUrl('');
+      setExtensionVideoUrl('');
+      setReferenceImages([]);
+      imageNodeIdRef.current = null;
+      lastFrameNodeIdRef.current = null;
+      extensionVideoNodeIdRef.current = null;
+      // 3) 按目标模式回填
+      const migrators: Record<string, () => void> = {
+        text_to_video: () => undefined,
+        image_to_video: () => {
+          const imgs = pool.filter((p) => p.refType === 'image');
+          const first = imgs[0];
+          const second = imgs[1];
+          first && (() => { setImageUrl(first.url); imageNodeIdRef.current = first.sourceNodeId; })();
+          second && (() => { setLastFrameImageUrl(second.url); lastFrameNodeIdRef.current = second.sourceNodeId; })();
+        },
+        reference_images: () => {
+          const imgs = pool.filter((p) => p.refType === 'image').slice(0, maxRefImages);
+          const vids = (supportsRefVideos ? pool.filter((p) => p.refType === 'video') : []).slice(0, maxRefVideos);
+          const auds = (supportsRefAudios ? pool.filter((p) => p.refType === 'audio') : []).slice(0, maxRefAudios);
+          const next: RefImage[] = [...imgs, ...vids, ...auds].map((p) => ({
+            url: p.url,
+            name: p.name,
+            refType: p.refType,
+            sourceNodeId: p.sourceNodeId ?? undefined,
+          }));
+          setReferenceImages(next);
+        },
+        edit: () => {
+          const first = pool.find((p) => p.refType === 'video');
+          first && (() => { setExtensionVideoUrl(first.url); extensionVideoNodeIdRef.current = first.sourceNodeId; })();
+        },
+        video_extension: () => {
+          const first = pool.find((p) => p.refType === 'video');
+          first && (() => { setExtensionVideoUrl(first.url); extensionVideoNodeIdRef.current = first.sourceNodeId; })();
+        },
+      };
+      migrators[videoMode]?.();
+    })();
+    prevModeRef.current = videoMode;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [videoMode]);
 

--- a/frontend/src/store/useCanvasStore.ts
+++ b/frontend/src/store/useCanvasStore.ts
@@ -161,11 +161,14 @@ interface CanvasState {
    * @param connection - ReactFlow 连接对象
    * @param options.fromQuickAdd - 来自 QuickAddMenu，已隐含用户同意，跳过确认
    * @param options.silent - 校验失败不弹 Toast（hook 侧批量处理时用）
+   * @param options.suppressPanelInject - 调用方（面板 picker / applySmartInject）已手动更新 UI，
+   *   跳过下游面板注入事件（smart-image-inject / add-reference-* / prompt-prefix）+ pending，
+   *   避免「UI 写一次 → 连线回调 → 面板事件再写一次」的重入双写。dataPatch / warnings 仍照常应用。
    * @returns { ok, reason } 指示是否成功
    */
   connectAndInject: (
     connection: Connection,
-    options?: { fromQuickAdd?: boolean; silent?: boolean },
+    options?: { fromQuickAdd?: boolean; silent?: boolean; suppressPanelInject?: boolean },
   ) => { ok: boolean; reason?: EdgeRejectReason };
   addNode: (node: CanvasNode) => void;
   deleteNode: (id: string) => void;
@@ -340,7 +343,7 @@ export const useCanvasStore = create<CanvasState>()(
         get().connectAndInject(connection);
       },
 
-      connectAndInject: (connection: Connection, options?: { fromQuickAdd?: boolean; silent?: boolean }) => {
+      connectAndInject: (connection: Connection, options?: { fromQuickAdd?: boolean; silent?: boolean; suppressPanelInject?: boolean }) => {
         const { edges, nodes } = get();
         const sourceNode = nodes.find((n) => n.id === connection.source);
         const targetNode = nodes.find((n) => n.id === connection.target);
@@ -395,10 +398,15 @@ export const useCanvasStore = create<CanvasState>()(
           );
         };
         applyPatch(result.dataPatch);
-        (result.panelEvents || []).forEach((e) => {
-          emitPanelInject(targetNode.id, e);
-          // smart-image-inject 额外写入 pending，覆盖订阅时序丢失 + 新节点模型未就绪的场景
+        // 面板内 picker / applySmartInject 触发的连线已在调用侧手动更新过 UI，跳过事件派发避免双写
+        const skipPanelEvents = !!options?.suppressPanelInject;
+        !skipPanelEvents && (result.panelEvents || []).forEach((e) => {
+          // smart-image-inject 先写入 pending、再 emit：
+          // - 已 mount 的面板会在订阅 handler 入口 takePendingSmartInject 消费掉，
+          //   避免 drain effect 因 refs 引用变化而重复触发（否则同一事件会被处理两次）。
+          // - 未 mount（QuickAdd 新节点）时订阅者不会被调用，pending 保留，等面板 mount 后 drain 一次。
           e.type === 'smart-image-inject' && setPendingSmartInject(targetNode.id, e);
+          emitPanelInject(targetNode.id, e);
         });
         (result.warnings || []).forEach((w) => edgeToast.warn(w));
         // storyboard 媒体列也直接 apply，不再二次确认


### PR DESCRIPTION
- 视频面板智能图像注入新增事件消费以避免重复触发
- 调整智能图像注入逻辑以兼容当前模式与已有参考素材，修复模式切换相关bug
- 视频面板参考素材模式变更时迁移已有素材，避免无条件清空和解除连线
- 修改节点ID生成策略，改用裸UUID避免持久化映射导致数据冲突
- 增加connectAndInject接口suppressPanelInject选项，避免UI重复写入和面板事件双重处理
- 移除无用containerRef传递并清理相关引用和代码
- 统一各连接hooks调用connectAndInject时添加suppressPanelInject防止双写
- useVideoPanelReferences内部实现参考素材迁移和mode切换时的副作用管控