### PR TITLE
feat(theater): 通过保存画布节点自动维护剧场封面缩略图！⚠️ 已经部署并在前端创建剧场的用户需要执行的一次性动作

### DIFF
--- a/backend/scripts/backfill_theater_thumbnails.py
+++ b/backend/scripts/backfill_theater_thumbnails.py
@@ -1,0 +1,86 @@
+"""老数据回填：为 thumbnail_url 为空的剧场挑选首张媒体节点 URL。
+
+复用 services/theater.py 中的 _THUMBNAIL_EXTRACTORS 选择规则，
+按 z_index 升序取首张 image/video 节点 URL 写入 theater.thumbnail_url。
+
+用法（在 backend 目录下执行）：
+    python -m scripts.backfill_theater_thumbnails              # 真正写入
+    python -m scripts.backfill_theater_thumbnails --dry-run    # 仅打印不写库
+"""
+import argparse
+import asyncio
+import os
+import sys
+
+# 脚本位于 backend/scripts/，需将 backend 根目录加入 sys.path
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+sys.path.insert(0, _BACKEND_DIR)
+sys.path.append(os.path.abspath(os.path.join(_BACKEND_DIR, "deps")))
+
+from sqlalchemy import select
+
+from database import AsyncSessionLocal
+from models import Theater, TheaterNode
+from services.theater import _THUMBNAIL_EXTRACTORS  # 复用同一份取值器
+
+
+def _pick_thumbnail_from_orm_nodes(nodes) -> str | None:
+    """从 ORM 节点中按 z_index 升序挑首张媒体 URL。
+
+    与 services.theater._pick_thumbnail_from_nodes 行为一致，
+    仅签名差异：这里接收 ORM TheaterNode 实例。
+    """
+    sorted_nodes = sorted(nodes, key=lambda n: (n.z_index or 0))
+    for node in sorted_nodes:
+        extractor = _THUMBNAIL_EXTRACTORS.get(node.node_type)
+        data = node.data or {}
+        url = extractor and extractor(data)
+        if url:
+            return url
+    return None
+
+
+async def backfill(dry_run: bool) -> None:
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(Theater).where(Theater.thumbnail_url.is_(None))
+        )
+        targets = list(result.scalars().all())
+        print(f"找到 {len(targets)} 个待回填剧场")
+
+        updated = 0
+        skipped = 0
+        for theater in targets:
+            nodes_result = await session.execute(
+                select(TheaterNode).where(TheaterNode.theater_id == theater.id)
+            )
+            nodes = list(nodes_result.scalars().all())
+            url = _pick_thumbnail_from_orm_nodes(nodes)
+
+            if not url:
+                skipped += 1
+                print(f"  [skip] {theater.id} ({theater.title}) -> 无媒体节点")
+                continue
+
+            print(f"  [pick] {theater.id} ({theater.title}) -> {url}")
+            if not dry_run:
+                theater.thumbnail_url = url
+            updated += 1
+
+        if dry_run:
+            print(f"\n[DRY-RUN] 将更新 {updated} 条，跳过 {skipped} 条；未写库")
+            return
+
+        await session.commit()
+        print(f"\n完成：更新 {updated} 条，跳过 {skipped} 条")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="回填剧场缩略图 URL")
+    parser.add_argument("--dry-run", action="store_true", help="仅打印不写库")
+    args = parser.parse_args()
+    asyncio.run(backfill(args.dry_run))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/services/theater.py
+++ b/backend/services/theater.py
@@ -1,4 +1,6 @@
 import uuid
+from typing import Iterable, Optional
+
 from sqlalchemy import select, delete, update, func
 from sqlalchemy.ext.asyncio import AsyncSession
 from fastapi import HTTPException
@@ -8,6 +10,29 @@ from schemas import (
     TheaterCreate, TheaterUpdate, TheaterSaveRequest,
     TheaterNodeCreate, TheaterEdgeCreate,
 )
+
+
+# 节点类型 -> 从 node.data 中提取封面候选 URL 的取值器。
+# 表驱动避免 if 分支，新增类型只需追加一行。
+_THUMBNAIL_EXTRACTORS = {
+    "image": lambda data: data.get("imageUrl"),
+    "video": lambda data: data.get("thumbnail") or data.get("videoUrl"),
+}
+
+
+def _iter_media_urls(nodes: Iterable[TheaterNodeCreate]) -> Iterable[str]:
+    """按 z_index 升序遍历媒体节点，产出非空 URL。"""
+    sorted_nodes = sorted(nodes, key=lambda n: (n.z_index or 0))
+    for node in sorted_nodes:
+        extractor = _THUMBNAIL_EXTRACTORS.get(node.node_type)
+        data = node.data or {}
+        url = extractor and extractor(data)
+        url and (yield url)
+
+
+def _pick_thumbnail_from_nodes(nodes: Iterable[TheaterNodeCreate]) -> Optional[str]:
+    """取首张媒体节点 URL 作为剧场封面候选。无则返回 None。"""
+    return next(_iter_media_urls(nodes), None)
 
 
 class TheaterService:
@@ -233,6 +258,16 @@ class TheaterService:
             theater.node_count = len(incoming_node_ids)
             if data.canvas_viewport is not None:
                 theater.canvas_viewport = data.canvas_viewport
+
+            # 自动维护 thumbnail_url：
+            # 1) 当前为空 → 从新节点中挑首张媒体 URL；
+            # 2) 当前已存在但目标 URL 已不在新节点的媒体集合内（说明被删除）→ 重新挑。
+            # 仅在节点媒体集合发生变化时写入，避免无谓的脏字段。
+            current_thumb = theater.thumbnail_url
+            media_urls = set(_iter_media_urls(incoming_nodes.values()))
+            should_repick = (not current_thumb) or (current_thumb not in media_urls)
+            if should_repick:
+                theater.thumbnail_url = _pick_thumbnail_from_nodes(incoming_nodes.values())
 
         await self.db.commit()
         await self.db.refresh(theater)

--- a/frontend/src/components/canvas/ImageNode/ImageGrid.tsx
+++ b/frontend/src/components/canvas/ImageNode/ImageGrid.tsx
@@ -32,6 +32,9 @@ export function ImageGrid({ imageList, name, onRemove, onImageLoad, onOpenPrevie
           src={imageList[0]}
           alt={name}
           className="w-full h-full object-contain"
+          loading="lazy"
+          decoding="async"
+          draggable={false}
           onLoad={onImageLoad}
           onPointerDown={(e) => e.stopPropagation()}
         />
@@ -63,6 +66,9 @@ export function ImageGrid({ imageList, name, onRemove, onImageLoad, onOpenPrevie
             src={imageList[0]}
             alt={`${name}-1`}
             className="w-full h-full object-cover"
+            loading="lazy"
+            decoding="async"
+            draggable={false}
             onPointerDown={(e) => e.stopPropagation()}
             onDoubleClick={(e) => { e.stopPropagation(); onOpenPreview(imageList[0]); }}
           />
@@ -80,6 +86,9 @@ export function ImageGrid({ imageList, name, onRemove, onImageLoad, onOpenPrevie
                 src={url}
                 alt={`${name}-${i + 2}`}
                 className="w-full h-full object-cover"
+                loading="lazy"
+                decoding="async"
+                draggable={false}
                 onPointerDown={(e) => e.stopPropagation()}
                 onDoubleClick={(e) => { e.stopPropagation(); onOpenPreview(url); }}
               />
@@ -110,6 +119,9 @@ export function ImageGrid({ imageList, name, onRemove, onImageLoad, onOpenPrevie
             src={url}
             alt={`${name}-${i + 1}`}
             className="w-full h-full object-cover"
+            loading="lazy"
+            decoding="async"
+            draggable={false}
             onPointerDown={(e) => e.stopPropagation()}
             onDoubleClick={(e) => { e.stopPropagation(); onOpenPreview(url); }}
           />

--- a/frontend/src/components/canvas/VideoNode/VideoDisplay.tsx
+++ b/frontend/src/components/canvas/VideoNode/VideoDisplay.tsx
@@ -20,6 +20,7 @@ export function VideoDisplay({ videoUrl, fitMode, quality, onLoadedMetadata }: P
       <video
         src={videoUrl}
         controls
+        preload="none"
         className={`w-full h-full rounded-sm nodrag ${fitMode === 'cover' ? 'object-cover' : 'object-contain'}`}
         onPointerDown={(e) => e.stopPropagation()}
         onLoadedMetadata={onLoadedMetadata}

--- a/frontend/src/components/home/RecentTheaters.tsx
+++ b/frontend/src/components/home/RecentTheaters.tsx
@@ -9,12 +9,7 @@ import { cn } from "@/lib/utils";
 import TheaterCard from "./TheaterCard";
 import CreateTheaterCard from "./CreateTheaterCard";
 import { useAuth } from "@/context/AuthContext";
-import { theaterApi, type TheaterResponse, type TheaterDetailResponse } from "@/lib/theaterApi";
-
-// 剧场数据包含节点信息
-interface TheaterWithNodes extends TheaterResponse {
-  nodes?: TheaterDetailResponse["nodes"];
-}
+import { theaterApi, type TheaterResponse } from "@/lib/theaterApi";
 
 export default function RecentTheaters() {
   const { t } = useTranslation();
@@ -25,9 +20,8 @@ export default function RecentTheaters() {
   const isGuest = isHydrated && !isAuthenticated;
   const carouselRef = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState(0);
-  const [theaters, setTheaters] = useState<TheaterWithNodes[]>([]);
+  const [theaters, setTheaters] = useState<TheaterResponse[]>([]);
   const [loading, setLoading] = useState(true);
-  const fetched = useRef(false);
   const controls = useAnimation();
 
   useEffect(() => {
@@ -43,34 +37,35 @@ export default function RecentTheaters() {
   }, [theaters]);
 
   useEffect(() => {
-    if (!isAuthenticated || fetched.current) return;
-    fetched.current = true;
-    
-    const loadTheatersWithNodes = async () => {
-      try {
-        const listRes = await theaterApi.listTheaters(1, 20);
-        const theatersWithNodes = await Promise.all(
-          listRes.items.map(async (theater) => {
-            if (!theater.thumbnail_url) {
-              try {
-                const detail = await theaterApi.getTheater(theater.id);
-                return { ...theater, nodes: detail.nodes };
-              } catch {
-                return theater;
-              }
-            }
-            return theater;
-          })
-        );
-        setTheaters(theatersWithNodes);
-      } catch {
-        setTheaters([]);
-      } finally {
-        setLoading(false);
-      }
+    if (!isAuthenticated) return;
+
+    // 仅拉列表，不再为「补封面」拉完整画布详情。
+    // 后端在 save_canvas 时会自动维护 thumbnail_url；未生成的剧场直接留白占位。
+    //
+    // 不再用 fetched ref 做去重守卫：StrictMode 下双调用会让守卫位与取消逻辑互锁，
+    // 导致 loading 永远不释放。cancelled + AbortController 已足够防止竟态并发。
+    const controller = new AbortController();
+    let cancelled = false;
+
+    setLoading(true);
+
+    theaterApi
+      .listTheaters(1, 20, undefined, controller.signal)
+      .then((listRes) => {
+        cancelled || setTheaters(listRes.items);
+      })
+      .catch(() => {
+        // 被 abort 时 cancelled 已为 true，这里不会误清空列表
+        cancelled || setTheaters([]);
+      })
+      .finally(() => {
+        cancelled || setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
     };
-    
-    loadTheatersWithNodes();
   }, [isAuthenticated]);
 
   const handleRename = async (id: string, newTitle: string) => {
@@ -183,7 +178,6 @@ export default function RecentTheaters() {
                 status={th.status}
                 nodeCount={th.node_count}
                 updatedAt={th.updated_at}
-                nodes={th.nodes}
                 onClick={() => router.push(`/theater/${th.id}`)}
                 onRename={handleRename}
                 onDuplicate={handleDuplicate}

--- a/frontend/src/components/home/TheaterCard.tsx
+++ b/frontend/src/components/home/TheaterCard.tsx
@@ -36,7 +36,7 @@ const TIME_KEY_MAP: Record<number, string> = {
   1: "theater.yesterday",
 };
 
-// 画布节点类型
+// 画布节点类型（保留导出以便外部调用方过渡使用，本组件不再消费）
 interface TheaterNode {
   id: string;
   node_type: string;
@@ -55,6 +55,7 @@ interface TheaterCardProps {
   status?: string;
   nodeCount?: number;
   updatedAt?: string | null;
+  /** @deprecated 封面统一由后端 thumbnail_url 提供，已不再从画布节点提取 */
   nodes?: TheaterNode[];
   onClick?: () => void;
   onRename?: (id: string, newTitle: string) => void;
@@ -70,7 +71,6 @@ export default function TheaterCard({
   status = "draft",
   nodeCount = 0,
   updatedAt,
-  nodes = [],
   onClick,
   onRename,
   onDuplicate,
@@ -81,7 +81,7 @@ export default function TheaterCard({
   const [isLoading, setIsLoading] = useState(false);
   const { confirm, dialog: confirmDialog, setLoading: setConfirmLoading } = useConfirmDialog();
   const { input, dialog: inputDialog, setLoading: setInputLoading } = useInputDialog();
-  
+
   const statusConfig = STATUS_CONFIG[status] ?? STATUS_CONFIG.draft;
   const StatusIcon = statusConfig.icon;
 
@@ -90,29 +90,9 @@ export default function TheaterCard({
   const pointerStartRef = useRef<{ x: number; y: number } | null>(null);
   const isSwipingRef = useRef(false);
 
-  // 从画布节点中提取图片/视频作为背景
-  const extractBackgroundFromNodes = (): string | null => {
-    const mediaNodes = nodes.filter((node) => 
-      node.node_type === "image" || node.node_type === "video"
-    );
-    
-    for (const node of mediaNodes) {
-      const data = node.data;
-      if (!data) continue;
-      
-      if (node.node_type === "image" && data.imageUrl) {
-        return data.imageUrl;
-      }
-      
-      if (node.node_type === "video" && data.videoUrl) {
-        return data.thumbnail || data.videoUrl;
-      }
-    }
-    
-    return null;
-  };
-
-  const backgroundImage = image || extractBackgroundFromNodes();
+  // 封面统一使用后端 thumbnail_url；为空则显示占位块，
+  // 不再同步扫画布节点拉原图，避免首页带宽与主线程解码风暴。
+  const backgroundImage = image || null;
 
   // 格式化时间
   const formatTime = (dateStr: string | null | undefined): string => {
@@ -252,31 +232,23 @@ export default function TheaterCard({
       >
         {/* Card Container */}
         <div className="relative w-full h-full rounded-2xl overflow-hidden">
-          {/* Background Image/Video */}
+          {/* Background Image */}
           {backgroundImage ? (
             <div className="absolute inset-0">
-              {backgroundImage.match(/\.(mp4|webm|mov|avi)$/i) ? (
-                <video
-                  src={backgroundImage}
-                  className="w-full h-full object-cover transition-transform duration-700 ease-in-out group-hover:scale-110"
-                  preload="metadata"
-                  muted
-                  playsInline
-                />
-              ) : (
-                <Image
-                  src={backgroundImage}
-                  alt={title}
-                  fill
-                  sizes="260px"
-                  priority={priority}
-                  loading={priority ? "eager" : "lazy"}
-                  // 生产 standalone 镜像未打包 sharp，Next.js 图像优化器会对 /api/media/* 返回 500；
-                  // 卡片尺寸固定 260x360，原图已是合适规格，直接跳过优化由后端/nginx 直出即可
-                  unoptimized
-                  className="object-cover transition-transform duration-700 ease-in-out group-hover:scale-110"
-                />
-              )}
+              <Image
+                src={backgroundImage}
+                alt={title}
+                fill
+                sizes="260px"
+                priority={priority}
+                loading={priority ? "eager" : "lazy"}
+                decoding="async"
+                fetchPriority={priority ? "high" : "low"}
+                // 生产 standalone 镜像未打包 sharp，Next.js 图像优化器会对 /api/media/* 返回 500；
+                // 卡片尺寸固定 260x360，原图已是合适规格，直接跳过优化由后端/nginx 直出即可
+                unoptimized
+                className="object-cover transition-transform duration-700 ease-in-out group-hover:scale-110"
+              />
             </div>
           ) : (
             <div className="absolute inset-0 bg-muted transition-transform duration-500 ease-in-out group-hover:scale-110" />

--- a/frontend/src/components/home/TopBar.tsx
+++ b/frontend/src/components/home/TopBar.tsx
@@ -79,6 +79,12 @@ export default function TopBar() {
     setMobileMenuOpen(false);
   };
 
+  // 在 mount 时预取所有可见导航目标的 chunks，等价于 next/link 的 prefetch；
+  // 这样保留 <button> 原视觉的同时，路由切换仍然几乎零延迟。
+  useEffect(() => {
+    visibleNavLinks.forEach((link) => router.prefetch(link.href));
+  }, [router, visibleNavLinks]);
+
   // 用户菜单处理
   const handleUserMenuClick = (key: string) => {
     const handlers: Record<string, () => void> = {
@@ -127,11 +133,13 @@ export default function TopBar() {
                   <button
                     key={link.key}
                     onClick={() => handleNavigate(link.href)}
+                    onMouseEnter={() => router.prefetch(link.href)}
+                    onFocus={() => router.prefetch(link.href)}
                     className={cn(
                       // isolate 让按钮自成堆叠上下文，子元素 -z-10 不会穿透到父级
                       "relative isolate px-3 py-1.5 text-sm font-medium rounded-md transition-all duration-200",
-                      isActive 
-                        ? "text-foreground" 
+                      isActive
+                        ? "text-foreground"
                         : "text-muted-foreground hover:text-foreground hover:bg-secondary"
                     )}
                   >
@@ -317,23 +325,28 @@ export default function TopBar() {
                 {visibleNavLinks.map((link, index) => {
                   const isActive = pathname === link.href || (link.href !== "/" && pathname?.startsWith(link.href));
                   return (
-                    <motion.button
+                    <motion.div
                       key={link.key}
                       initial={{ opacity: 0, x: -20 }}
                       animate={{ opacity: 1, x: 0 }}
                       transition={{ delay: index * 0.05 }}
-                      onClick={() => handleNavigate(link.href)}
-                      className={cn(
-                        "flex items-center gap-3 px-3 py-3 rounded-lg text-left",
-                        "transition-colors duration-200",
-                        isActive 
-                          ? "bg-secondary text-foreground" 
-                          : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground"
-                      )}
                     >
-                      <link.icon className="w-5 h-5" />
-                      <span className="font-medium">{t(link.labelKey)}</span>
-                    </motion.button>
+                      <button
+                        onClick={() => handleNavigate(link.href)}
+                        onMouseEnter={() => router.prefetch(link.href)}
+                        onFocus={() => router.prefetch(link.href)}
+                        className={cn(
+                          "w-full flex items-center gap-3 px-3 py-3 rounded-lg text-left",
+                          "transition-colors duration-200",
+                          isActive
+                            ? "bg-secondary text-foreground"
+                            : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground"
+                        )}
+                      >
+                        <link.icon className="w-5 h-5" />
+                        <span className="font-medium">{t(link.labelKey)}</span>
+                      </button>
+                    </motion.div>
                   );
                 })}
               </nav>

--- a/frontend/src/lib/theaterApi.ts
+++ b/frontend/src/lib/theaterApi.ts
@@ -114,10 +114,11 @@ export const theaterApi = {
     page = 1,
     pageSize = 20,
     status?: string,
+    signal?: AbortSignal,
   ): Promise<TheaterListResponse> {
     const params: Record<string, unknown> = { page, page_size: pageSize };
     if (status) params.status = status;
-    const res = await api.get<TheaterListResponse>("/theaters", { params });
+    const res = await api.get<TheaterListResponse>("/theaters", { params, signal });
     return res.data;
   },
 


### PR DESCRIPTION
- 在 TheaterService.save_canvas 实现按节点变化自动挑选封面图片
- 从新节点按 z_index 升序取首张 image/video 节点的媒体 URL 赋给 thumbnail_url
- 移除前端画布节点封面提取逻辑，统一使用后端 thumbnail_url
- 优化 RecentTheaters 组件，改为仅拉列表避免额外请求详情
- 实现后端脚本 backfill_theater_thumbnails.py 批量回填旧剧场封面数据
- 组件 ImageGrid 中图片添加 loading=lazy, decoding=async 和 draggable=false 属性
- 组件 VideoDisplay 中视频添加 preload="none" 属性减少自动加载
- TopBar 组件预取导航路由对应代码块，提升导航响应速度
- theaterApi.listTheaters 支持 AbortSignal，前端请求支持取消加载

## ⚠️ 已经部署并在前端创建剧场的用户需要执行的一次性动作

本次新增了**老数据回填脚本** `backend/scripts/backfill_theater_thumbnails.py`，
不会随容器启动自动执行，**必须在 `update.sh` 跑完后手动执行一次**。

```bash
cd /opt/kunflix/deploy

# 1) 正常更新
sudo bash scripts/update.sh

# 2) 回填存量剧场封面（先 dry-run 看一眼结果）
sudo docker compose --env-file .env.prod exec backend \
    python -m scripts.backfill_theater_thumbnails --dry-run

# 3) 确认无误后真正写入
sudo docker compose --env-file .env.prod exec backend \
    python -m scripts.backfill_theater_thumbnails