### PR TITLE
fix(db): 优化 chat_sessions.theater_id 外键兼容性

### DIFF
--- a/backend/migrations/versions/y5z6a7b8c9d0_chat_sessions_theater_id_set_null.py
+++ b/backend/migrations/versions/y5z6a7b8c9d0_chat_sessions_theater_id_set_null.py
@@ -10,8 +10,16 @@ Create Date: 2026-05-11 00:00:00.000000
 
 语义：剧场被删除时，关联会话仅断开 theater 引用，保留会话历史
 便于用户回看；与 ChatSession.theater_id 允许 nullable=True 一致。
+
+兼容性说明：
+- 历史走 alembic 链路建库 → FK 名为 `fk_chat_sessions_theater_id`
+- 走 startup._try_fast_bootstrap → create_all() 建库 → FK 名为
+  PG 默认 `chat_sessions_theater_id_fkey`
+本脚本通过 inspector 按列名反查真实 FK 名，兼容两种历史路径，
+并对「已为 SET NULL」的情况幂等跳过。
 """
 from alembic import op
+from sqlalchemy import inspect
 
 
 # revision identifiers, used by Alembic.
@@ -22,26 +30,62 @@ depends_on = None
 
 
 FK_NAME = "fk_chat_sessions_theater_id"
+TABLE = "chat_sessions"
+COLUMN = "theater_id"
+
+
+def _find_theater_fk(bind) -> dict | None:
+    """按列名反查 chat_sessions.theater_id 的外键元信息；找不到返回 None。"""
+    insp = inspect(bind)
+    return next(
+        (
+            fk
+            for fk in insp.get_foreign_keys(TABLE)
+            if COLUMN in (fk.get("constrained_columns") or [])
+        ),
+        None,
+    )
+
+
+def _fk_ondelete(fk: dict | None) -> str:
+    return ((fk or {}).get("options") or {}).get("ondelete", "").upper()
 
 
 def upgrade() -> None:
-    with op.batch_alter_table("chat_sessions") as batch_op:
-        batch_op.drop_constraint(FK_NAME, type_="foreignkey")
+    bind = op.get_bind()
+    fk = _find_theater_fk(bind)
+
+    # 幂等：create_all 路径下建出来就是 SET NULL，直接跳过
+    already_set_null = _fk_ondelete(fk) == "SET NULL"
+    actions = {
+        True: lambda: None,
+        False: lambda: _rebuild_fk(fk),
+    }
+    actions[already_set_null]()
+
+
+def _rebuild_fk(fk: dict | None) -> None:
+    existing_name = (fk or {}).get("name") or FK_NAME
+    with op.batch_alter_table(TABLE) as batch_op:
+        batch_op.drop_constraint(existing_name, type_="foreignkey")
         batch_op.create_foreign_key(
             FK_NAME,
             "theaters",
-            ["theater_id"],
+            [COLUMN],
             ["id"],
             ondelete="SET NULL",
         )
 
 
 def downgrade() -> None:
-    with op.batch_alter_table("chat_sessions") as batch_op:
-        batch_op.drop_constraint(FK_NAME, type_="foreignkey")
+    bind = op.get_bind()
+    fk = _find_theater_fk(bind)
+    existing_name = (fk or {}).get("name") or FK_NAME
+    with op.batch_alter_table(TABLE) as batch_op:
+        batch_op.drop_constraint(existing_name, type_="foreignkey")
         batch_op.create_foreign_key(
             FK_NAME,
             "theaters",
-            ["theater_id"],
+            [COLUMN],
             ["id"],
         )


### PR DESCRIPTION
- 按列名动态查找外键约束名称，兼容两种建库历史路径
- 添加幂等逻辑，避免重复设置 ON DELETE SET NULL 导致错误
- 修正升级脚本，确保仅在非 SET NULL 状态下变更约束
- 保留降级脚本以恢复默认外键行为
- 增强注释，说明兼容性设计和实现细节