### PR TITLE
refactor(admin): 优化用户删除时的级联清理逻辑

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -5,7 +5,22 @@ from sqlalchemy import func, delete
 from typing import List, Dict, Any, Optional
 
 from database import get_db
-from models import User, LLMProvider, Asset, Admin, CreditTransaction, SubscriptionPlan, ChatSession, Theater, generate_uuid
+from models import (
+    User,
+    LLMProvider,
+    Asset,
+    Admin,
+    CreditTransaction,
+    SubscriptionPlan,
+    ChatSession,
+    ChatMessage,
+    Theater,
+    TaskExecution,
+    SubTask,
+    VideoTask,
+    MusicTask,
+    generate_uuid,
+)
 from auth import require_admin, hash_password
 from schemas import (
     CreditAdjustRequest,
@@ -201,10 +216,33 @@ async def delete_user(
         raise HTTPException(status_code=404, detail="User not found")
 
     user_email = user.email
-    # 级联删除关联数据
-    await db.execute(delete(CreditTransaction).where(CreditTransaction.user_id == user_id))
+
+    # 级联删除关联数据：按外键依赖深度从子到父依次清理，规避 PG 外键约束报 500
+    session_ids_subq = select(ChatSession.id).where(ChatSession.user_id == user_id)
+    task_exec_ids_subq = select(TaskExecution.id).where(TaskExecution.user_id == user_id)
+
+    # 1) 任务执行的子任务（subtasks -> task_executions）
+    await db.execute(delete(SubTask).where(SubTask.task_execution_id.in_(task_exec_ids_subq)))
+    # 2) 视频/音乐任务（依赖 chat_sessions、chat_messages）
+    await db.execute(delete(VideoTask).where(VideoTask.session_id.in_(session_ids_subq)))
+    await db.execute(delete(MusicTask).where(MusicTask.session_id.in_(session_ids_subq)))
+    # 3) 任务执行（依赖 chat_sessions、users，不能晚于 chat_sessions/users）
+    await db.execute(delete(TaskExecution).where(TaskExecution.user_id == user_id))
+    # 4) 聊天消息（依赖 chat_sessions，FK 无 cascade，必须显式删除）
+    await db.execute(delete(ChatMessage).where(ChatMessage.session_id.in_(session_ids_subq)))
+    # 5) 积分交易（同时引用 users 与 chat_sessions，需先于二者删除）
+    await db.execute(
+        delete(CreditTransaction).where(
+            (CreditTransaction.user_id == user_id)
+            | (CreditTransaction.session_id.in_(session_ids_subq))
+        )
+    )
+    # 6) 聊天会话
     await db.execute(delete(ChatSession).where(ChatSession.user_id == user_id))
+    # 7) 剧场（theater_nodes/theater_edges 已在 FK 层 ON DELETE CASCADE）
     await db.execute(delete(Theater).where(Theater.user_id == user_id))
+    # 8) 资源文件（assets）
+    await db.execute(delete(Asset).where(Asset.user_id == user_id))
 
     await db.delete(user)
     await db.commit()

--- a/backend/routers/agents.py
+++ b/backend/routers/agents.py
@@ -1,9 +1,23 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.future import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import delete, update
 from typing import List, Optional
 from database import get_db
-from models import Agent, LLMProvider, Admin
+from models import (
+    Agent,
+    LLMProvider,
+    Admin,
+    ChatSession,
+    TheaterNode,
+    CreditTransaction,
+    PromptTemplate,
+    ToolExecution,
+    TaskExecution,
+    SubTask,
+    AdminDebugSession,
+    AdminDebugMessage,
+)
 from schemas import AgentCreate, AgentUpdate, AgentResponse
 from auth import get_current_active_user_or_admin, require_admin
 
@@ -141,10 +155,42 @@ async def delete_agent(agent_id: str, _admin: Admin = Depends(require_admin), db
     agent = result.scalars().first()
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
-    
+
     # Log deletion (In a real app, this might go to a dedicated audit log table)
     print(f"AUDIT: Agent {agent.name} (ID: {agent.id}) deleted.")
-    
+
+    # 外键依赖清理：优先 SET NULL 保留历史，NOT NULL 外键才走级联删除
+    # 1) 可空外键——解绑使业务历史保留
+    await db.execute(
+        update(ChatSession).where(ChatSession.agent_id == agent_id).values(agent_id=None)
+    )
+    await db.execute(
+        update(TheaterNode).where(TheaterNode.created_by_agent_id == agent_id).values(created_by_agent_id=None)
+    )
+    await db.execute(
+        update(CreditTransaction).where(CreditTransaction.agent_id == agent_id).values(agent_id=None)
+    )
+    await db.execute(
+        update(PromptTemplate).where(PromptTemplate.default_agent_id == agent_id).values(default_agent_id=None)
+    )
+    await db.execute(
+        update(ToolExecution).where(ToolExecution.agent_id == agent_id).values(agent_id=None)
+    )
+
+    # 2) NOT NULL 外键——级联删除依赖记录
+    # 2a) admin_debug_sessions 及其消息
+    debug_session_ids = select(AdminDebugSession.id).where(AdminDebugSession.agent_id == agent_id)
+    await db.execute(delete(AdminDebugMessage).where(AdminDebugMessage.session_id.in_(debug_session_ids)))
+    await db.execute(delete(AdminDebugSession).where(AdminDebugSession.agent_id == agent_id))
+
+    # 2b) task_executions(leader=agent) 及其 subtasks
+    leader_task_ids = select(TaskExecution.id).where(TaskExecution.leader_agent_id == agent_id)
+    await db.execute(delete(SubTask).where(SubTask.task_execution_id.in_(leader_task_ids)))
+    await db.execute(delete(TaskExecution).where(TaskExecution.leader_agent_id == agent_id))
+
+    # 2c) subtasks 中直接指向该 agent 的子任务
+    await db.execute(delete(SubTask).where(SubTask.agent_id == agent_id))
+
     await db.delete(agent)
     await db.commit()
     return {"message": "Agent deleted successfully"}

--- a/backend/routers/llm_config.py
+++ b/backend/routers/llm_config.py
@@ -1,11 +1,12 @@
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
+from sqlalchemy import func, update
 from typing import List
 import httpx
 
 from database import get_db
-from models import LLMProvider, Admin
+from models import LLMProvider, Admin, Agent, VideoTask, MusicTask
 from schemas import LLMProviderCreate, LLMProviderUpdate, LLMProviderResponse, TestConnectionRequest
 from auth import require_admin
 from agents import narrative_engine
@@ -245,8 +246,28 @@ async def delete_llm_provider(
     provider = result.scalars().first()
     if provider is None:
         raise HTTPException(status_code=404, detail="Provider not found")
-        
+
+    # 拒绝删除：仍有智能体依赖该供应商（避免静默丢失 LLM 路由信息）
+    agent_ref = await db.execute(
+        select(func.count(Agent.id)).where(Agent.provider_id == provider_id)
+    )
+    agent_count = int(agent_ref.scalar() or 0)
+    if agent_count > 0:
+        raise HTTPException(
+            status_code=409,
+            detail=f"该供应商仍被 {agent_count} 个智能体使用，请先删除或修改关联智能体",
+        )
+
     snapshot = {"name": provider.name, "provider_type": provider.provider_type, "model": provider.model}
+
+    # 历史任务记录中的 provider_id 采取 SET NULL，保留任务记录
+    await db.execute(
+        update(VideoTask).where(VideoTask.provider_id == provider_id).values(provider_id=None)
+    )
+    await db.execute(
+        update(MusicTask).where(MusicTask.provider_id == provider_id).values(provider_id=None)
+    )
+
     await db.delete(provider)
     await db.commit()
     await publish_invalidate("provider", provider_id)


### PR DESCRIPTION
- 按外键依赖深度顺序删除相关子数据，避免外键约束错误
- 增加对任务执行子任务、视频任务、音乐任务、聊天消息等的级联删除
- 明确聊天会话、剧场、资源文件等删除顺序及范围
- 确保删除操作事务一致性，防止孤立数据残留

refactor(agents): 完善智能体删除的关联数据解绑及级联删除

- 将可空外键置空保留业务历史数据
- 级联删除 NOT NULL 外键关联的调试会话及消息
- 级联删除由智能体领导的任务执行及其子任务
- 删除直接指向该智能体的子任务
- 添加删除日志，便于审计追踪

refactor(llm_config): 加强 LLM 提供商删除时的依赖校验与数据清理

- 删除前检查是否有智能体依赖，防止误删引发服务异常
- 拒绝删除存在依赖的提供商并返回合适错误提示
- 对历史任务中引用的提供商字段执行 SET NULL 保留记录
- 保持任务数据完整性与历史可追溯性