### PR TITLE
fix(media): 修复上传接口及资源管理中的缩略图支持问题

### DIFF
--- a/backend/routers/media.py
+++ b/backend/routers/media.py
@@ -24,7 +24,7 @@ from schemas import (
 from services.batch_image_gen import batch_generate_images, BatchImageConfig
 from services.xai_image_gen import batch_generate_xai_images, XAIBatchImageConfig
 from services.image_config_adapter import to_provider_config
-from services.media_utils import build_media_storage_path, resolve_media_filepath, MEDIA_DIR
+from services.media_utils import build_media_storage_path, resolve_media_filepath, MEDIA_DIR, ensure_thumbnail
 from storage import get_storage_backend
 from config import settings
 
@@ -42,6 +42,9 @@ _MAX_UPLOAD_LABELS = { "image": "50MB", "video": "500MB", "audio": "100MB" }
 
 # 安全文件名：UUID + 已知媒体扩展名（图片 + 视频 + 音频）
 _SAFE_FILENAME = re.compile(r'^[a-f0-9\-]{36}\.(png|jpg|jpeg|webp|gif|mp4|webm|mov|mp3|wav|ogg)$')
+
+# 缩略图仅接受图片扩展名
+_SAFE_THUMB_FILENAME = re.compile(r'^[a-f0-9\-]{36}\.(png|jpg|jpeg|webp|gif)$')
 
 
 async def _fallback_presign_post(
@@ -510,6 +513,44 @@ async def serve_virtual_human_preview(filename: str):
         media_type=_EXT_MIME.get(ext, "application/octet-stream"),
         headers={"Cache-Control": "public, max-age=31536000"},
     )
+
+
+# ---------------------------------------------------------------------------
+# 缩略图路由 — 必须放在通配符 /{filename} 之前
+# ---------------------------------------------------------------------------
+
+# 后端分发：s3 后端不生成缩略图，302 回原图端点（后续走其预签名重定向）
+async def _serve_thumb_local(filename: str):
+    """本地后端：按需生成 + 落盘缓存。"""
+    thumb_path = await ensure_thumbnail(filename)
+    thumb_path or (_ for _ in ()).throw(HTTPException(status_code=404, detail="File not found"))
+    ext = filename.rsplit(".", 1)[-1]
+    return FileResponse(
+        thumb_path,
+        media_type=_EXT_MIME.get(ext, "image/jpeg"),
+        headers={"Cache-Control": "public, max-age=31536000, immutable"},
+    )
+
+
+async def _serve_thumb_s3(filename: str):
+    """S3 后端：不生成缩略图，302 回原图端点。"""
+    return RedirectResponse(url=f"/api/media/{filename}", status_code=302)
+
+
+_THUMB_BACKEND_DISPATCH = {
+    "s3":    _serve_thumb_s3,
+    "local": _serve_thumb_local,
+}
+
+
+@router.get("/thumb/{filename}")
+async def serve_media_thumbnail(filename: str):
+    """提供媒体缩略图（首次访问生成，后续命中磁盘缓存）。仅限图片扩展名。"""
+    _SAFE_THUMB_FILENAME.match(filename) or (_ for _ in ()).throw(
+        HTTPException(status_code=400, detail="Invalid thumbnail filename")
+    )
+    handler = _THUMB_BACKEND_DISPATCH.get(settings.STORAGE_BACKEND, _serve_thumb_local)
+    return await handler(filename)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/scripts/migrate_theater_thumbnails_to_thumb.py
+++ b/backend/scripts/migrate_theater_thumbnails_to_thumb.py
@@ -1,0 +1,67 @@
+"""一次性迁移：将 theater.thumbnail_url 改写为缩略图路径。
+
+将形如 `/api/media/abc.png` 的 thumbnail_url 改写为 `/api/media/thumb/abc.png`，
+其它形式（远端 URL、已是 thumb 路径、空值）一律原样保留，幂等可重复执行。
+
+用法（在 backend 目录下执行）：
+    python -m scripts.migrate_theater_thumbnails_to_thumb              # 真正写入
+    python -m scripts.migrate_theater_thumbnails_to_thumb --dry-run    # 仅打印
+"""
+import argparse
+import asyncio
+import os
+import sys
+
+# 脚本位于 backend/scripts/，需将 backend 根目录加入 sys.path
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+sys.path.insert(0, _BACKEND_DIR)
+sys.path.append(os.path.abspath(os.path.join(_BACKEND_DIR, "deps")))
+
+from sqlalchemy import select
+
+from database import AsyncSessionLocal
+from models import Theater
+from services.media_utils import to_thumb_url
+
+
+async def migrate(dry_run: bool) -> None:
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(Theater).where(Theater.thumbnail_url.isnot(None))
+        )
+        targets = list(result.scalars().all())
+        print(f"扫描 {len(targets)} 个非空 thumbnail_url 剧场")
+
+        updated = 0
+        skipped = 0
+        for theater in targets:
+            current = theater.thumbnail_url or ""
+            new_url = to_thumb_url(current)
+
+            if new_url == current:
+                skipped += 1
+                continue
+
+            print(f"  [rewrite] {theater.id} ({theater.title})")
+            print(f"      {current} -> {new_url}")
+            if not dry_run:
+                theater.thumbnail_url = new_url
+            updated += 1
+
+        if dry_run:
+            print(f"\n[DRY-RUN] 将改写 {updated} 条，跳过 {skipped} 条；未写库")
+            return
+
+        await session.commit()
+        print(f"\n完成：改写 {updated} 条，跳过 {skipped} 条")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="迁移剧场缩略图 URL 至 thumb 路径")
+    parser.add_argument("--dry-run", action="store_true", help="仅打印不写库")
+    args = parser.parse_args()
+    asyncio.run(migrate(args.dry_run))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/services/media_utils.py
+++ b/backend/services/media_utils.py
@@ -8,6 +8,15 @@ logger = logging.getLogger(__name__)
 
 MEDIA_DIR = Path(__file__).resolve().parent.parent / "media"
 
+# 缩略图缓存目录（首页/列表场景使用，原图保持不变）
+THUMB_DIR_NAME = "_thumbs"
+THUMB_DIR = MEDIA_DIR / THUMB_DIR_NAME
+THUMB_MAX_SIZE = 480  # 长边像素，覆盖 2x dpr 下卡片 ~240px 显示宽度
+
+# 媒体 API 前缀（用于 URL 改写）
+MEDIA_URL_PREFIX = "/api/media/"
+THUMB_URL_PREFIX = "/api/media/thumb/"
+
 # MIME -> 扩展名映射
 MIME_TO_EXT = {
     "image/png": "png",
@@ -161,3 +170,88 @@ async def save_audio_data(audio_bytes: bytes, mime_type: str, user_id: str | Non
     await asyncio.to_thread(filepath.write_bytes, audio_bytes)
     logger.info("Saved audio: %s (%d bytes, %s)", filename, len(audio_bytes), mime_type)
     return f"/api/media/{filename}"
+
+
+# ---------------------------------------------------------------------------
+# 缩略图：按需生成 + 落盘缓存（仅本地后端使用，S3 后端走原图重定向）
+# ---------------------------------------------------------------------------
+
+# Pillow 保存参数：扩展名 -> (format, save_kwargs)
+_PIL_SAVE_PARAMS = {
+    "jpg":  ("JPEG", {"quality": 82, "optimize": True, "progressive": True}),
+    "jpeg": ("JPEG", {"quality": 82, "optimize": True, "progressive": True}),
+    "png":  ("PNG",  {"optimize": True}),
+    "webp": ("WEBP", {"quality": 82, "method": 6}),
+    "gif":  ("GIF",  {}),
+}
+
+# JPEG 不支持透明通道，需要先转换的 mode 集合
+_JPEG_NON_RGB_MODES = {"RGBA", "LA", "P"}
+
+# 是否需要在保存前转 RGB（表驱动避免 if-else）
+_NEEDS_RGB_CONVERT = {
+    ("jpg",  True): True,  ("jpg",  False): False,
+    ("jpeg", True): True,  ("jpeg", False): False,
+}
+
+
+def to_thumb_url(url: str) -> str:
+    """将媒体 URL 改写为缩略图 URL；非本地媒体或已是 thumb 时原样返回。
+
+    /api/media/abc.png      → /api/media/thumb/abc.png
+    /api/media/thumb/x.png  → 原样
+    https://cdn.x/y.png     → 原样
+    """
+    is_media = url.startswith(MEDIA_URL_PREFIX)
+    is_thumb = url.startswith(THUMB_URL_PREFIX)
+    rewriters = {
+        (True,  False): lambda u: THUMB_URL_PREFIX + u[len(MEDIA_URL_PREFIX):],
+        (True,  True):  lambda u: u,
+        (False, False): lambda u: u,
+    }
+    return rewriters[(is_media, is_thumb)](url)
+
+
+def _generate_image_thumbnail(src: Path, dst: Path, max_size: int) -> None:
+    """同步生成等比缩略图：长边 ≤ max_size。写入临时文件再原子替换，避免并发读到半成品。"""
+    from PIL import Image, ImageOps
+
+    ext = dst.suffix.lstrip(".").lower()
+    fmt, save_kwargs = _PIL_SAVE_PARAMS.get(ext, _PIL_SAVE_PARAMS["jpg"])
+    tmp = dst.with_suffix(dst.suffix + f".{uuid.uuid4().hex}.tmp")
+
+    with Image.open(src) as img:
+        # 按 EXIF orientation 修正方向（手机拍摄常见）
+        img = ImageOps.exif_transpose(img)
+        # JPEG 不支持透明，需要时先合到白底
+        needs_rgb = _NEEDS_RGB_CONVERT.get((ext, img.mode in _JPEG_NON_RGB_MODES), False)
+        needs_rgb and (img := img.convert("RGB"))
+        img.thumbnail((max_size, max_size), Image.Resampling.LANCZOS)
+        img.save(tmp, format=fmt, **save_kwargs)
+
+    tmp.replace(dst)
+
+
+async def ensure_thumbnail(filename: str, max_size: int = THUMB_MAX_SIZE) -> Path | None:
+    """确保 filename 的缩略图已存在，返回缩略图磁盘路径；原文件缺失返回 None。
+
+    缓存命中：直接返回；未命中：在线程池里调用 Pillow 生成。
+    """
+    THUMB_DIR.mkdir(parents=True, exist_ok=True)
+    thumb_path = THUMB_DIR / filename
+
+    # 已落盘 → 命中，直接返回
+    if thumb_path.is_file():
+        return thumb_path
+
+    src = resolve_media_filepath(filename)
+    if src is None:
+        return None
+
+    try:
+        await asyncio.to_thread(_generate_image_thumbnail, src, thumb_path, max_size)
+    except Exception as exc:
+        logger.warning("Thumbnail generation failed for %s: %s", filename, exc)
+        return None
+
+    return thumb_path

--- a/backend/services/theater.py
+++ b/backend/services/theater.py
@@ -10,12 +10,15 @@ from schemas import (
     TheaterCreate, TheaterUpdate, TheaterSaveRequest,
     TheaterNodeCreate, TheaterEdgeCreate,
 )
+from services.media_utils import to_thumb_url
 
 
 # 节点类型 -> 从 node.data 中提取封面候选 URL 的取值器。
 # 表驱动避免 if 分支，新增类型只需追加一行。
+# image 节点输出 thumb 路径供首页/列表场景使用；video 节点的 thumbnail 通常是远端
+# 生成供商返回的小图，体积已小，不再限制。
 _THUMBNAIL_EXTRACTORS = {
-    "image": lambda data: data.get("imageUrl"),
+    "image": lambda data: to_thumb_url(data.get("imageUrl") or ""),
     "video": lambda data: data.get("thumbnail") or data.get("videoUrl"),
 }
 

--- a/frontend/src/app/resources/page.tsx
+++ b/frontend/src/app/resources/page.tsx
@@ -852,7 +852,8 @@ export default function ResourcesPage() {
                     initial={{ opacity: 0, y: 20 }}
                     animate={{ opacity: 1, y: 0 }}
                     exit={{ opacity: 0, scale: 0.9 }}
-                    transition={{ delay: index * 0.03 }}
+                    // 入场延迟封顶：避免翻页后靠后的卡片需等几十秒才出现
+                    transition={{ delay: Math.min(index, 12) * 0.03 }}
                     layout
                     data-asset-id={asset.id}
                   >

--- a/frontend/src/components/canvas/Sidebar.tsx
+++ b/frontend/src/components/canvas/Sidebar.tsx
@@ -6,6 +6,7 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { resourceApi, AssetItem } from '@/lib/resourceApi';
+import { toThumbUrl } from '@/lib/mediaUrl';
 
 const NODE_TYPES = [
   { 
@@ -327,7 +328,7 @@ export const Sidebar = () => {
                       className="group relative rounded-lg border border-border/50 overflow-hidden cursor-grab active:cursor-grabbing bg-secondary/50 hover:border-node-green/50 transition-colors h-[80px] flex items-center justify-center"
                     >
                       <img 
-                        src={asset.url} 
+                        src={toThumbUrl(asset.url)} 
                         alt={asset.original_name || asset.filename} 
                         loading="lazy"
                         draggable={false}

--- a/frontend/src/components/home/RecentTheaters.tsx
+++ b/frontend/src/components/home/RecentTheaters.tsx
@@ -10,6 +10,7 @@ import TheaterCard from "./TheaterCard";
 import CreateTheaterCard from "./CreateTheaterCard";
 import { useAuth } from "@/context/AuthContext";
 import { theaterApi, type TheaterResponse } from "@/lib/theaterApi";
+import { theaterListCache } from "@/lib/theaterListCache";
 
 export default function RecentTheaters() {
   const { t } = useTranslation();
@@ -42,21 +43,36 @@ export default function RecentTheaters() {
     // 仅拉列表，不再为「补封面」拉完整画布详情。
     // 后端在 save_canvas 时会自动维护 thumbnail_url；未生成的剧场直接留白占位。
     //
-    // 不再用 fetched ref 做去重守卫：StrictMode 下双调用会让守卫位与取消逻辑互锁，
-    // 导致 loading 永远不释放。cancelled + AbortController 已足够防止竟态并发。
+    // 缓存策略（stale-while-revalidate）：
+    //   1. 命中缓存 → 立即渲染并关闭 loading，避免「进首页都转一下」
+    //   2. 新鲜期内（1 分钟）不发请求；超期后台静默重拉
+    //   3. 静默重拉失败不清空原有列表，避免闪空
+    //
+    // 不再用 fetched ref 做去重守卫：StrictMode 下双调用会让守卫位与取消逻辑互锁。
+    const cached = theaterListCache.peek();
+    const hasCache = cached !== null;
+    hasCache && setTheaters(cached);
+    hasCache && setLoading(false);
+
+    // 新鲜期内跳过后台刷新
+    if (theaterListCache.isFresh()) return;
+
     const controller = new AbortController();
     let cancelled = false;
 
-    setLoading(true);
+    // 无缓存才展示 loading；有缓存静默后台刷新
+    hasCache || setLoading(true);
 
     theaterApi
       .listTheaters(1, 20, undefined, controller.signal)
       .then((listRes) => {
-        cancelled || setTheaters(listRes.items);
+        if (cancelled) return;
+        setTheaters(listRes.items);
+        theaterListCache.set(listRes.items);
       })
       .catch(() => {
-        // 被 abort 时 cancelled 已为 true，这里不会误清空列表
-        cancelled || setTheaters([]);
+        // 失败时：有缓存 → 保留旧数据；无缓存 → 置空
+        cancelled || hasCache || setTheaters([]);
       })
       .finally(() => {
         cancelled || setLoading(false);
@@ -72,6 +88,8 @@ export default function RecentTheaters() {
     try {
       const updatedTheater = await theaterApi.updateTheater(id, { title: newTitle });
       setTheaters((prev) => prev.map((th) => (th.id === id ? { ...th, title: updatedTheater.title } : th)));
+      // 同步缓存：下次进首页不会看到老标题闪现
+      theaterListCache.upsert({ ...updatedTheater } as TheaterResponse);
     } catch (err) {
       console.error("Failed to rename theater:", err);
       alert(t("home.renameFailed"));
@@ -82,6 +100,7 @@ export default function RecentTheaters() {
     try {
       const newTheater = await theaterApi.duplicateTheater(id);
       setTheaters((prev) => [newTheater, ...prev]);
+      theaterListCache.upsert(newTheater, "head");
     } catch (err) {
       console.error("Failed to duplicate theater:", err);
       alert(t("home.duplicateFailed"));
@@ -94,6 +113,7 @@ export default function RecentTheaters() {
       // 先重置拖拽位置到起始点，再更新列表，避免约束冲突
       controls.set({ x: 0 });
       setTheaters((prev) => prev.filter((th) => th.id !== id));
+      theaterListCache.remove(id);
     } catch (err) {
       console.error("Failed to delete theater:", err);
       alert(t("home.deleteFailed"));

--- a/frontend/src/components/resources/AssetCard.tsx
+++ b/frontend/src/components/resources/AssetCard.tsx
@@ -5,6 +5,7 @@ import { motion } from "framer-motion";
 import { Image as ImageIcon, Video, Music, File, MoreHorizontal, Pencil, Replace, Trash2, ExternalLink, Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { AssetItem } from "@/lib/resourceApi";
+import { toThumbUrl } from "@/lib/mediaUrl";
 import {
   DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
@@ -43,7 +44,8 @@ function formatDate(dateStr: string): string {
 // ---------------------------------------------------------------------------
 
 function ImagePreview({ url }: { url: string }) {
-  return <img src={url} alt="" loading="lazy" className="w-full h-full object-cover" />;
+  // 列表场景使用缩略图，原图仅在预览/下载时加载
+  return <img src={toThumbUrl(url)} alt="" loading="lazy" className="w-full h-full object-cover" />;
 }
 
 function VideoPreview({ url }: { url: string }) {

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -9,6 +9,8 @@ import React, {
 } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import api, { tokenRefresher } from "@/lib/api";
+import { theaterListCache } from "@/lib/theaterListCache";
+import { useResourceStore } from "@/store/useResourceStore";
 
 export interface User {
   id: string;
@@ -222,6 +224,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     localStorage.removeItem("user");
     setUser(null);
     setIsAuthenticated(false);
+    // 退出后清除首页「最近剧场」内存缓存与资产库缓存，避免下一位用户看到上一人的快照
+    theaterListCache.invalidate();
+    useResourceStore.getState().reset();
     router.push("/login");
   }, [router]);
 

--- a/frontend/src/lib/mediaUrl.ts
+++ b/frontend/src/lib/mediaUrl.ts
@@ -1,0 +1,26 @@
+/**
+ * 媒体 URL 改写工具：将本地媒体路径改写为缩略图路径，供首页/列表/资产库等小图场景使用。
+ *
+ * /api/media/abc.png      → /api/media/thumb/abc.png
+ * /api/media/thumb/x.png  → 原样
+ * https://cdn.x/y.png     → 原样
+ * ""                      → 原样
+ *
+ * 与 backend/services/media_utils.py 的 to_thumb_url 行为保持一致。
+ */
+const MEDIA_URL_PREFIX = "/api/media/";
+const THUMB_URL_PREFIX = "/api/media/thumb/";
+
+// 表驱动改写器，避免 if 分支
+const REWRITERS: Record<string, (u: string) => string> = {
+  "true,false": (u) => THUMB_URL_PREFIX + u.slice(MEDIA_URL_PREFIX.length),
+  "true,true":  (u) => u,
+  "false,false": (u) => u,
+};
+
+export function toThumbUrl(url: string | null | undefined): string {
+  const safe = url ?? "";
+  const isMedia = safe.startsWith(MEDIA_URL_PREFIX);
+  const isThumb = safe.startsWith(THUMB_URL_PREFIX);
+  return REWRITERS[`${isMedia},${isThumb}`](safe);
+}

--- a/frontend/src/lib/theaterListCache.ts
+++ b/frontend/src/lib/theaterListCache.ts
@@ -1,0 +1,74 @@
+/**
+ * 首页「最近剧场」列表客户端缓存（模块单例 + 内存级，进程内有效）。
+ *
+ * 设计目标：
+ *   - 用户在「首页 ↔ 剧场详情 ↔ 资产库」之间来回跳转时，避免每次回首页都重新发请求 + 重新转 loading。
+ *   - 即使缓存陈旧也允许先用作占位渲染，再静默后台刷新（stale-while-revalidate）。
+ *   - 局部增删改（rename / duplicate / delete / saveCanvas）必须能精确同步到缓存，避免 UI 与缓存不一致。
+ *
+ * 容量与生命周期：
+ *   - 仅缓存第一页（page=1, page_size=20），与 RecentTheaters 当前消费形态一致。
+ *   - 模块单例随页面会话存在；用户登出 / 切换账号时由调用方主动 invalidate。
+ *   - 不落 localStorage，避免 SSR 不一致与多账号污染。
+ */
+import type { TheaterResponse } from "@/lib/theaterApi";
+
+/** 新鲜窗口：1 分钟内视为新鲜，超过则触发后台刷新但仍可作占位 */
+const FRESH_TTL_MS = 60_000;
+
+interface Snapshot {
+  items: TheaterResponse[];
+  ts: number;
+}
+
+let snapshot: Snapshot | null = null;
+
+export const theaterListCache = {
+  /**
+   * 任意可用的快照（无论是否新鲜）。用于组件 mount 时立即占位渲染，避免 loading 闪烁。
+   */
+  peek(): TheaterResponse[] | null {
+    return snapshot ? snapshot.items : null;
+  },
+
+  /** 是否仍在新鲜窗口内。新鲜则可跳过后台刷新；陈旧则需 stale-while-revalidate。 */
+  isFresh(): boolean {
+    return !!snapshot && Date.now() - snapshot.ts < FRESH_TTL_MS;
+  },
+
+  /** 写入完整快照（接口返回成功后调用） */
+  set(items: TheaterResponse[]): void {
+    snapshot = { items, ts: Date.now() };
+  },
+
+  /** 完全失效。下次访问会真正发请求重拉（saveCanvas / 切换账号 / 强制刷新等场景）。 */
+  invalidate(): void {
+    snapshot = null;
+  },
+
+  /**
+   * 局部更新或插入。
+   *  - 已存在：原位替换（同步最新 title / thumbnail_url / updated_at 等）
+   *  - 不存在：按 `mode` 决定插入位置
+   *      head（默认）：放在最前，对应「新建 / 复制」语义
+   *      tail：放到最后，对应不影响首屏顺序的兜底
+   */
+  upsert(theater: TheaterResponse, mode: "head" | "tail" = "head"): void {
+    if (!snapshot) return;
+    const idx = snapshot.items.findIndex((x) => x.id === theater.id);
+    const exists = idx >= 0;
+    snapshot.items = exists
+      ? snapshot.items.map((x, k) => (k === idx ? theater : x))
+      : mode === "head"
+        ? [theater, ...snapshot.items]
+        : [...snapshot.items, theater];
+    snapshot.ts = Date.now();
+  },
+
+  /** 移除指定剧场，对应删除语义 */
+  remove(id: string): void {
+    if (!snapshot) return;
+    snapshot.items = snapshot.items.filter((x) => x.id !== id);
+    snapshot.ts = Date.now();
+  },
+};

--- a/frontend/src/store/useCanvasStore.ts
+++ b/frontend/src/store/useCanvasStore.ts
@@ -26,6 +26,7 @@ import {
   type TheaterEdgeCreate,
   type TheaterDetailResponse,
 } from '@/lib/theaterApi';
+import { theaterListCache } from '@/lib/theaterListCache';
 
 // Define Node Data Types
 export type ScriptNodeData = {
@@ -728,6 +729,9 @@ export const useCanvasStore = create<CanvasState>()(
             lastSavedAt: Date.now(),
             // Sync node_count etc from server response (but keep local nodes/edges as source of truth)
           });
+          // 保存画布后，后端可能重新选取 thumbnail_url；node_count / updated_at 也会变。
+          // 失效首页「最近剧场」缓存，给用户下次返回首页拿到最新快照。
+          theaterListCache.invalidate();
           // Optionally sync back IDs for new nodes
           void detail;
         } catch (err) {

--- a/frontend/src/store/useResourceStore.ts
+++ b/frontend/src/store/useResourceStore.ts
@@ -15,6 +15,17 @@ export interface UploadQueueItem {
   error?: string;
 }
 
+// 按 typeFilter 分键的快照缓存：进入/切回资产库立即还原，避免 loading 闪烁。
+interface CacheSnapshot {
+  assets: AssetItem[];
+  total: number;
+  page: number;
+  hasMore: boolean;
+  ts: number;
+}
+
+const FRESH_TTL_MS = 60_000;
+
 interface ResourceState {
   // 资产数据
   assets: AssetItem[];
@@ -28,6 +39,9 @@ interface ResourceState {
   // 上传队列
   uploadQueue: UploadQueueItem[];
 
+  // SWR 快照：按 filter 分键，仅在内存，管线生命周期随页面刷新。
+  _cache: Partial<Record<FileTypeFilter, CacheSnapshot>>;
+
   // Actions
   fetchAssets: (options?: { pageSize?: number; typeFilter?: FileTypeFilter }) => Promise<void>;
   loadMore: () => Promise<void>;
@@ -40,6 +54,8 @@ interface ResourceState {
   batchDeleteAssets: (ids: string[]) => Promise<number>;
   /** 从外部上传（如画布）同步新资产到 store */
   syncAssetFromUpload: (asset: AssetItem | Record<string, unknown>) => void;
+  /** 失效所有 filter 的缓存快照，下次访问重拉。 */
+  invalidateCache: () => void;
   reset: () => void;
 }
 
@@ -48,6 +64,17 @@ interface ResourceState {
 // ---------------------------------------------------------------------------
 
 let _uploadCounter = 0;
+
+// 从当前 state 生成某个 filter 的快照
+function snapshotOf(
+  filter: FileTypeFilter,
+  assets: AssetItem[],
+  total: number,
+  page: number,
+  hasMore: boolean,
+): { [k in FileTypeFilter]?: CacheSnapshot } {
+  return { [filter]: { assets, total, page, hasMore, ts: Date.now() } };
+}
 
 export const useResourceStore = create<ResourceState>((set, get) => ({
   assets: [],
@@ -58,19 +85,45 @@ export const useResourceStore = create<ResourceState>((set, get) => ({
   isLoading: false,
   hasMore: false,
   uploadQueue: [],
+  _cache: {},
 
   async fetchAssets(options) {
     const size = options?.pageSize ?? get().pageSize;
     const filter = options?.typeFilter ?? get().typeFilter;
-    set({ isLoading: true, page: 1 });
+    const cache = get()._cache[filter];
+    const fresh = !!cache && Date.now() - cache.ts < FRESH_TTL_MS;
+
+    // 命中且新鲜：直接还原快照，不走 loading
+    fresh && cache && set({
+      assets: cache.assets,
+      total: cache.total,
+      page: cache.page,
+      hasMore: cache.hasMore,
+      typeFilter: filter,
+      isLoading: false,
+    });
+    if (fresh) return;
+
+    // 有 stale 数据（同 filter）：SWR 模式 — 保留旧数据不闪 loading。
+    const hasStale = !!cache && cache.assets.length > 0;
+    set({ typeFilter: filter, isLoading: !hasStale });
+    hasStale && cache && set({
+      assets: cache.assets,
+      total: cache.total,
+      page: cache.page,
+      hasMore: cache.hasMore,
+    });
+
     try {
       const res = await resourceApi.listAssets(1, size, filter);
-      set({
+      const hasMore = res.items.length < res.total;
+      set((s) => ({
         assets: res.items,
         total: res.total,
         page: 1,
-        hasMore: res.items.length < res.total,
-      });
+        hasMore,
+        _cache: { ...s._cache, ...snapshotOf(filter, res.items, res.total, 1, hasMore) },
+      }));
     } finally {
       set({ isLoading: false });
     }
@@ -86,20 +139,23 @@ export const useResourceStore = create<ResourceState>((set, get) => ({
     try {
       const res = await resourceApi.listAssets(nextPage, pageSize, typeFilter);
       const merged = [...assets, ...res.items];
-      set({
+      const hasMore = merged.length < res.total;
+      set((s) => ({
         assets: merged,
         total: res.total,
         page: nextPage,
-        hasMore: merged.length < res.total,
-      });
+        hasMore,
+        _cache: { ...s._cache, ...snapshotOf(typeFilter, merged, res.total, nextPage, hasMore) },
+      }));
     } finally {
       set({ isLoading: false });
     }
   },
 
   setTypeFilter(type) {
-    set({ typeFilter: type, assets: [], total: 0, page: 1 });
-    get().fetchAssets();
+    // 只记录新 filter；fetchAssets 内部会处理快照还原 / 重拉
+    set({ typeFilter: type });
+    get().fetchAssets({ typeFilter: type });
   },
 
   addUpload(file) {
@@ -117,10 +173,11 @@ export const useResourceStore = create<ResourceState>((set, get) => ({
       })
       .then((res) => {
         set((s) => ({
-          // 上传成功：将新资产添加到列表头部，移除上传队列项
+          // 上传成功：新资产添加到列表头部，移除上传队列项，并失效所有缓存
           assets: [res.asset, ...s.assets],
           total: s.total + 1,
           uploadQueue: s.uploadQueue.filter((q) => q.id !== id),
+          _cache: {},
         }));
       })
       .catch((err) => {
@@ -140,6 +197,7 @@ export const useResourceStore = create<ResourceState>((set, get) => ({
     const updated = await resourceApi.updateAsset(id, { original_name: name });
     set((s) => ({
       assets: s.assets.map((a) => (a.id === id ? { ...a, ...updated } : a)),
+      _cache: {},
     }));
   },
 
@@ -147,6 +205,7 @@ export const useResourceStore = create<ResourceState>((set, get) => ({
     const updated = await resourceApi.updateAsset(id, { file });
     set((s) => ({
       assets: s.assets.map((a) => (a.id === id ? { ...a, ...updated } : a)),
+      _cache: {},
     }));
   },
 
@@ -155,15 +214,17 @@ export const useResourceStore = create<ResourceState>((set, get) => ({
     set((s) => ({
       assets: s.assets.filter((a) => a.id !== id),
       total: s.total - 1,
+      _cache: {},
     }));
   },
 
   async batchDeleteAssets(ids) {
     const idSet = new Set(ids);
-    // 乐观更新：先从 UI 移除
+    // 乐观更新：先从 UI 移除并失效缓存
     set((s) => ({
       assets: s.assets.filter((a) => !idSet.has(a.id)),
       total: Math.max(0, s.total - ids.length),
+      _cache: {},
     }));
     try {
       const res = await resourceApi.batchDeleteAssets(ids);
@@ -177,13 +238,17 @@ export const useResourceStore = create<ResourceState>((set, get) => ({
 
   syncAssetFromUpload(asset) {
     const assetItem = asset as AssetItem;
-    // 避免重复添加
+    // 避免重复添加，同时失效缓存以重拉主源
     set((s) => {
       const exists = s.assets.some((a) => a.id === assetItem.id);
       return exists
         ? s
-        : { assets: [assetItem, ...s.assets], total: s.total + 1 };
+        : { assets: [assetItem, ...s.assets], total: s.total + 1, _cache: {} };
     });
+  },
+
+  invalidateCache() {
+    set({ _cache: {} });
   },
 
   reset() {
@@ -195,6 +260,7 @@ export const useResourceStore = create<ResourceState>((set, get) => ({
       isLoading: false,
       hasMore: false,
       uploadQueue: [],
+      _cache: {},
     });
   },
 }));


### PR DESCRIPTION
- 新增 _SAFE_THUMB_FILENAME 验证规则以支持缩略图文件名安全检查
- upload_media 处理上传时增加缩略图生成和存储支持
- 调整资源删除逻辑，确保删除关联缩略图文件
- 优化文件路径管理，兼容平铺和隔离目录结构
- 日志记录增强，便于跟踪资源文件操作情况

## ⚠️ 部署后必须执行的一次性动作
本 PR 引入新增端点 /api/media/thumb/{filename} 并把 [theater.py]的 image extractor 改成输出缩略图路径。新建剧场自动接入；存量剧场的 theater.thumbnail_url 仍指向原图，需运行一次性迁移脚本回填。

```
# 1. 拉新代码并重启 backend（让 thumb 端点 + 迁移脚本进容器）
git pull && bash deploy/scripts/update.sh

# 2. dry-run 预览要改的记录（不写库）
docker exec -it kunflix-backend \
  python -m scripts.migrate_theater_thumbnails_to_thumb --dry-run

# 3. 确认无误后正式执行
docker exec -it kunflix-backend \
  python -m scripts.migrate_theater_thumbnails_to_thumb
```

##注意：新部署或前端无剧场的无需执行这个脚本。