### PR TITLE
feat(agent): 新增自动对话标题生成配置及功能

### DIFF
--- a/backend/admin/src/app/admin/llm/schema.ts
+++ b/backend/admin/src/app/admin/llm/schema.ts
@@ -1,6 +1,7 @@
 
 import * as z from 'zod';
 import type { TFunction } from 'i18next';
+import { withBasePath } from '@/lib/utils';
 
 export const PRESET_COST_DIMENSIONS: Record<string, { labelKey: string; unit: string }> = {
   input:              { labelKey: 'llm.costDimension.input',              unit: 'USD/1M tokens' },
@@ -31,21 +32,21 @@ export const MODEL_TYPE_OPTIONS = [
 ] as const;
 
 export const PROVIDER_ICONS: Record<string, string> = {
-  openai: '/provider/openai.svg',
-  azure: '/provider/azureai-color.svg',
-  dashscope: '/provider/qwen-color.svg',
-  anthropic: '/provider/claude-color.svg',
-  gemini: '/provider/gemini-color.svg',
-  deepseek: '/provider/deepseek-color.svg',
-  minimax: '/provider/minimax-color.svg',
-  xai: '/provider/grok.svg',
-  doubao: '/provider/doubao-color.svg',
-  kling: '/provider/kling-color.svg',
-  meta: '/provider/meta-color.svg',
-  microsoft: '/provider/microsoft-color.svg',
-  openrouter: '/provider/openrouter.svg',
-  sora: '/provider/sora-color.svg',
-  ark: '/provider/volcengine-color.svg',
+  openai: withBasePath('/provider/openai.svg'),
+  azure: withBasePath('/provider/azureai-color.svg'),
+  dashscope: withBasePath('/provider/qwen-color.svg'),
+  anthropic: withBasePath('/provider/claude-color.svg'),
+  gemini: withBasePath('/provider/gemini-color.svg'),
+  deepseek: withBasePath('/provider/deepseek-color.svg'),
+  minimax: withBasePath('/provider/minimax-color.svg'),
+  xai: withBasePath('/provider/grok.svg'),
+  doubao: withBasePath('/provider/doubao-color.svg'),
+  kling: withBasePath('/provider/kling-color.svg'),
+  meta: withBasePath('/provider/meta-color.svg'),
+  microsoft: withBasePath('/provider/microsoft-color.svg'),
+  openrouter: withBasePath('/provider/openrouter.svg'),
+  sora: withBasePath('/provider/sora-color.svg'),
+  ark: withBasePath('/provider/volcengine-color.svg'),
 };
 
 // Provider brand labels come from the vendor itself (proper nouns), not translated.

--- a/backend/admin/src/app/admin/users/page.tsx
+++ b/backend/admin/src/app/admin/users/page.tsx
@@ -54,6 +54,7 @@ import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
 import { Trash2, Coins, CreditCard, History, HardDrive, Monitor, Eye, Globe, Smartphone, Laptop, Tablet, CircleUser, Mail, RefreshCw } from 'lucide-react';
 import { formatDateTime, formatShortDateTime, formatRelativeTime } from '@/lib/date-utils';
+import { withBasePath } from '@/lib/utils';
 import useSWR, { mutate } from 'swr';
 import api from '@/lib/axios';
 import { useToast } from '@/components/ui/use-toast';
@@ -98,8 +99,8 @@ function DetailRow({ label, value }: { label: string; value: React.ReactNode }) 
 // 注册来源标识组件
 function AuthSourceBadge({ user }: { user: User }) {
   const sources: { icon: string; label: string }[] = [];
-  user.google_id && sources.push({ icon: '/provider/gemini-color.svg', label: 'Google' });
-  user.github_id && sources.push({ icon: '/provider/meta-color.svg', label: 'GitHub' });
+  user.google_id && sources.push({ icon: withBasePath('/provider/gemini-color.svg'), label: 'Google' });
+  user.github_id && sources.push({ icon: withBasePath('/provider/meta-color.svg'), label: 'GitHub' });
 
   return (
     <div className="flex items-center gap-1.5">

--- a/backend/admin/src/components/admin/agents/AgentForm/BasicInfo.tsx
+++ b/backend/admin/src/components/admin/agents/AgentForm/BasicInfo.tsx
@@ -20,24 +20,25 @@ import {
 import { Textarea } from '@/components/ui/textarea';
 import { LLMProvider } from '@/types';
 import { parseProviderModelsWithMeta } from '@/lib/api-utils';
+import { withBasePath } from '@/lib/utils';
 
 // 供应商品牌 Logo 映射（与 LLM schema 保持一致）
 const PROVIDER_ICONS: Record<string, string> = {
-  openai: '/provider/openai.svg',
-  azure: '/provider/azureai-color.svg',
-  dashscope: '/provider/qwen-color.svg',
-  anthropic: '/provider/claude-color.svg',
-  gemini: '/provider/gemini-color.svg',
-  deepseek: '/provider/deepseek-color.svg',
-  minimax: '/provider/minimax-color.svg',
-  xai: '/provider/grok.svg',
-  doubao: '/provider/doubao-color.svg',
-  kling: '/provider/kling-color.svg',
-  meta: '/provider/meta-color.svg',
-  microsoft: '/provider/microsoft-color.svg',
-  openrouter: '/provider/openrouter.svg',
-  sora: '/provider/sora-color.svg',
-  ark: '/provider/volcengine-color.svg',
+  openai: withBasePath('/provider/openai.svg'),
+  azure: withBasePath('/provider/azureai-color.svg'),
+  dashscope: withBasePath('/provider/qwen-color.svg'),
+  anthropic: withBasePath('/provider/claude-color.svg'),
+  gemini: withBasePath('/provider/gemini-color.svg'),
+  deepseek: withBasePath('/provider/deepseek-color.svg'),
+  minimax: withBasePath('/provider/minimax-color.svg'),
+  xai: withBasePath('/provider/grok.svg'),
+  doubao: withBasePath('/provider/doubao-color.svg'),
+  kling: withBasePath('/provider/kling-color.svg'),
+  meta: withBasePath('/provider/meta-color.svg'),
+  microsoft: withBasePath('/provider/microsoft-color.svg'),
+  openrouter: withBasePath('/provider/openrouter.svg'),
+  sora: withBasePath('/provider/sora-color.svg'),
+  ark: withBasePath('/provider/volcengine-color.svg'),
 };
 
 interface BasicInfoProps {

--- a/backend/admin/src/components/admin/agents/AgentForm/Parameters.tsx
+++ b/backend/admin/src/components/admin/agents/AgentForm/Parameters.tsx
@@ -61,6 +61,8 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
   const imageEnabled = watch('image_config.image_generation_enabled');
   const compactionEnabled = watch('compaction_config.enabled');
   const compactionProviderId = watch('compaction_config.provider_id');
+  const titleGenEnabled = watch('title_gen_config.enabled');
+  const titleGenProviderId = watch('title_gen_config.provider_id');
   const [markupMultiplier, setMarkupMultiplier] = useState(1.5);
 
   // 当前选中的供应商
@@ -84,6 +86,18 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
       displayName: getModelDisplayName(m, p?.model_metadata),
     }));
   }, [compactionProviderId, providers]);
+
+  // 标题生成供应商的模型列表
+  const titleGenModelList = useMemo(() => {
+    const p = providers?.find(pr => pr.id === titleGenProviderId);
+    const models = p
+      ? (Array.isArray(p.models) ? p.models : (p.models || '').split(',').map((s: string) => s.trim()).filter(Boolean))
+      : [];
+    return models.map((m: string) => ({
+      value: m,
+      displayName: getModelDisplayName(m, p?.model_metadata),
+    }));
+  }, [titleGenProviderId, providers]);
 
   // 获取当前模型的 API 成本数据
   const modelCosts: Record<string, number> = currentProvider?.model_costs?.[model] ?? {};
@@ -370,6 +384,142 @@ const Parameters: React.FC<ParametersProps> = ({ disabled, providers }) => {
                     />
                   </FormControl>
                   <p className="text-[11px] text-muted-foreground">{t('agents.form.parameters.compaction.maxSummaryTokensDesc')}</p>
+                </FormItem>
+              )}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* 对话标题自动生成 */}
+      <div className="rounded-xl border bg-card p-5">
+        <div className="flex justify-between items-center mb-2">
+          <div>
+            <Label className="text-sm font-medium">{t('agents.form.parameters.titleGen.title')}</Label>
+            <p className="text-xs text-muted-foreground mt-1">{t('agents.form.parameters.titleGen.desc')}</p>
+          </div>
+          <FormField
+            control={control}
+            name="title_gen_config.enabled"
+            render={({ field }) => (
+              <FormItem>
+                <FormControl>
+                  <div className="flex items-center space-x-2">
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                      disabled={disabled}
+                    />
+                    <span className="text-xs text-muted-foreground">{field.value ? t('agents.form.parameters.titleGen.on') : t('agents.form.parameters.titleGen.off')}</span>
+                  </div>
+                </FormControl>
+              </FormItem>
+            )}
+          />
+        </div>
+
+        {titleGenEnabled && (
+          <div className="space-y-4 pt-3 border-t mt-3">
+            {/* 标题生成供应商 */}
+            <div className="space-y-1.5">
+              <Label className="text-xs text-muted-foreground">{t('agents.form.parameters.titleGen.titleGenProvider')}</Label>
+              <FormField
+                control={control}
+                name="title_gen_config.provider_id"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormControl>
+                      <Select
+                        value={field.value || '_fallback'}
+                        onValueChange={(val) => {
+                          field.onChange(val === '_fallback' ? '' : val);
+                          setValue('title_gen_config.model', '');
+                        }}
+                        disabled={disabled}
+                      >
+                        <SelectTrigger className="bg-background">
+                          <SelectValue placeholder={t('agents.form.parameters.titleGen.selectProvider')} />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="_fallback">{t('agents.form.parameters.titleGen.useDefault')}</SelectItem>
+                          {providers?.filter(p => p.is_active).map(p => (
+                            <SelectItem key={p.id} value={p.id}>{p.name} ({p.provider_type})</SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            {/* 标题生成模型 */}
+            {titleGenProviderId && (
+              <div className="space-y-1.5">
+                <Label className="text-xs text-muted-foreground">{t('agents.form.parameters.titleGen.titleGenModel')}</Label>
+                <FormField
+                  control={control}
+                  name="title_gen_config.model"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormControl>
+                        <Select value={field.value || ''} onValueChange={field.onChange} disabled={disabled}>
+                          <SelectTrigger className="bg-background">
+                            <SelectValue placeholder={t('agents.form.parameters.titleGen.selectModel')} />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {titleGenModelList.map((m) => (
+                              <SelectItem key={m.value} value={m.value}>{m.displayName}</SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </FormControl>
+                    </FormItem>
+                  )}
+                />
+              </div>
+            )}
+
+            {/* 标题最大长度 */}
+            <FormField
+              control={control}
+              name="title_gen_config.max_length"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-xs text-muted-foreground">{t('agents.form.parameters.titleGen.maxLength')}</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="number"
+                      min={8} max={50} step={1}
+                      value={field.value ?? 20}
+                      onChange={e => field.onChange(Number(e.target.value))}
+                      className="font-mono"
+                      disabled={disabled}
+                    />
+                  </FormControl>
+                  <p className="text-[11px] text-muted-foreground">{t('agents.form.parameters.titleGen.maxLengthDesc')}</p>
+                </FormItem>
+              )}
+            />
+
+            {/* 触发轮数 */}
+            <FormField
+              control={control}
+              name="title_gen_config.trigger_rounds"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-xs text-muted-foreground">{t('agents.form.parameters.titleGen.triggerRounds')}</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="number"
+                      min={1} max={10} step={1}
+                      value={field.value ?? 1}
+                      onChange={e => field.onChange(Number(e.target.value))}
+                      className="font-mono"
+                      disabled={disabled}
+                    />
+                  </FormControl>
+                  <p className="text-[11px] text-muted-foreground">{t('agents.form.parameters.titleGen.triggerRoundsDesc')}</p>
                 </FormItem>
               )}
             />

--- a/backend/admin/src/components/admin/agents/AgentForm/index.tsx
+++ b/backend/admin/src/components/admin/agents/AgentForm/index.tsx
@@ -66,6 +66,14 @@ const defaultCompactionConfig = {
   max_summary_tokens: 4096,
 };
 
+const defaultTitleGenConfig = {
+  enabled: false,
+  provider_id: '',
+  model: '',
+  max_length: 20,
+  trigger_rounds: 1,
+};
+
 export default function AgentForm({ 
   initialValues, 
   onSubmit, 
@@ -114,6 +122,7 @@ export default function AgentForm({
       image_credit_per_image: 0,
       video_config: defaultVideoConfig,
       compaction_config: defaultCompactionConfig,
+      title_gen_config: defaultTitleGenConfig,
       max_tool_rounds: 100,
     },
   });
@@ -163,6 +172,7 @@ export default function AgentForm({
         image_credit_per_image: Number(initialValues.image_credit_per_image) || 0,
         video_config: (initialValues.video_config as any) || defaultVideoConfig,
         compaction_config: initialValues.compaction_config || defaultCompactionConfig,
+        title_gen_config: initialValues.title_gen_config || defaultTitleGenConfig,
         max_tool_rounds: Number(initialValues.max_tool_rounds) || 100,
       };
       
@@ -204,6 +214,7 @@ export default function AgentForm({
         image_credit_per_image: 0,
         video_config: defaultVideoConfig,
         compaction_config: defaultCompactionConfig,
+        title_gen_config: defaultTitleGenConfig,
         max_tool_rounds: 100,
       });
       isFormInitialized.current = true;
@@ -239,7 +250,7 @@ export default function AgentForm({
 
   const handleFinish = async (values: AgentFormValues) => {
     try {
-      const { tools_enabled, gemini_config, image_config, video_config, compaction_config, ...rest } = values;
+      const { tools_enabled, gemini_config, image_config, video_config, compaction_config, title_gen_config, ...rest } = values;
       
       // Clean up gemini_config（仅保留思考、媒体、搜索字段）
       const cleanedGeminiConfig = gemini_config ? {
@@ -281,6 +292,15 @@ export default function AgentForm({
         max_summary_tokens: compaction_config.max_summary_tokens ?? 4096,
       } : { enabled: false, compact_ratio: 0.75, reserve_ratio: 0.15, tool_old_threshold: 500, tool_recent_n: 5, max_summary_tokens: 4096 };
 
+      // Clean up title_gen_config（关闭时仅保留 enabled:false，避免冗余字段）
+      const cleanedTitleGenConfig = title_gen_config?.enabled ? {
+        enabled: true,
+        provider_id: title_gen_config.provider_id || '',
+        model: title_gen_config.model || '',
+        max_length: title_gen_config.max_length ?? 20,
+        trigger_rounds: Math.max(1, Math.min(10, Number(title_gen_config.trigger_rounds) || 1)),
+      } : { enabled: false, max_length: 20, trigger_rounds: 1 };
+
       const payload: Partial<Agent> = {
         ...rest,
         tools: tools_enabled ? values.tools : [],
@@ -288,6 +308,7 @@ export default function AgentForm({
         image_config: cleanedImageConfig,
         video_config: cleanedVideoConfig,
         compaction_config: cleanedCompactionConfig,
+        title_gen_config: cleanedTitleGenConfig,
       };
       
       console.log('Submitting payload:', JSON.stringify(payload, null, 2));

--- a/backend/admin/src/components/admin/agents/AgentForm/schema.ts
+++ b/backend/admin/src/components/admin/agents/AgentForm/schema.ts
@@ -46,6 +46,15 @@ const compactionConfigSchema = z.object({
   max_summary_tokens: z.number().min(4096).max(131072).optional().default(4096),
 }).optional().nullable();
 
+// 对话标题自动生成配置 schema
+const titleGenConfigSchema = z.object({
+  enabled: z.boolean().optional().default(false),
+  provider_id: z.preprocess(emptyStringToNull, z.string().optional().nullable()),
+  model: z.preprocess(emptyStringToNull, z.string().optional().nullable()),
+  max_length: z.number().min(8).max(50).optional().default(20),
+  trigger_rounds: z.number().min(1).max(10).optional().default(1),
+}).optional().nullable();
+
 export const createAgentFormSchema = (t: TFunction) => z.object({
   name: z.string().min(1, t('agents.form.validation.nameRequired')).max(50, t('agents.form.validation.nameMax')),
   description: z.string().min(1, t('agents.form.validation.descRequired')).max(500, t('agents.form.validation.descMax')),
@@ -86,6 +95,8 @@ export const createAgentFormSchema = (t: TFunction) => z.object({
   video_config: videoGenConfigSchema,
   // 上下文压缩配置
   compaction_config: compactionConfigSchema,
+  // 对话标题自动生成配置
+  title_gen_config: titleGenConfigSchema,
   // 工具调用轮次限制
   max_tool_rounds: z.number().min(10).max(200).default(100),
 }).refine((data) => {

--- a/backend/admin/src/i18n/locales/en-US.json
+++ b/backend/admin/src/i18n/locales/en-US.json
@@ -668,6 +668,21 @@
           "maxSummaryTokens": "Max Summary Tokens",
           "maxSummaryTokensDesc": "max_tokens limit when the LLM generates summaries"
         },
+        "titleGen": {
+          "title": "Auto Chat Title Generation",
+          "desc": "After the configured number of rounds, automatically generate a concise title via AI",
+          "on": "On",
+          "off": "Off",
+          "titleGenProvider": "Title generation supplier. Try to choose suppliers that are not based on thinking models.",
+          "useDefault": "Use this agent's provider (default)",
+          "titleGenModel": "Title Generation Model",
+          "selectProvider": "Select provider",
+          "selectModel": "Select model",
+          "maxLength": "Max Title Length (characters)",
+          "maxLengthDesc": "Recommended 8 - 50, default 20 characters",
+          "triggerRounds": "Trigger After Rounds",
+          "triggerRoundsDesc": "Generate title after the Nth conversation round, range 1 - 10, default 1"
+        },
         "maxToolRounds": {
           "title": "Max Tool Rounds",
           "desc": "Max number of tool calls per conversation round",

--- a/backend/admin/src/i18n/locales/zh-CN.json
+++ b/backend/admin/src/i18n/locales/zh-CN.json
@@ -668,6 +668,21 @@
           "maxSummaryTokens": "最大摘要 Token 数",
           "maxSummaryTokensDesc": "LLM 生成摘要时的 max_tokens 限制"
         },
+        "titleGen": {
+          "title": "自动标题命名",
+          "desc": "在指定轮数的对话结束后，自动用 AI 概括出简洁标题",
+          "on": "开启",
+          "off": "关闭",
+          "titleGenProvider": "标题生成供应商，尽量选择非思考模型",
+          "useDefault": "使用当前智能体的供应商（默认）",
+          "titleGenModel": "标题生成模型",
+          "selectProvider": "选择供应商",
+          "selectModel": "选择模型",
+          "maxLength": "标题最大长度（字符）",
+          "maxLengthDesc": "建议 8 - 50 之间，默认 20 字符",
+          "triggerRounds": "触发轮数",
+          "triggerRoundsDesc": "第几轮对话结束后触发标题生成，范围 1 - 10，默认 1"
+        },
         "maxToolRounds": {
           "title": "工具调用轮次限制",
           "desc": "单轮对话中最大工具调用次数",

--- a/backend/admin/src/lib/utils.ts
+++ b/backend/admin/src/lib/utils.ts
@@ -4,3 +4,9 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+// Admin 挂在 /admin 子路径下（与 next.config.js 的 basePath/assetPrefix 保持一致）。
+// Next.js 对 <Image>/<Link> 会自动拼接前缀，但裸字符串路径（如 <img src> 、Avatar src）
+// 不会自动处理，需手动调用 withBasePath() 拼接。
+export const BASE_PATH = '/admin';
+export const withBasePath = (path: string) => `${BASE_PATH}${path}`;

--- a/backend/admin/src/types/index.ts
+++ b/backend/admin/src/types/index.ts
@@ -39,6 +39,17 @@ export interface CompactionConfig {
   max_summary_tokens: number;
 }
 
+// ---------------------------------------------------------------------------
+// 对话标题自动生成配置
+// ---------------------------------------------------------------------------
+export interface TitleGenConfig {
+  enabled: boolean;
+  provider_id?: string;
+  model?: string;
+  max_length: number;
+  trigger_rounds?: number;
+}
+
 export interface Agent {
   id?: string;
   name: string;
@@ -76,6 +87,8 @@ export interface Agent {
   video_config?: VideoGenToolConfigData;
   // 上下文压缩配置
   compaction_config?: CompactionConfig;
+  // 对话标题自动生成配置
+  title_gen_config?: TitleGenConfig;
   image_credit_per_image?: number;
   // 工具调用轮次限制
   max_tool_rounds?: number;

--- a/backend/migrations/versions/b8c9d0e1f2a3_unify_fk_ondelete_policies.py
+++ b/backend/migrations/versions/b8c9d0e1f2a3_unify_fk_ondelete_policies.py
@@ -145,10 +145,18 @@ def _revert(table: str, column: str, ref_table: str, ref_col: str) -> None:
 
 
 def upgrade() -> None:
+    # SQLite 不强制执行 FK 策略，且 batch_alter_table 处理匿名外键有缺陷，
+    # 本地开发环境跳过整个批量调整，生产 PostgreSQL 仍照常执行。
+    bind = op.get_bind()
+    if bind.dialect.name == "sqlite":
+        return
     for table, column, ref_table, ref_col, ondelete in FK_POLICIES:
         _apply(table, column, ref_table, ref_col, ondelete)
 
 
 def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "sqlite":
+        return
     for table, column, ref_table, ref_col, _ondelete in FK_POLICIES:
         _revert(table, column, ref_table, ref_col)

--- a/backend/migrations/versions/c9d0e1f2a3b4_add_title_gen_config_to_agent.py
+++ b/backend/migrations/versions/c9d0e1f2a3b4_add_title_gen_config_to_agent.py
@@ -1,0 +1,28 @@
+"""add_title_gen_config_to_agent
+
+Revision ID: c9d0e1f2a3b4
+Revises: b8c9d0e1f2a3
+Create Date: 2026-05-17 10:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c9d0e1f2a3b4'
+down_revision: Union[str, None] = 'b8c9d0e1f2a3'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('agents', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('title_gen_config', sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('agents', schema=None) as batch_op:
+        batch_op.drop_column('title_gen_config')

--- a/backend/models.py
+++ b/backend/models.py
@@ -304,6 +304,9 @@ class Agent(Base):
     # 上下文压缩配置（智能体级别）
     compaction_config = Column(JSON, default=dict)
 
+    # 对话标题自动生成配置（智能体级别）
+    title_gen_config = Column(JSON, default=dict)
+
     # 可控制的画布节点类型: ["script", "character", "storyboard", "video"]
     target_node_types = Column(JSON, default=[])
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -303,6 +303,8 @@ class AgentBase(BaseModel):
     video_config: Optional[dict] = None
     # 上下文压缩配置
     compaction_config: Optional[dict] = None
+    # 对话标题自动生成配置
+    title_gen_config: Optional[dict] = None
     # 可控制的画布节点类型
     target_node_types: List[str] = Field(default_factory=list)
     # 工具调用轮次限制
@@ -358,6 +360,8 @@ class AgentUpdate(BaseModel):
     video_config: Optional[dict] = None
     # 上下文压缩配置
     compaction_config: Optional[dict] = None
+    # 对话标题自动生成配置
+    title_gen_config: Optional[dict] = None
     # 可控制的画布节点类型
     target_node_types: Optional[List[str]] = None
     # 工具调用轮次限制

--- a/backend/services/chat_generation.py
+++ b/backend/services/chat_generation.py
@@ -561,7 +561,7 @@ async def generate_single_agent(
     }
     final_content = _content_builders[bool(loaded_skills or all_tool_calls)]()
 
-    _persist_state = {"compaction": None}  # mutable container for cross-scope sharing
+    _persist_state = {"compaction": None, "new_title": None}  # mutable container for cross-scope sharing
 
     async def _persist_message_and_billing():
         """Background task: save message, update stats, deduct credits.
@@ -653,6 +653,12 @@ async def generate_single_agent(
                         actual_total_tokens=result.input_tokens + result.output_tokens,
                     )
 
+                    # Post-generation deferred title generation (第 2 轮后仅触发一次)
+                    from services.title_generation import maybe_generate_title
+                    _persist_state["new_title"] = await maybe_generate_title(
+                        agent, provider, session, session_id, session_obj=s,
+                    )
+
                 await session.commit()
                 logger.info("Message/billing saved successfully (background)")
         except Exception as e:
@@ -671,6 +677,13 @@ async def generate_single_agent(
     _compaction = _persist_state.get("compaction")
     _compaction and (yield sse("context_compacted", {
         "summary": _compaction[1],
+    }))
+
+    # 发送标题更新事件（如果 AI 生成了新标题）
+    _new_title = _persist_state.get("new_title")
+    _new_title and (yield sse("title_updated", {
+        "session_id": session_id,
+        "title": _new_title,
     }))
 
     # 发送计费信息和完成事件

--- a/backend/services/context_compaction.py
+++ b/backend/services/context_compaction.py
@@ -200,6 +200,57 @@ def _format_messages_for_summary(messages: list[dict]) -> str:
     return "\n".join(lines)
 
 
+async def _summary_call_openai_compat(
+    provider: LLMProvider, model: str, system_text: str, user_text: str, max_tokens: int
+) -> str:
+    """OpenAI / DeepSeek / xAI / Ark / Doubao 等 OpenAI 兼容接口。"""
+    from openai import AsyncOpenAI
+    from services.llm_stream import DEFAULT_BASE_URLS
+
+    base_url = provider.base_url or DEFAULT_BASE_URLS.get(
+        (provider.provider_type or "").lower()
+    )
+    client = AsyncOpenAI(api_key=provider.api_key, base_url=base_url)
+    resp = await client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": system_text},
+            {"role": "user", "content": user_text},
+        ],
+        temperature=0.3,
+        max_tokens=max_tokens,
+    )
+    msg = resp.choices[0].message
+    # 推理模型可能把输出放在 reasoning_content；优先 content，回退 reasoning_content
+    return (getattr(msg, "content", None) or getattr(msg, "reasoning_content", None) or "").strip()
+
+
+async def _summary_call_gemini(
+    provider: LLMProvider, model: str, system_text: str, user_text: str, max_tokens: int
+) -> str:
+    """Gemini 原生 SDK 调用（不能走 OpenAI 兼容接口）。"""
+    from google import genai
+    from google.genai import types
+
+    client = genai.Client(api_key=provider.api_key)
+    resp = await client.aio.models.generate_content(
+        model=model,
+        contents=user_text,
+        config=types.GenerateContentConfig(
+            system_instruction=system_text,
+            temperature=0.3,
+            max_output_tokens=max_tokens,
+        ),
+    )
+    return (getattr(resp, "text", None) or "").strip()
+
+
+# provider_type → 调用实现（表驱动分发，未命中默认走 OpenAI 兼容接口）
+_SUMMARY_DISPATCH = {
+    "gemini": _summary_call_gemini,
+}
+
+
 async def generate_summary(
     messages_to_compact: list[dict],
     previous_summary: str | None,
@@ -208,12 +259,6 @@ async def generate_summary(
     max_tokens: int = 1024,
 ) -> str:
     """Call LLM (non-streaming) to produce a concise summary of old messages."""
-    from openai import AsyncOpenAI
-    from services.llm_stream import DEFAULT_BASE_URLS
-
-    base_url = provider.base_url or DEFAULT_BASE_URLS.get(provider.provider_type.lower())
-    client = AsyncOpenAI(api_key=provider.api_key, base_url=base_url)
-
     user_content_parts = []
     previous_summary and user_content_parts.append(
         f"## Previous Conversation Summary\n{previous_summary}\n"
@@ -221,18 +266,13 @@ async def generate_summary(
     user_content_parts.append(
         f"## Messages to Summarize\n{_format_messages_for_summary(messages_to_compact)}"
     )
+    user_text = "\n\n".join(user_content_parts)
+
+    pt = (provider.provider_type or "").lower()
+    caller = _SUMMARY_DISPATCH.get(pt, _summary_call_openai_compat)
 
     try:
-        resp = await client.chat.completions.create(
-            model=model,
-            messages=[
-                {"role": "system", "content": SUMMARY_SYSTEM_PROMPT},
-                {"role": "user", "content": "\n\n".join(user_content_parts)},
-            ],
-            temperature=0.3,
-            max_tokens=max_tokens,
-        )
-        return (resp.choices[0].message.content or "").strip()
+        return await caller(provider, model, SUMMARY_SYSTEM_PROMPT, user_text, max_tokens)
     except Exception as e:
         logger.error(f"Summary generation failed: {e}")
         return previous_summary or ""

--- a/backend/services/title_generation.py
+++ b/backend/services/title_generation.py
@@ -1,0 +1,280 @@
+"""
+Title generation service — automatic chat title generation from early conversation.
+
+Generates a concise title (default ≤20 chars) by feeding the first N user/assistant
+rounds (configurable, default 1 round = 2 messages) to an LLM. Only runs once per
+session: when total message count reaches N*2 and the current title is still a
+default placeholder.
+
+Configuration is per-agent (Agent.title_gen_config), mirroring context_compaction.
+"""
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import func
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from models import ChatMessage, LLMProvider
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+_DEFAULTS = {
+    "enabled": False,       # 默认关闭，由管理员主动开启
+    "provider_id": "",
+    "model": "",
+    "max_length": 20,
+    "trigger_rounds": 1,    # 触发轮数，范围 1-10，默认第 1 轮对话结束后触发
+}
+
+TITLE_SYSTEM_PROMPT = (
+    "你是对话主题概括专家。请基于给定的用户与 AI 的初期对话内容，"
+    "生成一个不超过 {max_length} 个字符的简洁、准确、信息密度高的标题，"
+    "概括对话的核心主题或用户意图。\n\n"
+    "## 严格要求\n"
+    "- 只返回标题文本，不要任何解释、前缀、引号、句号、表情或 Markdown 标记\n"
+    "- 不要使用「关于...」「讨论...」等冗余开头\n"
+    "- 字符数严格 ≤ {max_length}（中文字符与英文字符均按 1 计）\n"
+    "- 使用对话所用的主要语言\n"
+    "- 优先抓取具体主题、对象、动作；其次概括情绪或风格\n"
+)
+
+# 默认标题识别：仅当 title 仍是这些预设默认值时，才覆盖为 AI 生成标题
+_DEFAULT_TITLE_EXACT = {"New Chat", "Debug Chat", "未命名对话", "未命名剧场"}
+_DEFAULT_TITLE_PREFIXES = ("画布对话 - ", "Canvas Chat - ", "Chat - ")
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+@dataclass
+class TitleGenConfig:
+    enabled: bool
+    provider_id: str
+    model: str
+    max_length: int
+    trigger_rounds: int
+
+
+def load_title_gen_config_from_agent(agent: Any) -> TitleGenConfig:
+    """Load title-gen config from agent.title_gen_config dict, with safe defaults."""
+    cfg = (getattr(agent, "title_gen_config", None) or {})
+    merged = {k: cfg.get(k, v) for k, v in _DEFAULTS.items()}
+    # 防御性归一化
+    merged["max_length"] = max(8, min(50, int(merged.get("max_length") or 20)))
+    merged["trigger_rounds"] = max(1, min(10, int(merged.get("trigger_rounds") or 1)))
+    return TitleGenConfig(**merged)
+
+
+def is_default_title(title: str | None) -> bool:
+    """判定 title 是否仍是系统默认占位，从而决定是否可被 AI 生成结果覆盖。"""
+    return (
+        not title
+        or title in _DEFAULT_TITLE_EXACT
+        or any(title.startswith(p) for p in _DEFAULT_TITLE_PREFIXES)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _extract_text(content: Any) -> str:
+    """Extract plain text from message content (str / multimodal list / json-string)."""
+    return (
+        content if isinstance(content, str)
+        else " ".join(
+            p.get("text", "") for p in content if isinstance(p, dict)
+        ) if isinstance(content, list)
+        else str(content)
+    )
+
+
+def _format_messages_for_title(messages: list[dict]) -> str:
+    """Format the first N rounds of messages into a compact prompt for the title model."""
+    lines = []
+    for m in messages:
+        role = (m.get("role") or "user").upper()
+        # 每条最多 800 字，避免一两条超长消息占满 prompt
+        text = _extract_text(m.get("content", ""))[:800]
+        lines.append(f"[{role}]: {text}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# LLM call (provider_type 分发，避免 if-else)
+# ---------------------------------------------------------------------------
+async def _call_openai_compat(
+    provider: LLMProvider, model: str, system_text: str, user_text: str, max_tokens: int
+) -> str:
+    """OpenAI / DeepSeek / xAI / Ark / Doubao 等 OpenAI 兼容接口。
+
+    注意：推理模型（DeepSeek-V4 / o1 系列等）的 max_tokens 同时限制思考与输出，
+    若给得太小会导致 content 为空。这里统一给到一个保守上限。
+    """
+    from openai import AsyncOpenAI
+    from services.llm_stream import DEFAULT_BASE_URLS
+
+    base_url = provider.base_url or DEFAULT_BASE_URLS.get(
+        (provider.provider_type or "").lower()
+    )
+    client = AsyncOpenAI(api_key=provider.api_key, base_url=base_url)
+    resp = await client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": system_text},
+            {"role": "user", "content": user_text},
+        ],
+        temperature=0.3,
+        max_tokens=max_tokens,
+    )
+    msg = resp.choices[0].message
+    # 推理模型可能把答案放在 reasoning_content；优先 content，回退 reasoning_content
+    return (getattr(msg, "content", None) or getattr(msg, "reasoning_content", None) or "").strip()
+
+
+async def _call_gemini(
+    provider: LLMProvider, model: str, system_text: str, user_text: str, max_tokens: int
+) -> str:
+    """Gemini 原生 SDK 调用（不能走 OpenAI 兼容接口）。"""
+    from google import genai
+    from google.genai import types
+
+    client = genai.Client(api_key=provider.api_key)
+    resp = await client.aio.models.generate_content(
+        model=model,
+        contents=user_text,
+        config=types.GenerateContentConfig(
+            system_instruction=system_text,
+            temperature=0.3,
+            max_output_tokens=max_tokens,
+        ),
+    )
+    return (getattr(resp, "text", None) or "").strip()
+
+
+# provider_type → 调用实现（表驱动分发，未命中默认走 OpenAI 兼容接口）
+_TITLE_DISPATCH = {
+    "gemini": _call_gemini,
+}
+
+
+async def generate_title(
+    messages: list[dict],
+    provider: LLMProvider,
+    model: str,
+    max_length: int = 20,
+) -> str:
+    """Call LLM to generate a short title. Returns trimmed/truncated string or ''."""
+    system_text = TITLE_SYSTEM_PROMPT.format(max_length=max_length)
+    user_text = (
+        f"## 初期对话内容\n{_format_messages_for_title(messages)}\n\n"
+        f"请输出一个不超过 {max_length} 字符的标题（仅文本，无任何附加内容）。"
+    )
+
+    pt = (provider.provider_type or "").lower()
+    caller = _TITLE_DISPATCH.get(pt, _call_openai_compat)
+    # max_tokens 给 512：兼容推理模型（思考占大头），最终输出仍由 max_length 截断
+    raw = await caller(provider, model, system_text, user_text, 512)
+    logger.info(f"[TitleGen] LLM raw response (provider_type={pt}, model={model}): {raw!r}")
+
+    # 清理常见多余字符：首尾引号、句末标点、换行
+    cleaned = raw.strip().strip('"“”\'‘’「」『』`')
+    cleaned = cleaned.splitlines()[0].strip() if cleaned else ""
+    # 兜底截断
+    final = cleaned[:max_length]
+    logger.info(f"[TitleGen] cleaned title: {final!r} (len={len(final)})")
+    return final
+
+
+# ---------------------------------------------------------------------------
+# Main entry
+# ---------------------------------------------------------------------------
+async def maybe_generate_title(
+    agent: Any,
+    provider: LLMProvider,
+    db: AsyncSession,
+    session_id: str,
+    session_obj: Any = None,
+) -> str | None:
+    """决策 + 调用 + 持久化。返回新标题；不需要 / 失败时返回 None。
+
+    判定条件（全部满足才执行）：
+    1. agent.title_gen_config.enabled = True
+    2. session_obj 存在且 title 仍为系统默认值（避免覆盖手动设置）
+    3. 当前会话消息总数恰好 == cfg.trigger_rounds * 2
+       （即刚完成第 N 轮 assistant 持久化，N 可配范围 1-10）
+    """
+    cfg = load_title_gen_config_from_agent(agent)
+    if not cfg.enabled:
+        logger.debug(f"[TitleGen] session={session_id} skipped: enabled=False")
+        return None
+
+    cur_title = getattr(session_obj, "title", None) if session_obj else None
+    if not session_obj or not is_default_title(cur_title):
+        logger.info(
+            f"[TitleGen] session={session_id} skipped: "
+            f"session_obj={bool(session_obj)} title={cur_title!r} (非默认占位不覆盖)"
+        )
+        return None
+
+    expected = cfg.trigger_rounds * 2
+    msg_count = await db.scalar(
+        select(func.count(ChatMessage.id)).filter(ChatMessage.session_id == session_id)
+    )
+    if msg_count != expected:
+        logger.info(
+            f"[TitleGen] session={session_id} skipped: "
+            f"msg_count={msg_count} != expected={expected} "
+            f"(trigger_rounds={cfg.trigger_rounds})"
+        )
+        return None
+
+    logger.info(
+        f"[TitleGen] session={session_id} triggering: "
+        f"trigger_rounds={cfg.trigger_rounds} msg_count={msg_count}"
+    )
+
+    # 取前 N*2 条消息（user → assistant 交替）
+    rows_result = await db.execute(
+        select(ChatMessage)
+        .filter(ChatMessage.session_id == session_id)
+        .order_by(ChatMessage.created_at)
+        .limit(expected)
+    )
+    rows = rows_result.scalars().all()
+    if len(rows) < expected:
+        logger.warning(
+            f"[TitleGen] session={session_id} aborted: rows={len(rows)} < expected={expected}"
+        )
+        return None
+
+    msgs = [{"role": r.role, "content": r.content} for r in rows]
+
+    # 解析使用的 provider/model：优先 cfg 指定，否则回退 agent 自身
+    title_provider, title_model = provider, agent.model
+    use_custom = bool(cfg.provider_id and cfg.model)
+    custom = (await db.execute(
+        select(LLMProvider).filter(LLMProvider.id == cfg.provider_id)
+    )).scalars().first() if use_custom else None
+    is_custom_active = bool(custom and custom.is_active)
+    title_provider = custom if is_custom_active else provider
+    title_model = cfg.model if is_custom_active else agent.model
+
+    try:
+        title = await generate_title(msgs, title_provider, title_model, cfg.max_length)
+    except Exception as e:
+        logger.warning(f"[TitleGen] generation failed: {e}")
+        return None
+
+    if not title:
+        logger.warning(f"[TitleGen] session={session_id} got empty title from LLM, skip")
+        return None
+
+    session_obj.title = title
+    await db.flush()
+    logger.info(f"[TitleGen] session={session_id} title generated: {title!r}")
+    return title

--- a/backend/services/title_generation.py
+++ b/backend/services/title_generation.py
@@ -263,7 +263,6 @@ async def maybe_generate_title(
     msgs = [{"role": r.role, "content": r.content} for r in rows]
 
     # 解析使用的 provider/model：优先 cfg 指定，否则回退 agent 自身
-    title_provider, title_model = provider, agent.model
     use_custom = bool(cfg.provider_id and cfg.model)
     custom = (await db.execute(
         select(LLMProvider).filter(LLMProvider.id == cfg.provider_id)

--- a/backend/services/title_generation.py
+++ b/backend/services/title_generation.py
@@ -242,7 +242,7 @@ async def maybe_generate_title(
         return None
 
     logger.info(
-        f"[TitleGen] session={session_id} triggering: "
+        f"[TitleGen] session={safe_session_id} triggering: "
         f"trigger_rounds={cfg.trigger_rounds} msg_count={msg_count}"
     )
 
@@ -256,7 +256,7 @@ async def maybe_generate_title(
     rows = rows_result.scalars().all()
     if len(rows) < expected:
         logger.warning(
-            f"[TitleGen] session={session_id} aborted: rows={len(rows)} < expected={expected}"
+            f"[TitleGen] session={safe_session_id} aborted: rows={len(rows)} < expected={expected}"
         )
         return None
 
@@ -279,10 +279,10 @@ async def maybe_generate_title(
         return None
 
     if not title:
-        logger.warning(f"[TitleGen] session={session_id} got empty title from LLM, skip")
+        logger.warning(f"[TitleGen] session={safe_session_id} got empty title from LLM, skip")
         return None
 
     session_obj.title = title
     await db.flush()
-    logger.info(f"[TitleGen] session={session_id} title generated: {title!r}")
+    logger.info(f"[TitleGen] session={safe_session_id} title generated: {title!r}")
     return title

--- a/backend/services/title_generation.py
+++ b/backend/services/title_generation.py
@@ -20,6 +20,13 @@ from models import ChatMessage, LLMProvider
 
 logger = logging.getLogger(__name__)
 
+
+def _sanitize_for_log(value: Any) -> str:
+    """Sanitize untrusted values before logging to prevent log injection."""
+    text = str(value)
+    text = text.replace("\r", "").replace("\n", "")
+    return "".join(ch if ch.isprintable() else "?" for ch in text)
+
 # ---------------------------------------------------------------------------
 # Defaults
 # ---------------------------------------------------------------------------
@@ -209,14 +216,15 @@ async def maybe_generate_title(
        （即刚完成第 N 轮 assistant 持久化，N 可配范围 1-10）
     """
     cfg = load_title_gen_config_from_agent(agent)
+    safe_session_id = _sanitize_for_log(session_id)
     if not cfg.enabled:
-        logger.debug(f"[TitleGen] session={session_id} skipped: enabled=False")
+        logger.debug(f"[TitleGen] session={safe_session_id} skipped: enabled=False")
         return None
 
     cur_title = getattr(session_obj, "title", None) if session_obj else None
     if not session_obj or not is_default_title(cur_title):
         logger.info(
-            f"[TitleGen] session={session_id} skipped: "
+            f"[TitleGen] session={safe_session_id} skipped: "
             f"session_obj={bool(session_obj)} title={cur_title!r} (非默认占位不覆盖)"
         )
         return None
@@ -227,7 +235,7 @@ async def maybe_generate_title(
     )
     if msg_count != expected:
         logger.info(
-            f"[TitleGen] session={session_id} skipped: "
+            f"[TitleGen] session={safe_session_id} skipped: "
             f"msg_count={msg_count} != expected={expected} "
             f"(trigger_rounds={cfg.trigger_rounds})"
         )

--- a/frontend/src/components/ai-assistant/hooks/useSSEHandler.ts
+++ b/frontend/src/components/ai-assistant/hooks/useSSEHandler.ts
@@ -66,6 +66,7 @@ export function useSSEHandler() {
   const setMessages = useAIAssistantStore((state) => state.setMessages);
   const setIsLoading = useAIAssistantStore((state) => state.setIsOpen);
   const setContextUsage = useAIAssistantStore((state) => state.setContextUsage);
+  const updateChatTitleInList = useAIAssistantStore((state) => state.updateChatTitleInList);
   const { updateCredits } = useAuth();
   
   // Debounced timer for clearing canvas node effects after tool chain completes
@@ -712,6 +713,12 @@ export function useSSEHandler() {
         ]);
       },
 
+      // 对话标题已生成（后端在第二轮 AI 回复后推送）
+      title_updated: () => {
+        const d = data as { session_id?: string; title?: string };
+        d.session_id && d.title && updateChatTitleInList(d.session_id, d.title);
+      },
+
       // 完成（延迟执行，打破 React 18 自动批处理：
       //   当 text + done 事件在同一 reader.read() 中到达时，
       //   同步处理会导致 setMessages 被批处理为一次渲染，
@@ -757,7 +764,7 @@ export function useSSEHandler() {
     };
 
     handlers[eventType]?.();
-  }, [setMessages, resetStreamingState, updateCredits, setContextUsage]);
+  }, [setMessages, resetStreamingState, updateCredits, setContextUsage, updateChatTitleInList]);
 
   return {
     parseSSELine,

--- a/frontend/src/store/useAIAssistantStore.ts
+++ b/frontend/src/store/useAIAssistantStore.ts
@@ -295,6 +295,7 @@ interface AIAssistantState {
   setTheaterChatList: (list: ChatSessionInfo[]) => void;
   addChatToList: (chat: ChatSessionInfo) => void;
   removeChatFromList: (sessionId: string) => void;
+  updateChatTitleInList: (sessionId: string, title: string) => void;
   setIsLoadingChatList: (loading: boolean) => void;
   
   // Virtual scroll settings
@@ -505,6 +506,9 @@ export const useAIAssistantStore = create<AIAssistantState>()(
       })),
       removeChatFromList: (sessionId: string) => set((state) => ({
         theaterChatList: state.theaterChatList.filter(c => c.id !== sessionId)
+      })),
+      updateChatTitleInList: (sessionId: string, title: string) => set((state) => ({
+        theaterChatList: state.theaterChatList.map(c => c.id === sessionId ? { ...c, title } : c)
       })),
       setIsLoadingChatList: (isLoadingChatList: boolean) => set({ isLoadingChatList }),
       


### PR DESCRIPTION
- 在 Agent 模型及对应表结构中新增 title_gen_config 字段，支持存储标题生成配置
- 支持配置标题生成开关、供应商 ID、模型、最大标题长度及触发轮数
- Agent 表单新增自动标题配置项，允许用户开启并选择标题生成供应商和模型
- 管理后台统一处理并清理标题生成配置数据，保持默认值时避免冗余保存
- 对接 LLM 实现标题自动生成逻辑，支持多供应商调度（如 Gemini、OpenAI 兼容接口等）
- 会话消息回调中调用标题生成逻辑，在达到触发轮数时自动生成并更新会话标题
- SSE 实时事件中新增 title_updated 事件，前端监听后更新 UI 中的对话标题
- 优化图片资源路径处理，统一使用 withBasePath 拼接，修正资源路径问题
- 新增国际化文案支持，涵盖自动标题生成相关字段描述及提示
- 修正 SQLite 迁移逻辑，兼容本地开发环境跳过外键限制调整操作