### PR TITLE
chore(build): 添加 lightningcss 可选依赖并更新 Docker 构建命令

### DIFF
--- a/backend/admin/package-lock.json
+++ b/backend/admin/package-lock.json
@@ -72,6 +72,12 @@
         "tailwindcss": "^4.2.0",
         "typescript": "^5.9.3",
         "vitest": "^4.1.5"
+      },
+      "optionalDependencies": {
+        "lightningcss-linux-arm64-gnu": "^1.30.1",
+        "lightningcss-linux-arm64-musl": "^1.30.1",
+        "lightningcss-linux-x64-gnu": "^1.30.1",
+        "lightningcss-linux-x64-musl": "^1.30.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -8169,7 +8175,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8190,7 +8195,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8211,7 +8215,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8232,7 +8235,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/backend/admin/package.json
+++ b/backend/admin/package.json
@@ -85,5 +85,11 @@
     "axios": "^1.16.0",
     "lodash": "^4.18.1",
     "prismjs": "^1.30.0"
+  },
+  "optionalDependencies": {
+    "lightningcss-linux-x64-musl": "^1.30.1",
+    "lightningcss-linux-x64-gnu": "^1.30.1",
+    "lightningcss-linux-arm64-musl": "^1.30.1",
+    "lightningcss-linux-arm64-gnu": "^1.30.1"
   }
 }

--- a/deploy/admin.Dockerfile
+++ b/deploy/admin.Dockerfile
@@ -19,7 +19,8 @@ RUN npm config set registry ${NPM_REGISTRY} \
     && npm config set fetch-retry-mintimeout 20000 \
     && npm config set fetch-retry-maxtimeout 120000
 COPY backend/admin/package.json backend/admin/package-lock.json ./
-RUN npm ci --no-audit --no-fund --legacy-peer-deps
+# --include=optional 显式保证 lightningcss 等平台依赖的 native .node 被安装
+RUN npm ci --no-audit --no-fund --legacy-peer-deps --include=optional
 
 # ---------- Stage 2: 构建 ----------
 FROM node:26-alpine AS build

--- a/deploy/frontend.Dockerfile
+++ b/deploy/frontend.Dockerfile
@@ -19,7 +19,8 @@ RUN npm config set registry ${NPM_REGISTRY} \
     && npm config set fetch-retry-mintimeout 20000 \
     && npm config set fetch-retry-maxtimeout 120000
 COPY frontend/package.json frontend/package-lock.json ./
-RUN npm ci --no-audit --no-fund --legacy-peer-deps
+# --include=optional 显式保证 lightningcss 等平台依赖的 native .node 被安装
+RUN npm ci --no-audit --no-fund --legacy-peer-deps --include=optional
 
 # ---------- Stage 2: 构建 ----------
 FROM node:26-alpine AS build

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -102,6 +102,12 @@
         "tailwindcss": "^4",
         "ts-jest": "^29.4.6",
         "typescript": "^6"
+      },
+      "optionalDependencies": {
+        "lightningcss-linux-arm64-gnu": "^1.30.1",
+        "lightningcss-linux-arm64-musl": "^1.30.1",
+        "lightningcss-linux-x64-gnu": "^1.30.1",
+        "lightningcss-linux-x64-musl": "^1.30.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2438,6 +2444,7 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmmirror.com/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2477,6 +2484,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2497,6 +2505,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2517,6 +2526,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2537,6 +2547,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2557,6 +2568,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2577,6 +2589,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2597,6 +2610,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2617,6 +2631,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2637,6 +2652,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2657,6 +2673,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2677,6 +2694,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2697,6 +2715,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2717,6 +2736,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6178,6 +6198,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmmirror.com/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -7177,7 +7198,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmmirror.com/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -45910,7 +45931,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmmirror.com/immutable/-/immutable-5.1.5.tgz",
       "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -46049,7 +46070,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmmirror.com/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -46079,7 +46100,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmmirror.com/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -47508,7 +47529,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -47529,7 +47549,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -47550,7 +47569,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -47571,7 +47589,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -48975,6 +48992,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmmirror.com/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -49261,7 +49279,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -49919,7 +49937,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmmirror.com/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -50178,7 +50196,7 @@
       "version": "1.98.0",
       "resolved": "https://registry.npmmirror.com/sass/-/sass-1.98.0.tgz",
       "integrity": "sha512-+4N/u9dZ4PrgzGgPlKnaaRQx64RO0JBKs9sDhQ2pLgN6JQZ25uPQZKQYaBJU48Kd5BxgXoJ4e09Dq7nMcOUW3A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",
@@ -50668,6 +50686,7 @@
     },
     "node_modules/tailwindcss": {
       "version": "4.1.18",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
@@ -50951,7 +50970,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -119,5 +119,11 @@
     "prismjs": "^1.30.0",
     "react": "19.2.3",
     "react-dom": "19.2.3"
+  },
+  "optionalDependencies": {
+    "lightningcss-linux-x64-musl": "^1.30.1",
+    "lightningcss-linux-x64-gnu": "^1.30.1",
+    "lightningcss-linux-arm64-musl": "^1.30.1",
+    "lightningcss-linux-arm64-gnu": "^1.30.1"
   }
 }


### PR DESCRIPTION
- 在 backend/admin 和 frontend 的 package.json 中增加 lightningcss 各平台的 optionalDependencies
- 更新 package-lock.json 中相关依赖，移除 dev 标记，保证 optional 依赖正确处理
- 修改后端和前端 Dockerfile 中 npm ci 命令，显式加入 --include=optional 参数
- 确保 lightningcss 的 native .node 模块能够在构建时被正确安装和包含
- 提升跨平台构建的一致性和兼容性，解决可能的环境依赖缺失问题