### PR TITLE
refactor(database): 统一外键删除策略并简化关联删除逻辑

### DIFF
--- a/backend/migrations/versions/b8c9d0e1f2a3_unify_fk_ondelete_policies.py
+++ b/backend/migrations/versions/b8c9d0e1f2a3_unify_fk_ondelete_policies.py
@@ -1,0 +1,154 @@
+"""unify FK ondelete policies (CASCADE / SET NULL)
+
+Revision ID: b8c9d0e1f2a3
+Revises: a7b8c9d0e1f2
+Create Date: 2026-05-13 00:00:00.000000
+
+统一全表外键的 ON DELETE 策略，根治删除父记录时频繁触发的
+ForeignKeyViolationError 500 问题。
+
+策略原则：
+- 父记录被删除后子表仍有保留意义（历史/审计/配置）→ SET NULL
+- 子表无父就失去意义（消息属于会话/子任务属于任务等）→ CASCADE
+
+兼容性：
+- 旧库走 alembic 链路 → FK 名 fk_<table>_<column>
+- 新库走 startup._try_fast_bootstrap (create_all) → FK 名
+  PG 默认 <table>_<column>_fkey
+本脚本通过 inspector 按列名反查真实 FK 名，幂等：当前 ondelete
+已与目标一致则跳过。
+"""
+from alembic import op
+from sqlalchemy import inspect
+
+
+# revision identifiers, used by Alembic.
+revision = "b8c9d0e1f2a3"
+down_revision = "a7b8c9d0e1f2"
+branch_labels = None
+depends_on = None
+
+
+# (table, column, referred_table, referred_column, ondelete)
+FK_POLICIES: list[tuple[str, str, str, str, str]] = [
+    # users 子表
+    ("theaters", "user_id", "users", "id", "CASCADE"),
+    ("assets", "user_id", "users", "id", "CASCADE"),
+    ("credit_transactions", "user_id", "users", "id", "SET NULL"),
+    ("task_executions", "user_id", "users", "id", "CASCADE"),
+    # subscription_plans
+    ("users", "subscription_plan_id", "subscription_plans", "id", "SET NULL"),
+    # theaters 子表（拓扑结构强一致：剧场删除则节点/连线一并清理）
+    ("theater_nodes", "theater_id", "theaters", "id", "CASCADE"),
+    ("theater_edges", "theater_id", "theaters", "id", "CASCADE"),
+    ("chat_sessions", "theater_id", "theaters", "id", "SET NULL"),
+    # theater_nodes 子表
+    ("theater_edges", "source_node_id", "theater_nodes", "id", "CASCADE"),
+    ("theater_edges", "target_node_id", "theater_nodes", "id", "CASCADE"),
+    # chat_sessions 子表
+    ("chat_messages", "session_id", "chat_sessions", "id", "CASCADE"),
+    ("credit_transactions", "session_id", "chat_sessions", "id", "SET NULL"),
+    ("task_executions", "session_id", "chat_sessions", "id", "SET NULL"),
+    ("video_tasks", "session_id", "chat_sessions", "id", "SET NULL"),
+    ("music_tasks", "session_id", "chat_sessions", "id", "SET NULL"),
+    # chat_messages 子表
+    ("video_tasks", "message_id", "chat_messages", "id", "SET NULL"),
+    # llm_providers 子表
+    ("agents", "provider_id", "llm_providers", "id", "SET NULL"),
+    ("video_tasks", "provider_id", "llm_providers", "id", "SET NULL"),
+    ("music_tasks", "provider_id", "llm_providers", "id", "SET NULL"),
+    # agents 子表
+    ("theater_nodes", "created_by_agent_id", "agents", "id", "SET NULL"),
+    ("chat_sessions", "agent_id", "agents", "id", "SET NULL"),
+    ("credit_transactions", "agent_id", "agents", "id", "SET NULL"),
+    ("task_executions", "leader_agent_id", "agents", "id", "CASCADE"),
+    ("subtasks", "agent_id", "agents", "id", "CASCADE"),
+    ("prompt_templates", "default_agent_id", "agents", "id", "SET NULL"),
+    ("admin_debug_sessions", "agent_id", "agents", "id", "CASCADE"),
+    ("tool_executions", "agent_id", "agents", "id", "SET NULL"),
+    # task_executions / subtasks
+    ("subtasks", "task_execution_id", "task_executions", "id", "CASCADE"),
+    ("subtasks", "parent_subtask_id", "subtasks", "id", "SET NULL"),
+    # admin_debug_sessions 子表
+    ("admin_debug_messages", "session_id", "admin_debug_sessions", "id", "CASCADE"),
+    # admins 子表
+    ("credit_transactions", "admin_id", "admins", "id", "SET NULL"),
+    ("admin_debug_sessions", "admin_id", "admins", "id", "CASCADE"),
+]
+
+
+def _find_fk(insp, table: str, column: str) -> dict | None:
+    """按列名反查指定表的外键元信息；找不到返回 None。"""
+    return next(
+        (
+            fk
+            for fk in insp.get_foreign_keys(table)
+            if column in (fk.get("constrained_columns") or [])
+        ),
+        None,
+    )
+
+
+def _ondelete(fk: dict | None) -> str:
+    return ((fk or {}).get("options") or {}).get("ondelete", "").upper()
+
+
+def _apply(table: str, column: str, ref_table: str, ref_col: str, ondelete: str) -> None:
+    bind = op.get_bind()
+    insp = inspect(bind)
+    # 表不存在直接跳过（兼容部分模块在历史分支被裁剪的情况）
+    if not insp.has_table(table):
+        return
+
+    fk = _find_fk(insp, table, column)
+    # 幂等：已是目标策略则跳过
+    if _ondelete(fk) == ondelete.upper():
+        return
+
+    desired_name = f"fk_{table}_{column}"
+    existing_name = (fk or {}).get("name") or desired_name
+    drop_dispatch = {
+        True: lambda b: b.drop_constraint(existing_name, type_="foreignkey"),
+        False: lambda b: None,
+    }
+    with op.batch_alter_table(table) as batch_op:
+        drop_dispatch[fk is not None](batch_op)
+        batch_op.create_foreign_key(
+            desired_name,
+            ref_table,
+            [column],
+            [ref_col],
+            ondelete=ondelete,
+        )
+
+
+def _revert(table: str, column: str, ref_table: str, ref_col: str) -> None:
+    bind = op.get_bind()
+    insp = inspect(bind)
+    if not insp.has_table(table):
+        return
+    fk = _find_fk(insp, table, column)
+    desired_name = f"fk_{table}_{column}"
+    existing_name = (fk or {}).get("name") or desired_name
+    drop_dispatch = {
+        True: lambda b: b.drop_constraint(existing_name, type_="foreignkey"),
+        False: lambda b: None,
+    }
+    with op.batch_alter_table(table) as batch_op:
+        drop_dispatch[fk is not None](batch_op)
+        batch_op.create_foreign_key(
+            desired_name,
+            ref_table,
+            [column],
+            [ref_col],
+        )
+
+
+def upgrade() -> None:
+    for table, column, ref_table, ref_col, ondelete in FK_POLICIES:
+        _apply(table, column, ref_table, ref_col, ondelete)
+
+
+def downgrade() -> None:
+    for table, column, ref_table, ref_col, _ondelete in FK_POLICIES:
+        _revert(table, column, ref_table, ref_col)

--- a/backend/models.py
+++ b/backend/models.py
@@ -53,7 +53,7 @@ class User(Base):
     is_balance_frozen = Column(Boolean, default=False)  # 资金冻结状态
 
     # Subscription (订阅系统)
-    subscription_plan_id = Column(String(36), ForeignKey("subscription_plans.id"), nullable=True)
+    subscription_plan_id = Column(String(36), ForeignKey("subscription_plans.id", ondelete="SET NULL"), nullable=True)
     subscription_status = Column(String(20), default="inactive")  # inactive | active | expired
     subscription_start_at = Column(DateTime(timezone=True), nullable=True)
     subscription_end_at = Column(DateTime(timezone=True), nullable=True)
@@ -102,7 +102,7 @@ class Theater(Base):
     )
 
     id = Column(String(36), primary_key=True, default=generate_uuid, index=True)
-    user_id = Column(String(36), ForeignKey("users.id"), nullable=False, index=True)
+    user_id = Column(String(36), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
     title = Column(String(200), nullable=False, default="未命名剧场")
     description = Column(Text, nullable=True)
     thumbnail_url = Column(String, nullable=True)
@@ -134,7 +134,7 @@ class TheaterNode(Base):
     data = Column(JSON, default=dict)  # 节点业务数据（title, content, imageUrl 等）
 
     # 创建此节点的 Agent（可选）
-    created_by_agent_id = Column(String(36), ForeignKey("agents.id"), nullable=True)
+    created_by_agent_id = Column(String(36), ForeignKey("agents.id", ondelete="SET NULL"), nullable=True)
 
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
@@ -166,7 +166,7 @@ class Asset(Base):
     )
 
     id = Column(String(36), primary_key=True, default=generate_uuid, index=True)
-    user_id = Column(String(36), ForeignKey("users.id"), nullable=False, index=True)
+    user_id = Column(String(36), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
     filename = Column(String(255), nullable=False)        # UUID 文件名 (xxx.png)
     original_name = Column(String(255), nullable=True)     # 用户原始文件名
     file_path = Column(String(500), nullable=False)        # 存储路径 (同 filename)
@@ -216,7 +216,7 @@ class ChatSession(Base):
 
     id = Column(String(36), primary_key=True, default=generate_uuid, index=True)
     title = Column(String, default="New Chat")
-    agent_id = Column(String(36), ForeignKey("agents.id"))
+    agent_id = Column(String(36), ForeignKey("agents.id", ondelete="SET NULL"), nullable=True)
     user_id = Column(String(36), nullable=True, index=True)  # 可存储用户或管理员 ID
     theater_id = Column(String(36), ForeignKey("theaters.id", ondelete="SET NULL"), nullable=True, index=True)  # 关联画布/剧场；剧场删除时置空保留会话历史
 
@@ -239,7 +239,7 @@ class ChatMessage(Base):
     )
 
     id = Column(String(36), primary_key=True, default=generate_uuid, index=True)
-    session_id = Column(String(36), ForeignKey("chat_sessions.id"), index=True)
+    session_id = Column(String(36), ForeignKey("chat_sessions.id", ondelete="CASCADE"), index=True)
     role = Column(String)  # user, assistant, system
     content = Column(Text)
 
@@ -254,7 +254,7 @@ class Agent(Base):
     description = Column(String(500))
 
     # Provider Association
-    provider_id = Column(String(36), ForeignKey("llm_providers.id"))
+    provider_id = Column(String(36), ForeignKey("llm_providers.id", ondelete="SET NULL"), nullable=True)
     model = Column(String)  # The specific model name under the provider
 
     # Agent Type: text | image | multimodal | video
@@ -328,10 +328,10 @@ class CreditTransaction(Base):
     )
 
     id = Column(String(36), primary_key=True, default=generate_uuid)
-    user_id = Column(String(36), ForeignKey("users.id"), nullable=True, index=True)
-    admin_id = Column(String(36), ForeignKey("admins.id"), nullable=True, index=True)
-    agent_id = Column(String(36), ForeignKey("agents.id"), nullable=True)
-    session_id = Column(String(36), ForeignKey("chat_sessions.id"), nullable=True)
+    user_id = Column(String(36), ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True)
+    admin_id = Column(String(36), ForeignKey("admins.id", ondelete="SET NULL"), nullable=True, index=True)
+    agent_id = Column(String(36), ForeignKey("agents.id", ondelete="SET NULL"), nullable=True)
+    session_id = Column(String(36), ForeignKey("chat_sessions.id", ondelete="SET NULL"), nullable=True)
 
     transaction_type = Column(String(20), nullable=False)  # deduction | recharge | admin_adjust | refund
     amount = Column(Numeric(18, 4), nullable=False)          # 负数=扣费, 正数=充值
@@ -355,9 +355,9 @@ class TaskExecution(Base):
     )
 
     id = Column(String(36), primary_key=True, default=generate_uuid, index=True)
-    leader_agent_id = Column(String(36), ForeignKey("agents.id"), nullable=False)
-    user_id = Column(String(36), ForeignKey("users.id"), nullable=False, index=True)
-    session_id = Column(String(36), ForeignKey("chat_sessions.id"), nullable=True)
+    leader_agent_id = Column(String(36), ForeignKey("agents.id", ondelete="CASCADE"), nullable=False)
+    user_id = Column(String(36), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    session_id = Column(String(36), ForeignKey("chat_sessions.id", ondelete="SET NULL"), nullable=True)
 
     task_description = Column(Text, nullable=False)
     coordination_mode = Column(String(20))  # auto, pipeline, plan, discussion
@@ -378,9 +378,9 @@ class SubTask(Base):
     __tablename__ = "subtasks"
 
     id = Column(String(36), primary_key=True, default=generate_uuid, index=True)
-    task_execution_id = Column(String(36), ForeignKey("task_executions.id"), nullable=False, index=True)
-    agent_id = Column(String(36), ForeignKey("agents.id"), nullable=False)
-    parent_subtask_id = Column(String(36), ForeignKey("subtasks.id"), nullable=True)
+    task_execution_id = Column(String(36), ForeignKey("task_executions.id", ondelete="CASCADE"), nullable=False, index=True)
+    agent_id = Column(String(36), ForeignKey("agents.id", ondelete="CASCADE"), nullable=False)
+    parent_subtask_id = Column(String(36), ForeignKey("subtasks.id", ondelete="SET NULL"), nullable=True)
 
     description = Column(Text, nullable=False)
     order_index = Column(Integer, default=0)
@@ -427,7 +427,7 @@ class PromptTemplate(Base):
     variables_schema = Column(JSON, default=list)
     
     # 关联的智能体（可选，指定默认使用哪个智能体）
-    default_agent_id = Column(String(36), ForeignKey("agents.id"), nullable=True)
+    default_agent_id = Column(String(36), ForeignKey("agents.id", ondelete="SET NULL"), nullable=True)
     
     is_active = Column(Boolean, default=True)
     is_default = Column(Boolean, default=False)  # 是否为该类型的默认模板
@@ -475,9 +475,9 @@ class VideoTask(Base):
 
     id = Column(String(36), primary_key=True, default=generate_uuid, index=True)
     xai_task_id = Column(String(255), index=True)           # xAI 返回的外部任务ID
-    session_id = Column(String(36), ForeignKey("chat_sessions.id"), nullable=True)
-    message_id = Column(String(36), ForeignKey("chat_messages.id"), nullable=True)
-    provider_id = Column(String(36), ForeignKey("llm_providers.id"))
+    session_id = Column(String(36), ForeignKey("chat_sessions.id", ondelete="SET NULL"), nullable=True)
+    message_id = Column(String(36), ForeignKey("chat_messages.id", ondelete="SET NULL"), nullable=True)
+    provider_id = Column(String(36), ForeignKey("llm_providers.id", ondelete="SET NULL"), nullable=True)
     model = Column(String, nullable=True)
     user_id = Column(String(36), index=True)
 
@@ -510,8 +510,8 @@ class MusicTask(Base):
     )
 
     id = Column(String(36), primary_key=True, default=generate_uuid, index=True)
-    session_id = Column(String(36), ForeignKey("chat_sessions.id"), nullable=True, index=True)
-    provider_id = Column(String(36), ForeignKey("llm_providers.id"), nullable=True)
+    session_id = Column(String(36), ForeignKey("chat_sessions.id", ondelete="SET NULL"), nullable=True, index=True)
+    provider_id = Column(String(36), ForeignKey("llm_providers.id", ondelete="SET NULL"), nullable=True)
     model = Column(String(100), nullable=False)
     user_id = Column(String(36), nullable=False, index=True)
 
@@ -537,8 +537,8 @@ class AdminDebugSession(Base):
 
     id = Column(String(36), primary_key=True, default=generate_uuid, index=True)
     title = Column(String, default="Debug Chat")
-    agent_id = Column(String(36), ForeignKey("agents.id"), nullable=False, index=True)
-    admin_id = Column(String(36), ForeignKey("admins.id"), nullable=False, index=True)
+    agent_id = Column(String(36), ForeignKey("agents.id", ondelete="CASCADE"), nullable=False, index=True)
+    admin_id = Column(String(36), ForeignKey("admins.id", ondelete="CASCADE"), nullable=False, index=True)
 
     # 上下文压缩
     compressed_summary = Column(Text, nullable=True)
@@ -553,7 +553,7 @@ class AdminDebugMessage(Base):
     __tablename__ = "admin_debug_messages"
 
     id = Column(String(36), primary_key=True, default=generate_uuid, index=True)
-    session_id = Column(String(36), ForeignKey("admin_debug_sessions.id"), nullable=False, index=True)
+    session_id = Column(String(36), ForeignKey("admin_debug_sessions.id", ondelete="CASCADE"), nullable=False, index=True)
     role = Column(String)  # user, assistant, system
     content = Column(Text)
 
@@ -604,7 +604,7 @@ class ToolExecution(Base):
     id = Column(String(36), primary_key=True, default=generate_uuid, index=True)
     tool_name = Column(String(100), nullable=False, index=True)
     provider_name = Column(String(50), nullable=False, index=True)
-    agent_id = Column(String(36), ForeignKey("agents.id"), nullable=True, index=True)
+    agent_id = Column(String(36), ForeignKey("agents.id", ondelete="SET NULL"), nullable=True, index=True)
     session_id = Column(String(36), nullable=True, index=True)
     user_id = Column(String(36), nullable=True, index=True)
     is_admin = Column(Boolean, default=False)

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -13,12 +13,10 @@ from models import (
     CreditTransaction,
     SubscriptionPlan,
     ChatSession,
-    ChatMessage,
     Theater,
-    TaskExecution,
-    SubTask,
     VideoTask,
     MusicTask,
+    ToolExecution,
     generate_uuid,
 )
 from auth import require_admin, hash_password
@@ -217,33 +215,17 @@ async def delete_user(
 
     user_email = user.email
 
-    # 级联删除关联数据：按外键依赖深度从子到父依次清理，规避 PG 外键约束报 500
-    session_ids_subq = select(ChatSession.id).where(ChatSession.user_id == user_id)
-    task_exec_ids_subq = select(TaskExecution.id).where(TaskExecution.user_id == user_id)
-
-    # 1) 任务执行的子任务（subtasks -> task_executions）
-    await db.execute(delete(SubTask).where(SubTask.task_execution_id.in_(task_exec_ids_subq)))
-    # 2) 视频/音乐任务（依赖 chat_sessions、chat_messages）
-    await db.execute(delete(VideoTask).where(VideoTask.session_id.in_(session_ids_subq)))
-    await db.execute(delete(MusicTask).where(MusicTask.session_id.in_(session_ids_subq)))
-    # 3) 任务执行（依赖 chat_sessions、users，不能晚于 chat_sessions/users）
-    await db.execute(delete(TaskExecution).where(TaskExecution.user_id == user_id))
-    # 4) 聊天消息（依赖 chat_sessions，FK 无 cascade，必须显式删除）
-    await db.execute(delete(ChatMessage).where(ChatMessage.session_id.in_(session_ids_subq)))
-    # 5) 积分交易（同时引用 users 与 chat_sessions，需先于二者删除）
-    await db.execute(
-        delete(CreditTransaction).where(
-            (CreditTransaction.user_id == user_id)
-            | (CreditTransaction.session_id.in_(session_ids_subq))
-        )
-    )
-    # 6) 聊天会话
+    # 仅清理「无 FK 关联」的孤儿数据；其余关联表已在 FK 层声明
+    # ondelete=CASCADE/SET NULL，由数据库自动级联处理。
+    # 无 FK 列：chat_sessions.user_id / video_tasks.user_id /
+    #         music_tasks.user_id / tool_executions.user_id
+    await db.execute(delete(VideoTask).where(VideoTask.user_id == user_id))
+    await db.execute(delete(MusicTask).where(MusicTask.user_id == user_id))
+    await db.execute(delete(ToolExecution).where(ToolExecution.user_id == user_id))
     await db.execute(delete(ChatSession).where(ChatSession.user_id == user_id))
-    # 7) 剧场（theater_nodes/theater_edges 已在 FK 层 ON DELETE CASCADE）
-    await db.execute(delete(Theater).where(Theater.user_id == user_id))
-    # 8) 资源文件（assets）
-    await db.execute(delete(Asset).where(Asset.user_id == user_id))
 
+    # FK 层自动级联：theaters/assets/task_executions/subtasks (CASCADE),
+    # credit_transactions (SET NULL 保留审计)
     await db.delete(user)
     await db.commit()
     audit.record(

--- a/backend/routers/agents.py
+++ b/backend/routers/agents.py
@@ -1,22 +1,12 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.future import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import delete, update
 from typing import List, Optional
 from database import get_db
 from models import (
     Agent,
     LLMProvider,
     Admin,
-    ChatSession,
-    TheaterNode,
-    CreditTransaction,
-    PromptTemplate,
-    ToolExecution,
-    TaskExecution,
-    SubTask,
-    AdminDebugSession,
-    AdminDebugMessage,
 )
 from schemas import AgentCreate, AgentUpdate, AgentResponse
 from auth import get_current_active_user_or_admin, require_admin
@@ -159,38 +149,14 @@ async def delete_agent(agent_id: str, _admin: Admin = Depends(require_admin), db
     # Log deletion (In a real app, this might go to a dedicated audit log table)
     print(f"AUDIT: Agent {agent.name} (ID: {agent.id}) deleted.")
 
-    # 外键依赖清理：优先 SET NULL 保留历史，NOT NULL 外键才走级联删除
-    # 1) 可空外键——解绑使业务历史保留
-    await db.execute(
-        update(ChatSession).where(ChatSession.agent_id == agent_id).values(agent_id=None)
-    )
-    await db.execute(
-        update(TheaterNode).where(TheaterNode.created_by_agent_id == agent_id).values(created_by_agent_id=None)
-    )
-    await db.execute(
-        update(CreditTransaction).where(CreditTransaction.agent_id == agent_id).values(agent_id=None)
-    )
-    await db.execute(
-        update(PromptTemplate).where(PromptTemplate.default_agent_id == agent_id).values(default_agent_id=None)
-    )
-    await db.execute(
-        update(ToolExecution).where(ToolExecution.agent_id == agent_id).values(agent_id=None)
-    )
-
-    # 2) NOT NULL 外键——级联删除依赖记录
-    # 2a) admin_debug_sessions 及其消息
-    debug_session_ids = select(AdminDebugSession.id).where(AdminDebugSession.agent_id == agent_id)
-    await db.execute(delete(AdminDebugMessage).where(AdminDebugMessage.session_id.in_(debug_session_ids)))
-    await db.execute(delete(AdminDebugSession).where(AdminDebugSession.agent_id == agent_id))
-
-    # 2b) task_executions(leader=agent) 及其 subtasks
-    leader_task_ids = select(TaskExecution.id).where(TaskExecution.leader_agent_id == agent_id)
-    await db.execute(delete(SubTask).where(SubTask.task_execution_id.in_(leader_task_ids)))
-    await db.execute(delete(TaskExecution).where(TaskExecution.leader_agent_id == agent_id))
-
-    # 2c) subtasks 中直接指向该 agent 的子任务
-    await db.execute(delete(SubTask).where(SubTask.agent_id == agent_id))
-
+    # 所有外键已在 FK 层声明 ondelete：
+    #   SET NULL: chat_sessions.agent_id, theater_nodes.created_by_agent_id,
+    #             credit_transactions.agent_id, prompt_templates.default_agent_id,
+    #             tool_executions.agent_id
+    #   CASCADE : task_executions.leader_agent_id (连带 subtasks),
+    #             subtasks.agent_id, admin_debug_sessions.agent_id
+    #             (连带 admin_debug_messages)
+    # 由数据库自动级联处理，应用层无需手工清理。
     await db.delete(agent)
     await db.commit()
     return {"message": "Agent deleted successfully"}

--- a/backend/routers/llm_config.py
+++ b/backend/routers/llm_config.py
@@ -1,12 +1,12 @@
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
-from sqlalchemy import func, update
+from sqlalchemy import func
 from typing import List
 import httpx
 
 from database import get_db
-from models import LLMProvider, Admin, Agent, VideoTask, MusicTask
+from models import LLMProvider, Admin, Agent
 from schemas import LLMProviderCreate, LLMProviderUpdate, LLMProviderResponse, TestConnectionRequest
 from auth import require_admin
 from agents import narrative_engine
@@ -258,16 +258,10 @@ async def delete_llm_provider(
             detail=f"该供应商仍被 {agent_count} 个智能体使用，请先删除或修改关联智能体",
         )
 
-    snapshot = {"name": provider.name, "provider_type": provider.provider_type, "model": provider.model}
+    snapshot = {"name": provider.name, "provider_type": provider.provider_type, "models": provider.models}
 
-    # 历史任务记录中的 provider_id 采取 SET NULL，保留任务记录
-    await db.execute(
-        update(VideoTask).where(VideoTask.provider_id == provider_id).values(provider_id=None)
-    )
-    await db.execute(
-        update(MusicTask).where(MusicTask.provider_id == provider_id).values(provider_id=None)
-    )
-
+    # FK 层自动 SET NULL：agents.provider_id / video_tasks.provider_id /
+    # music_tasks.provider_id（上面预检已拦截 agent 引用场景）
     await db.delete(provider)
     await db.commit()
     await publish_invalidate("provider", provider_id)

--- a/deploy/scripts/update.sh
+++ b/deploy/scripts/update.sh
@@ -162,6 +162,14 @@ fi
 run "${COMPOSE[@]} up -d --remove-orphans"
 ok "容器已启动，开始等待 healthcheck"
 
+# nginx 容器本身往往未重建（镜像未变），但 backend/frontend/admin
+# 的容器 IP 在 up -d 后已轮换。nginx 在启动时缓存了 upstream 的
+# DNS 解析，不重启会持续 502 直到其自动重试。强制 restart
+# 令其重新解析 upstream，避免Step 5 健康检查期间的间歇性 502。
+log "重启 nginx 刷新 upstream DNS 解析"
+run "${COMPOSE[@]} restart nginx"
+ok "nginx 已重启"
+
 # ---------------------------------------------------------------------------
 # 5. 健康检查
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- 统一各表外键的ON DELETE策略，分为CASCADE和SET NULL两类，提升数据一致性与健壮性
- 移除应用层手动级联删除逻辑，利用数据库级联自动处理关联数据清理
- 修正多处模型定义，添加ondelete参数确保删除操作正确传播
- 优化删除用户和智能体时的依赖关系清理代码，减少数据库请求次数
- 调整LLM提供商删除逻辑，依赖数据库自动更新相关联智能体和任务关联字段
- 部署脚本新增重启nginx逻辑，解决后端服务IP变更导致的502间歇性错误