### PR TITLE
chore(docker): 优化镜像构建流程，移除镜像内包升级命令

### DIFF
--- a/deploy/admin.Dockerfile
+++ b/deploy/admin.Dockerfile
@@ -9,9 +9,9 @@
 # 使用 node:22-alpine（当前 Active LTS）以规避 node:20-alpine 镜像层的已知 CVE
 FROM node:26-alpine AS deps
 WORKDIR /app
-# 主动升级 alpine 包以吸纳上游已发布的安全补丁
-RUN apk upgrade --no-cache \
-    && apk add --no-cache libc6-compat
+# 不在镜像内跑 apk upgrade：CVE 修复交由上游 node:26-alpine 镜像定期 bump tag 处理，
+# 避免不可重复构建与额外跨网依赖
+RUN apk add --no-cache libc6-compat
 # npm 镜像源（国内服务器默认用 npmmirror，外网环境可 --build-arg NPM_REGISTRY=https://registry.npmjs.org 覆盖）
 ARG NPM_REGISTRY=https://registry.npmmirror.com
 RUN npm config set registry ${NPM_REGISTRY} \
@@ -39,8 +39,7 @@ ENV NODE_ENV=production \
     PORT=3888 \
     HOSTNAME=0.0.0.0
 
-# 运行阶段同样主动升级系统包，消除基础镜像 CVE
-RUN apk upgrade --no-cache
+# 运行阶段不跑 apk upgrade：CVE 交由上游 base 镜像 bump tag 统一处理
 
 RUN addgroup --system --gid 1001 nodejs \
     && adduser --system --uid 1001 nextjs

--- a/deploy/backend.Dockerfile
+++ b/deploy/backend.Dockerfile
@@ -14,22 +14,24 @@ ENV PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     TZ=Asia/Shanghai
 
-# Debian 镜像源（国内服务器默认用清华，外网环境可通过 --build-arg DEBIAN_MIRROR= 清空覆盖）
-ARG DEBIAN_MIRROR=mirrors.tuna.tsinghua.edu.cn
+# Debian 镜像源（主：阿里云；外网环境可通过 --build-arg DEBIAN_MIRROR= 清空覆盖）
+# 原主源清华 TUNA 在部分国内云服务器上 80 端口存在跨网连接超时（IP 101.6.15.130），
+# 改用阿里云后稳定性明显提升
+ARG DEBIAN_MIRROR=mirrors.aliyun.com
 RUN if [ -n "$DEBIAN_MIRROR" ]; then \
       sed -i "s@deb.debian.org@${DEBIAN_MIRROR}@g; s@security.debian.org@${DEBIAN_MIRROR}@g" /etc/apt/sources.list.d/debian.sources 2>/dev/null || true; \
     fi
 
 # 系统依赖：libpq-dev 供 psycopg2 编译；build-essential 为可选 C 扩展兜底
-# 同步执行 apt-get upgrade 拉取上游已发布的安全补丁，降低基础镜像 CVE 告警
-RUN apt-get update \
-    && apt-get -y upgrade \
+# 说明：不在镜像内跑 apt-get upgrade。CVE 修复交由上游 python:3.14-slim-bookworm
+# 镜像定期 bump tag 处理，避免不可重复构建与额外跨网依赖
+# -o Acquire::Retries=3 限制单次重试次数，-o Acquire::http::Timeout=20 避免单包超时叠加
+RUN apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=20 \
     && apt-get install -y --no-install-recommends \
         build-essential \
         libpq-dev \
         curl \
         tini \
-    && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/deploy/frontend.Dockerfile
+++ b/deploy/frontend.Dockerfile
@@ -9,9 +9,9 @@
 # 使用 node:22-alpine（当前 Active LTS）以规避 node:20-alpine 镜像层的已知 CVE
 FROM node:26-alpine AS deps
 WORKDIR /app
-# 主动升级 alpine 包以吸纳上游已发布的安全补丁
-RUN apk upgrade --no-cache \
-    && apk add --no-cache libc6-compat
+# 不在镜像内跑 apk upgrade：CVE 修复交由上游 node:26-alpine 镜像定期 bump tag 处理，
+# 避免不可重复构建与额外跨网依赖
+RUN apk add --no-cache libc6-compat
 # npm 镜像源（国内服务器默认用 npmmirror，外网环境可 --build-arg NPM_REGISTRY=https://registry.npmjs.org 覆盖）
 ARG NPM_REGISTRY=https://registry.npmmirror.com
 RUN npm config set registry ${NPM_REGISTRY} \
@@ -39,8 +39,7 @@ ENV NODE_ENV=production \
     PORT=3666 \
     HOSTNAME=0.0.0.0
 
-# 运行阶段同样主动升级系统包，消除基础镜像 CVE
-RUN apk upgrade --no-cache
+# 运行阶段不跑 apk upgrade：CVE 交由上游 base 镜像 bump tag 统一处理
 
 # 非 root 运行
 RUN addgroup --system --gid 1001 nodejs \


### PR DESCRIPTION
- 移除 admin、frontend 镜像中 apk upgrade 命令，避免不可重复构建和跨网依赖
- backend 镜像取消 apt-get upgrade，改为依赖上游镜像定期安全更新
- 后台脚本调整 Debian 镜像源为阿里云，提高国内构建的网络稳定性
- 保留必要依赖安装，清理缓存降低镜像体积
- 运行阶段不再主动升级系统包，转由基础镜像统一处理 CVE 修复