### PR TITLE
feat(resources): 实现资产预览对话框及多项拖拽改进

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -42,12 +42,19 @@ services:
   redis:
     image: redis:7-alpine
     container_name: kunflix-redis
+    # 注：REDIS_PASSWORD 既要在编排期被 Compose 注入到 --requirepass，
+    # 也必须以环境变量形式存在于容器内，否则 healthcheck 里的
+    # `redis-cli -a $REDIS_PASSWORD` 在容器 shell 中展开为空，触发 NOAUTH
+    # 导致容器始终 unhealthy（业务实际可用，但 update.sh 健康检查超时）。
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
     command: ["redis-server", "/usr/local/etc/redis/redis.conf", "--requirepass", "${REDIS_PASSWORD}"]
     volumes:
       - ./redis/redis.conf:/usr/local/etc/redis/redis.conf:ro
       - redisdata:/data
     healthcheck:
-      test: ["CMD-SHELL", "redis-cli -a $${REDIS_PASSWORD} ping | grep -q PONG"]
+      # 用单引号包裹 -a 的密码，避免特殊字符被容器 shell 二次解析
+      test: ["CMD-SHELL", "redis-cli -a \"$$REDIS_PASSWORD\" --no-auth-warning ping | grep -q PONG"]
       interval: 10s
       timeout: 3s
       retries: 5

--- a/frontend/src/app/resources/page.tsx
+++ b/frontend/src/app/resources/page.tsx
@@ -162,6 +162,8 @@ export default function ResourcesPage() {
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
     setIsDragOver(false);
+    // 仅接受 OS 文件拖拽；过滤页面内元素（如预览图片）冒泡过来的拖拽
+    if (!Array.from(e.dataTransfer.types).includes("Files")) return;
     handleFiles(e.dataTransfer.files);
   };
 
@@ -784,7 +786,12 @@ export default function ResourcesPage() {
         {/* Asset Grid / List with Drag Overlay */}
         <div 
           className="relative"
-          onDragOver={(e) => { e.preventDefault(); setIsDragOver(true); }}
+          onDragOver={(e) => {
+            // 仅在拖动 OS 文件时激活上传高亮；页面内元素拖拽直接忽略
+            if (!Array.from(e.dataTransfer.types).includes("Files")) return;
+            e.preventDefault();
+            setIsDragOver(true);
+          }}
           onDragLeave={() => setIsDragOver(false)}
           onDrop={handleDrop}
         >
@@ -907,6 +914,8 @@ export default function ResourcesPage() {
       {/* Dialogs */}
       <AssetPreviewDialog
         asset={previewTarget}
+        assets={assets}
+        onNavigate={setPreviewTarget}
         onClose={() => setPreviewTarget(null)}
       />
       <AssetEditDialog

--- a/frontend/src/components/resources/AssetCard.tsx
+++ b/frontend/src/components/resources/AssetCard.tsx
@@ -45,13 +45,31 @@ function formatDate(dateStr: string): string {
 
 function ImagePreview({ url }: { url: string }) {
   // 列表场景使用缩略图，原图仅在预览/下载时加载
-  return <img src={toThumbUrl(url)} alt="" loading="lazy" className="w-full h-full object-cover" />;
+  // 禁用原生拖拽，避免用户从缩略图拖出后被页面拖拽上传区误推为文件上传
+  return (
+    <img
+      src={toThumbUrl(url)}
+      alt=""
+      loading="lazy"
+      draggable={false}
+      onDragStart={(e) => e.preventDefault()}
+      className="w-full h-full object-cover"
+    />
+  );
 }
 
 function VideoPreview({ url }: { url: string }) {
   return (
     <div className="relative w-full h-full bg-black/80">
-      <video src={`${url}#t=0.5`} preload="metadata" muted playsInline className="w-full h-full object-cover opacity-60" />
+      <video
+        src={`${url}#t=0.5`}
+        preload="metadata"
+        muted
+        playsInline
+        draggable={false}
+        onDragStart={(e) => e.preventDefault()}
+        className="w-full h-full object-cover opacity-60"
+      />
       <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
         <div className="w-8 h-8 rounded-full bg-black/50 backdrop-blur flex items-center justify-center">
           <div className="w-0 h-0 border-t-[5px] border-t-transparent border-l-[8px] border-l-white border-b-[5px] border-b-transparent ml-0.5" />
@@ -65,7 +83,14 @@ function AudioPreview({ url }: { url: string }) {
   return (
     <div className="w-full h-full flex flex-col items-center justify-center gap-3 bg-secondary/50 p-4">
       <Music className="w-10 h-10 text-muted-foreground/30" />
-      <audio src={url} controls preload="metadata" className="w-full max-w-full h-8 [&::-webkit-media-controls-panel]:bg-transparent" />
+      <audio
+        src={url}
+        controls
+        preload="metadata"
+        draggable={false}
+        onDragStart={(e) => e.preventDefault()}
+        className="w-full max-w-full h-8 [&::-webkit-media-controls-panel]:bg-transparent"
+      />
     </div>
   );
 }

--- a/frontend/src/components/resources/AssetPreviewDialog.tsx
+++ b/frontend/src/components/resources/AssetPreviewDialog.tsx
@@ -1,38 +1,71 @@
 "use client";
 
-import React from "react";
-import { X, Download } from "lucide-react";
-import { AssetItem } from "@/lib/resourceApi";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ChevronLeft, ChevronRight, Download, X, ZoomIn, ZoomOut } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { AssetItem } from "@/lib/resourceApi";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ImageViewState {
+  scale: number;
+  position: { x: number; y: number };
+  isDragging: boolean;
+}
+
+interface RendererProps {
+  asset: AssetItem;
+  view: ImageViewState;
+  onPointerDown: (e: React.PointerEvent) => void;
+  onPointerMove: (e: React.PointerEvent) => void;
+  onPointerUp: (e: React.PointerEvent) => void;
+}
 
 // ---------------------------------------------------------------------------
 // 预览渲染器映射表（避免 if-else）
 // ---------------------------------------------------------------------------
 
-function ImageFullPreview({ asset }: { asset: AssetItem }) {
+function ImageFullPreview({ asset, view, onPointerDown, onPointerMove, onPointerUp }: RendererProps) {
   return (
     <img
       src={asset.url}
       alt={asset.original_name || asset.filename}
-      className="max-w-full max-h-[80vh] object-contain rounded-lg"
+      className="max-w-[80vw] max-h-[75vh] object-contain rounded-lg select-none transition-transform duration-75 ease-out"
+      style={{
+        transform: `translate(${view.position.x}px, ${view.position.y}px) scale(${view.scale})`,
+        cursor: view.isDragging ? "grabbing" : "grab",
+      }}
+      draggable={false}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onClick={(e) => e.stopPropagation()}
     />
   );
 }
 
-function VideoFullPreview({ asset }: { asset: AssetItem }) {
+function VideoFullPreview({ asset }: RendererProps) {
   return (
     <video
       src={asset.url}
       controls
       autoPlay
-      className="max-w-full max-h-[80vh] rounded-lg"
+      className="max-w-[80vw] max-h-[75vh] rounded-lg"
+      onClick={(e) => e.stopPropagation()}
     />
   );
 }
 
-function AudioFullPreview({ asset }: { asset: AssetItem }) {
+function AudioFullPreview({ asset }: RendererProps) {
   return (
-    <div className="flex flex-col items-center gap-6 p-8 bg-secondary/30 rounded-xl min-w-[360px]">
+    <div
+      className="flex flex-col items-center gap-6 p-8 bg-secondary/30 rounded-xl min-w-[360px]"
+      onClick={(e) => e.stopPropagation()}
+    >
       <div className="w-24 h-24 rounded-full bg-primary/10 flex items-center justify-center">
         <div className="w-12 h-12 rounded-full bg-primary/20 flex items-center justify-center">
           <div className="w-0 h-0 border-t-[10px] border-t-transparent border-l-[16px] border-l-primary border-b-[10px] border-b-transparent ml-1" />
@@ -46,7 +79,7 @@ function AudioFullPreview({ asset }: { asset: AssetItem }) {
   );
 }
 
-const FULL_PREVIEW_RENDERERS: Record<string, React.FC<{ asset: AssetItem }>> = {
+const FULL_PREVIEW_RENDERERS: Record<string, React.FC<RendererProps>> = {
   image: ImageFullPreview,
   video: VideoFullPreview,
   audio: AudioFullPreview,
@@ -58,40 +91,244 @@ const FULL_PREVIEW_RENDERERS: Record<string, React.FC<{ asset: AssetItem }>> = {
 
 interface AssetPreviewDialogProps {
   asset: AssetItem | null;
+  /** 资产列表，用于左右切换；不传则不显示切换按钮 */
+  assets?: AssetItem[];
+  /** 切换到指定资产时的回调（更新外部 previewTarget） */
+  onNavigate?: (asset: AssetItem) => void;
   onClose: () => void;
 }
 
-export default function AssetPreviewDialog({ asset, onClose }: AssetPreviewDialogProps) {
+const SCALE_MIN = 0.1;
+const SCALE_MAX = 5;
+const SCALE_STEP = 0.25;
+
+export default function AssetPreviewDialog({ asset, assets, onNavigate, onClose }: AssetPreviewDialogProps) {
+  const { t } = useTranslation();
   const Renderer = FULL_PREVIEW_RENDERERS[asset?.file_type ?? ""];
+  const isImage = asset?.file_type === "image";
+
+  // ----- 缩放/拖拽状态（仅图像有效） -----
+  const [scale, setScale] = useState(1);
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+  const [isDragging, setIsDragging] = useState(false);
+  const dragStartRef = useRef({ x: 0, y: 0 });
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  // 切换 asset 时重置视图
+  useEffect(() => {
+    setScale(1);
+    setPosition({ x: 0, y: 0 });
+    setIsDragging(false);
+  }, [asset?.id]);
+
+  // ----- 切换索引 -----
+  const list = assets ?? [];
+  const currentIndex = asset ? list.findIndex((a) => a.id === asset.id) : -1;
+  const canPrev = currentIndex > 0;
+  const canNext = currentIndex >= 0 && currentIndex < list.length - 1;
+
+  const goPrev = useCallback(() => {
+    canPrev && onNavigate?.(list[currentIndex - 1]);
+  }, [canPrev, currentIndex, list, onNavigate]);
+
+  const goNext = useCallback(() => {
+    canNext && onNavigate?.(list[currentIndex + 1]);
+  }, [canNext, currentIndex, list, onNavigate]);
+
+  const zoomIn = useCallback(() => setScale((p) => Math.min(SCALE_MAX, p + SCALE_STEP)), []);
+  const zoomOut = useCallback(() => setScale((p) => Math.max(SCALE_MIN, p - SCALE_STEP)), []);
+
+  // ----- 键盘快捷键：左右切换 + 上下缩放 -----
+  useEffect(() => {
+    if (!asset) return;
+    const handler = (e: KeyboardEvent) => {
+      const tag = (e.target as HTMLElement | null)?.tagName?.toLowerCase();
+      if (tag === "input" || tag === "textarea") return;
+      e.key === "ArrowLeft" && (e.preventDefault(), goPrev());
+      e.key === "ArrowRight" && (e.preventDefault(), goNext());
+      isImage && e.key === "ArrowUp" && (e.preventDefault(), zoomIn());
+      isImage && e.key === "ArrowDown" && (e.preventDefault(), zoomOut());
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [asset, isImage, goPrev, goNext, zoomIn, zoomOut]);
+
+  // ----- 滚轮缩放（仅图像）：window 级别监听 + 容器内目标校验 -----
+  useEffect(() => {
+    if (!asset || !isImage) return;
+    const handleWheel = (e: WheelEvent) => {
+      const target = e.target as Node | null;
+      if (!target || !containerRef.current?.contains(target)) return;
+      e.preventDefault();
+      // 乘性缩放更符合人眼感知；指数补偿使不同设备 deltaY 表现一致
+      setScale((prev) => {
+        const factor = Math.exp(-e.deltaY * 0.0015);
+        return Math.min(Math.max(SCALE_MIN, prev * factor), SCALE_MAX);
+      });
+    };
+    window.addEventListener("wheel", handleWheel, { passive: false });
+    return () => window.removeEventListener("wheel", handleWheel);
+  }, [asset, isImage]);
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      if (e.button !== 0 || !isImage) return;
+      setIsDragging(true);
+      dragStartRef.current = { x: e.clientX - position.x, y: e.clientY - position.y };
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    },
+    [isImage, position.x, position.y],
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      isDragging && setPosition({
+        x: e.clientX - dragStartRef.current.x,
+        y: e.clientY - dragStartRef.current.y,
+      });
+    },
+    [isDragging],
+  );
+
+  const handlePointerUp = useCallback((e: React.PointerEvent) => {
+    setIsDragging(false);
+    (e.target as HTMLElement).releasePointerCapture(e.pointerId);
+  }, []);
+
+  // ----- 下载 -----
+  const handleDownload = useCallback(async () => {
+    if (!asset) return;
+    const url = asset.url;
+    const name = asset.original_name || asset.filename || "asset";
+    const fallback = () => window.open(url, "_blank");
+    try {
+      const resp = await fetch(url, { mode: "cors" });
+      if (!resp.ok) return fallback();
+      const blob = await resp.blob();
+      const blobUrl = URL.createObjectURL(blob);
+      const ext = (blob.type.split("/")[1] || "bin").split(";")[0];
+      const safeName = name.replace(/[\\/:*?"<>|]/g, "_");
+      const link = document.createElement("a");
+      link.href = blobUrl;
+      link.download = /\.[a-z0-9]+$/i.test(safeName) ? safeName : `${safeName}.${ext}`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      setTimeout(() => URL.revokeObjectURL(blobUrl), 1000);
+    } catch {
+      fallback();
+    }
+  }, [asset]);
+
+  const view: ImageViewState = { scale, position, isDragging };
+  const showNav = list.length > 1 && currentIndex >= 0;
 
   return (
     <Dialog open={!!asset} onOpenChange={(open) => { open || onClose(); }}>
-      <DialogContent className="max-w-[90vw] w-auto p-0 bg-transparent border-none shadow-none [&>button]:hidden">
-        <DialogTitle className="sr-only">{asset?.original_name || asset?.filename || "预览"}</DialogTitle>
-        <div className="relative flex flex-col items-center gap-3">
-          {/* Top bar */}
-          <div className="flex items-center gap-2 self-end">
-            <a
-              href={asset?.url}
-              download={asset?.original_name || asset?.filename}
-              className="p-2 rounded-full bg-black/60 backdrop-blur-sm hover:bg-black/80 transition-colors"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <Download className="w-4 h-4 text-white" />
-            </a>
-            <button
-              onClick={onClose}
-              className="p-2 rounded-full bg-black/60 backdrop-blur-sm hover:bg-black/80 transition-colors"
-            >
-              <X className="w-4 h-4 text-white" />
-            </button>
-          </div>
+      <DialogContent
+        className="max-w-[95vw] w-[95vw] h-[92vh] p-0 bg-transparent border-none shadow-none [&>button]:hidden flex items-center justify-center"
+        onClick={onClose}
+      >
+        <DialogTitle className="sr-only">
+          {asset?.original_name || asset?.filename || t("resources.preview.title", "Preview")}
+        </DialogTitle>
 
-          {/* Content */}
-          {asset && Renderer && <Renderer asset={asset} />}
+        {/* Top-right controls */}
+        <div
+          className="absolute top-4 right-4 flex items-center gap-2 z-50"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {isImage && (
+            <>
+              <div className="bg-black/50 text-white px-3 py-1.5 rounded-md text-sm font-medium backdrop-blur-md">
+                {Math.round(scale * 100)}%
+              </div>
+              <Button
+                variant="secondary"
+                size="icon"
+                className="bg-black/50 hover:bg-black/70 text-white border-none backdrop-blur-md"
+                onClick={zoomIn}
+                title={t("canvas.node.preview.zoomIn", "Zoom in")}
+              >
+                <ZoomIn className="h-5 w-5" />
+              </Button>
+              <Button
+                variant="secondary"
+                size="icon"
+                className="bg-black/50 hover:bg-black/70 text-white border-none backdrop-blur-md"
+                onClick={zoomOut}
+                title={t("canvas.node.preview.zoomOut", "Zoom out")}
+              >
+                <ZoomOut className="h-5 w-5" />
+              </Button>
+            </>
+          )}
+          <Button
+            variant="secondary"
+            size="icon"
+            className="bg-black/50 hover:bg-black/70 text-white border-none backdrop-blur-md"
+            onClick={handleDownload}
+            title={t("canvas.node.preview.download", "Download")}
+          >
+            <Download className="h-5 w-5" />
+          </Button>
+          <Button
+            variant="secondary"
+            size="icon"
+            className="bg-black/50 hover:bg-black/70 text-white border-none backdrop-blur-md"
+            onClick={onClose}
+            title={t("canvas.node.preview.close", "Close")}
+          >
+            <X className="h-5 w-5" />
+          </Button>
+        </div>
 
-          {/* File info */}
-          <div className="text-xs text-white/60 bg-black/40 backdrop-blur-sm px-3 py-1 rounded-full">
+        {/* Main content area */}
+        <div
+          ref={containerRef}
+          className="w-full h-full flex items-center justify-center overflow-hidden p-8 pb-28"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {asset && Renderer && (
+            <Renderer
+              asset={asset}
+              view={view}
+              onPointerDown={handlePointerDown}
+              onPointerMove={handlePointerMove}
+              onPointerUp={handlePointerUp}
+            />
+          )}
+        </div>
+
+        {/* Bottom toolbar: prev/next pager + file info */}
+        <div
+          className="absolute bottom-6 left-1/2 -translate-x-1/2 z-50 flex flex-col items-center gap-2"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {showNav && (
+            <div className="flex items-center gap-1 bg-black/70 backdrop-blur-md text-white rounded-lg px-2 py-1.5 shadow-lg">
+              <button
+                disabled={!canPrev}
+                className="h-8 w-8 flex items-center justify-center rounded text-white/90 hover:bg-white/10 disabled:opacity-30 disabled:pointer-events-none"
+                onClick={goPrev}
+                title={t("resources.preview.prev", "Previous")}
+              >
+                <ChevronLeft className="w-4 h-4" />
+              </button>
+              <span className="text-xs text-white/80 px-2 tabular-nums min-w-[48px] text-center">
+                {currentIndex + 1} / {list.length}
+              </span>
+              <button
+                disabled={!canNext}
+                className="h-8 w-8 flex items-center justify-center rounded text-white/90 hover:bg-white/10 disabled:opacity-30 disabled:pointer-events-none"
+                onClick={goNext}
+                title={t("resources.preview.next", "Next")}
+              >
+                <ChevronRight className="w-4 h-4" />
+              </button>
+            </div>
+          )}
+          <div className="text-xs text-white/60 bg-black/40 backdrop-blur-sm px-3 py-1 rounded-full max-w-[80vw] truncate">
             {asset?.original_name || asset?.filename}
           </div>
         </div>

--- a/frontend/src/i18n/locales/en-US.json
+++ b/frontend/src/i18n/locales/en-US.json
@@ -136,7 +136,12 @@
     "downloading": "Downloading...",
     "deleteProgress": "Deleting {{current}}/{{total}}",
     "deleteComplete": "Deleted {{count}} assets successfully",
-    "deleteFailed": "Partially failed, deleted {{deleted}}/{{total}}"
+    "deleteFailed": "Partially failed, deleted {{deleted}}/{{total}}",
+    "preview": {
+      "title": "Preview",
+      "prev": "Previous",
+      "next": "Next"
+    }
   },
   "filter": {
     "all": "All",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -136,7 +136,12 @@
     "downloading": "下载中...",
     "deleteProgress": "正在删除 {{current}}/{{total}}",
     "deleteComplete": "删除完成，共删除 {{count}} 个资产",
-    "deleteFailed": "部分删除失败，已删除 {{deleted}}/{{total}}"
+    "deleteFailed": "部分删除失败，已删除 {{deleted}}/{{total}}",
+    "preview": {
+      "title": "预览",
+      "prev": "上一张",
+      "next": "下一张"
+    }
   },
   "filter": {
     "all": "全部",


### PR DESCRIPTION
- 资源页拖拽仅响应来自操作系统的文件，防止页面元素误触发上传高亮
- 禁用缩略图、视频和音频控件的原生拖拽，避免与文件拖拽冲突
- 资产预览对话框全新改版，支持图片缩放、拖拽及键盘快捷键操作
- 新增预览图像的缩放比例显示及放大、缩小按钮
- 增加资产列表预览的上一张/下一张切换功能及快捷键支持
- 预览对话框点击遮罩层可关闭，防止事件冒泡影响内部操作
- 优化资产下载功能，支持从网络加载后再下载并处理文件名及扩展名
- docker-compose 中 redis 容器增加环境变量注入，修复 healthcheck 的身份验证问题
- 补充中英文国际化文本，支持预览界面按钮及提示文案显示