### PR TITLE
fix(backend): 删除剧场时解除 chat_sessions 的 theater 关联

### DIFF
--- a/backend/migrations/versions/y5z6a7b8c9d0_chat_sessions_theater_id_set_null.py
+++ b/backend/migrations/versions/y5z6a7b8c9d0_chat_sessions_theater_id_set_null.py
@@ -1,0 +1,47 @@
+"""chat_sessions.theater_id FK ondelete SET NULL
+
+Revision ID: y5z6a7b8c9d0
+Revises: x4y5z6a7b8c9
+Create Date: 2026-05-11 00:00:00.000000
+
+将 chat_sessions.theater_id 的外键约束改为 ON DELETE SET NULL。
+旧约束为默认 NO ACTION/RESTRICT，导致删除 theater 时若存在关联
+的 chat_sessions 记录就会抛出 ForeignKeyViolationError 500。
+
+语义：剧场被删除时，关联会话仅断开 theater 引用，保留会话历史
+便于用户回看；与 ChatSession.theater_id 允许 nullable=True 一致。
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "y5z6a7b8c9d0"
+down_revision = "x4y5z6a7b8c9"
+branch_labels = None
+depends_on = None
+
+
+FK_NAME = "fk_chat_sessions_theater_id"
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("chat_sessions") as batch_op:
+        batch_op.drop_constraint(FK_NAME, type_="foreignkey")
+        batch_op.create_foreign_key(
+            FK_NAME,
+            "theaters",
+            ["theater_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("chat_sessions") as batch_op:
+        batch_op.drop_constraint(FK_NAME, type_="foreignkey")
+        batch_op.create_foreign_key(
+            FK_NAME,
+            "theaters",
+            ["theater_id"],
+            ["id"],
+        )

--- a/backend/models.py
+++ b/backend/models.py
@@ -213,7 +213,7 @@ class ChatSession(Base):
     title = Column(String, default="New Chat")
     agent_id = Column(String(36), ForeignKey("agents.id"))
     user_id = Column(String(36), nullable=True, index=True)  # 可存储用户或管理员 ID
-    theater_id = Column(String(36), ForeignKey("theaters.id"), nullable=True, index=True)  # 关联画布/剧场
+    theater_id = Column(String(36), ForeignKey("theaters.id", ondelete="SET NULL"), nullable=True, index=True)  # 关联画布/剧场；剧场删除时置空保留会话历史
 
     # 上下文使用统计（累计 token 使用量）
     total_tokens_used = Column(BigInteger, default=0)

--- a/backend/services/theater.py
+++ b/backend/services/theater.py
@@ -1,9 +1,9 @@
 import uuid
-from sqlalchemy import select, delete, func
+from sqlalchemy import select, delete, update, func
 from sqlalchemy.ext.asyncio import AsyncSession
 from fastapi import HTTPException
 
-from models import Theater, TheaterNode, TheaterEdge, generate_uuid
+from models import Theater, TheaterNode, TheaterEdge, ChatSession, generate_uuid
 from schemas import (
     TheaterCreate, TheaterUpdate, TheaterSaveRequest,
     TheaterNodeCreate, TheaterEdgeCreate,
@@ -102,6 +102,13 @@ class TheaterService:
 
     async def delete_theater(self, theater_id: str, user_id: str) -> None:
         theater = await self._get_owned_theater(theater_id, user_id)
+        # 解绑关联的 chat_sessions.theater_id：保留会话历史，避免外键约束报 500。
+        # 数据库层还未执行 ondelete=SET NULL 的流通旧环境有此兆长保险。
+        await self.db.execute(
+            update(ChatSession)
+            .where(ChatSession.theater_id == theater_id)
+            .values(theater_id=None)
+        )
         await self.db.delete(theater)
         await self.db.commit()
 

--- a/frontend/src/components/home/TopBar.tsx
+++ b/frontend/src/components/home/TopBar.tsx
@@ -99,10 +99,10 @@ export default function TopBar() {
       {/* Main TopBar */}
       <header className="fixed top-0 left-0 right-0 z-50 bg-background/80 backdrop-blur-xl border-b border-border/50">
         <div className="w-full max-w-[1440px] mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between h-16">
+          <div className="flex items-center justify-between h-16 gap-4">
             
             {/* Left: Logo */}
-            <div className="flex items-center">
+            <div className="flex items-center flex-shrink-0">
               <button 
                 onClick={() => handleNavigate("/")}
                 className="flex items-center gap-2 group"
@@ -114,8 +114,10 @@ export default function TopBar() {
               </button>
             </div>
 
-            {/* Center: Desktop Navigation */}
-            <nav className="hidden md:flex items-center gap-1 absolute left-1/2 -translate-x-1/2">
+            {/* Center: Desktop Navigation
+                采用 flex-1 + justify-center 自然居中，不再用 absolute，避免
+                定位上下文穿透到 fixed header 引发的堂栈与点击遇遮问题。 */}
+            <nav className="hidden md:flex items-center gap-1 flex-1 justify-center">
               {visibleNavLinks.map((link) => {
                 const isActive = pathname === link.href || (link.href !== "/" && pathname?.startsWith(link.href));
                 return (
@@ -123,7 +125,8 @@ export default function TopBar() {
                     key={link.key}
                     onClick={() => handleNavigate(link.href)}
                     className={cn(
-                      "relative px-3 py-1.5 text-sm font-medium rounded-md transition-all duration-200",
+                      // isolate 让按钮自成堆叠上下文，子元素 -z-10 不会穿透到父级
+                      "relative isolate px-3 py-1.5 text-sm font-medium rounded-md transition-all duration-200",
                       isActive 
                         ? "text-foreground" 
                         : "text-muted-foreground hover:text-foreground hover:bg-secondary"
@@ -143,7 +146,7 @@ export default function TopBar() {
             </nav>
 
             {/* Right: Search + User */}
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 flex-shrink-0">
               {/* Search Container */}
               <div className="search-container relative flex items-center">
                 <AnimatePresence mode="wait">


### PR DESCRIPTION
- 修改 chat_sessions.theater_id 外键约束为 ON DELETE SET NULL
- 添加 Alembic 迁移脚本更新外键行为
- 删除剧场时手动将关联会话的 theater_id 置空，避免外键报错
- 保留会话历史，用户可回看已删除剧场关联的会话
- 修复前端 TopBar 导航使用 flex 居中布局，避免定位穿透问题
- 调整前端部分布局样式，增强响应式和交互体验