### PR TITLE
fix(db): 处理响应模型空agent_id及持久化node

### DIFF
--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -410,6 +410,10 @@ class ChatSessionUpdate(BaseModel):
 
 class ChatSessionResponse(ChatSessionBase):
     id: str
+    # agent_id 在数据库为 nullable（ondelete="SET NULL"）：
+    # 当关联 Agent 被删除后，旧会话的 agent_id 会被置为 NULL，
+    # 响应侧必须允许 None，否则触发 ResponseValidationError → 500。
+    agent_id: Optional[str] = None
     user_id: Optional[str] = None
     theater_id: Optional[str] = None
     total_tokens_used: int = 0  # 累计 token 使用量

--- a/backend/services/tool_manager/providers/image_edit.py
+++ b/backend/services/tool_manager/providers/image_edit.py
@@ -462,6 +462,7 @@ async def _maybe_create_edit_node(
             created_by_agent_id=ctx.agent.id,
         )
         db.add(new_node)
+        await db.flush()  # 先持久化 node，确保 FK 引用有效
 
         # 创建连线：源节点右侧输出 → 新节点左侧输入
         edge = TheaterEdge(


### PR DESCRIPTION
- 允许 ChatSessionResponse 中 agent_id 为 None，避免关联Agent删除后响应错误
- 在新增 TheaterNode 后调用 db.flush() 以确保外键引用有效
- 解决删除Agent导致旧会话agent_id置空时的ResponseValidationError问题
- 优化数据库操作流程，确保数据一致性和完整性