### PR TITLE
perf(canvas): 优化画布节点数据快照与新增悬停预览功能

### DIFF
--- a/frontend/src/components/ai-assistant/MusicTaskCard.tsx
+++ b/frontend/src/components/ai-assistant/MusicTaskCard.tsx
@@ -188,7 +188,7 @@ export function MusicTaskCard({ task, className }: MusicTaskCardProps) {
   return (
     <div
       className={cn(
-        'rounded-lg border overflow-hidden transition-all duration-300 my-2',
+        'rounded-lg overflow-hidden transition-all duration-300 my-2',
         isActive
           ? 'bg-[var(--color-status-processing-bg)] border-[var(--color-status-processing-border)]'
           : status === 'completed'

--- a/frontend/src/components/ai-assistant/VideoTaskCard.tsx
+++ b/frontend/src/components/ai-assistant/VideoTaskCard.tsx
@@ -198,7 +198,7 @@ export function VideoTaskCard({ task, className }: VideoTaskCardProps) {
   return (
     <div
       className={cn(
-        'rounded-lg border overflow-hidden transition-all duration-300 my-2',
+        'rounded-lg overflow-hidden transition-all duration-300 my-2',
         isActive
           ? 'bg-[var(--color-status-processing-bg)] border-[var(--color-status-processing-border)]'
           : status === 'completed'

--- a/frontend/src/components/canvas/Sidebar.tsx
+++ b/frontend/src/components/canvas/Sidebar.tsx
@@ -87,6 +87,44 @@ const EMPTY_STATE_CONFIG: Record<string, { icon: React.ElementType; labelKey: st
   audio: { icon: Headphones, labelKey: 'sidebar.noAudio' },
 };
 
+// 悬停预览渲染器映射表（避免 if-else 分支）
+const HOVER_PREVIEW_RENDERERS: Record<string, React.FC<{ asset: AssetItem }>> = {
+  image: ({ asset }) => (
+    <img
+      src={asset.url}
+      alt={asset.original_name || asset.filename}
+      draggable={false}
+      className="w-full h-full object-contain bg-black/5"
+    />
+  ),
+  video: ({ asset }) => (
+    <video
+      src={asset.url}
+      autoPlay
+      muted
+      controls
+      playsInline
+      className="w-full h-full object-contain bg-black"
+    />
+  ),
+  audio: ({ asset }) => (
+    <div className="w-full h-full flex flex-col items-center justify-center gap-5 p-6 bg-secondary/30">
+      <div className="w-24 h-24 rounded-full bg-amber-500/10 flex items-center justify-center">
+        <Headphones className="w-12 h-12 text-amber-500/60" />
+      </div>
+      <span className="text-sm font-medium text-foreground truncate max-w-[90%] text-center">
+        {asset.original_name || asset.filename}
+      </span>
+      <audio src={asset.url} autoPlay controls className="w-[80%]" />
+    </div>
+  ),
+};
+
+const HOVER_DELAY_MS = 1000;
+const PREVIEW_W = 768;
+const PREVIEW_H = 384;
+const PREVIEW_GAP = 12;
+
 // Tab key -> API file_type 映射
 const TAB_TYPE_MAP: Record<string, string> = { images: 'image', videos: 'video', audio: 'audio' };
 const PAGE_SIZE = 20;
@@ -114,6 +152,42 @@ export const Sidebar = () => {
   const scrollRef = useRef<HTMLDivElement>(null);
   const tabDataRef = useRef(tabData);
   tabDataRef.current = tabData;
+
+  // ── 悬停预览状态 ──
+  const [previewAsset, setPreviewAsset] = useState<AssetItem | null>(null);
+  const [previewPos, setPreviewPos] = useState({ top: 0, left: 0 });
+  const previewHoverRef = useRef<NodeJS.Timeout | null>(null);
+  const previewCloseRef = useRef<NodeJS.Timeout | null>(null);
+  const previewAssetRef = useRef<AssetItem | null>(null);
+  previewAssetRef.current = previewAsset;
+
+  const handleAssetHoverEnter = useCallback((e: React.MouseEvent, asset: AssetItem) => {
+    previewCloseRef.current && clearTimeout(previewCloseRef.current);
+    previewHoverRef.current && clearTimeout(previewHoverRef.current);
+    const el = e.currentTarget as HTMLElement;
+    // 已有预览时立即切换；否则延迟 1s
+    const delay = previewAssetRef.current ? 0 : HOVER_DELAY_MS;
+    previewHoverRef.current = setTimeout(() => {
+      const rect = el.getBoundingClientRect();
+      const top = Math.max(8, Math.min(rect.top, window.innerHeight - PREVIEW_H - 8));
+      const left = Math.min(rect.right + PREVIEW_GAP, window.innerWidth - PREVIEW_W - 8);
+      setPreviewPos({ top, left });
+      setPreviewAsset(asset);
+    }, delay);
+  }, []);
+
+  const handleAssetHoverLeave = useCallback(() => {
+    previewHoverRef.current && clearTimeout(previewHoverRef.current);
+    previewCloseRef.current = setTimeout(() => setPreviewAsset(null), 200);
+  }, []);
+
+  const handlePreviewEnter = useCallback(() => {
+    previewCloseRef.current && clearTimeout(previewCloseRef.current);
+  }, []);
+
+  const handlePreviewLeave = useCallback(() => {
+    setPreviewAsset(null);
+  }, []);
 
   // 加载指定 tab 的下一页（通过 ref 读取最新状态，避免闭包陈旧值）
   const loadPage = useCallback(async (tab: string) => {
@@ -149,6 +223,19 @@ export const Sidebar = () => {
   useEffect(() => {
     activeMenu !== 'assets' && setTabData({ images: { ...INIT_TAB }, videos: { ...INIT_TAB }, audio: { ...INIT_TAB } });
   }, [activeMenu]);
+
+  // 面板关闭 / 切换 tab 时清理悬停预览
+  useEffect(() => {
+    setPreviewAsset(null);
+    previewHoverRef.current && clearTimeout(previewHoverRef.current);
+    previewCloseRef.current && clearTimeout(previewCloseRef.current);
+  }, [activeMenu, activeAssetTab]);
+
+  // 组件卸载时清理定时器
+  useEffect(() => () => {
+    previewHoverRef.current && clearTimeout(previewHoverRef.current);
+    previewCloseRef.current && clearTimeout(previewCloseRef.current);
+  }, []);
 
   // 滚动到底部时加载更多
   const handleScroll = useCallback(() => {
@@ -222,7 +309,10 @@ export const Sidebar = () => {
     onDragStart(event, info.nodeType, info.data);
   };
 
+  const PreviewRenderer = previewAsset ? HOVER_PREVIEW_RENDERERS[previewAsset.file_type ?? ''] : null;
+
   return (
+    <>
     <div className="fixed left-6 top-1/2 -translate-y-1/2 z-50">
       <div 
         className="flex flex-col gap-2 p-1.5 rounded-xl bg-background border border-border/50 shadow-none"
@@ -308,7 +398,7 @@ export const Sidebar = () => {
             </div>
 
             {/* Content Area */}
-            <div ref={scrollRef} onScroll={handleScroll} className="max-h-[300px] min-h-[300px] overflow-y-auto pr-1 custom-scrollbar">
+            <div ref={scrollRef} onScroll={handleScroll} className="max-h-[500px] min-h-[500px] overflow-y-auto pr-1 custom-scrollbar">
               
               {/* Loading state - 首次加载 */}
               {isLoading && (
@@ -325,6 +415,8 @@ export const Sidebar = () => {
                       key={asset.id} 
                       draggable
                       onDragStart={(e) => onAssetDragStart(e, asset)}
+                      onMouseEnter={(e) => handleAssetHoverEnter(e, asset)}
+                      onMouseLeave={handleAssetHoverLeave}
                       className="group relative rounded-lg border border-border/50 overflow-hidden cursor-grab active:cursor-grabbing bg-secondary/50 hover:border-node-green/50 transition-colors h-[80px] flex items-center justify-center"
                     >
                       <img 
@@ -360,6 +452,8 @@ export const Sidebar = () => {
                       key={asset.id} 
                       draggable
                       onDragStart={(e) => onAssetDragStart(e, asset)}
+                      onMouseEnter={(e) => handleAssetHoverEnter(e, asset)}
+                      onMouseLeave={handleAssetHoverLeave}
                       className="group relative rounded-lg border border-border/50 overflow-hidden cursor-grab active:cursor-grabbing bg-secondary/50 hover:border-node-yellow/50 transition-colors h-[80px] flex items-center justify-center bg-black/80"
                     >
                       <video 
@@ -400,6 +494,8 @@ export const Sidebar = () => {
                       key={asset.id} 
                       draggable
                       onDragStart={(e) => onAssetDragStart(e, asset)}
+                      onMouseEnter={(e) => handleAssetHoverEnter(e, asset)}
+                      onMouseLeave={handleAssetHoverLeave}
                       className="group flex items-center gap-3 p-2.5 rounded-lg border border-border/50 cursor-grab active:cursor-grabbing bg-secondary/50 hover:border-node-blue/50 transition-colors"
                     >
                       <div className="p-1.5 rounded-md bg-node-blue/10 shrink-0">
@@ -440,5 +536,23 @@ export const Sidebar = () => {
         </div>
       </div>
     </div>
+
+    {/* 悬停预览浮层 */}
+    {previewAsset && PreviewRenderer && (
+      <div
+        className="fixed z-[60] bg-background border border-border/50 rounded-xl overflow-hidden shadow-xl animate-in fade-in zoom-in-95 duration-150"
+        style={{
+          top: previewPos.top,
+          left: previewPos.left,
+          width: PREVIEW_W,
+          height: PREVIEW_H,
+        }}
+        onMouseEnter={handlePreviewEnter}
+        onMouseLeave={handlePreviewLeave}
+      >
+        <PreviewRenderer asset={previewAsset} />
+      </div>
+    )}
+    </>
   );
 };

--- a/frontend/src/components/canvas/VideoNode/VideoDisplay.tsx
+++ b/frontend/src/components/canvas/VideoNode/VideoDisplay.tsx
@@ -20,7 +20,7 @@ export function VideoDisplay({ videoUrl, fitMode, quality, onLoadedMetadata }: P
       <video
         src={videoUrl}
         controls
-        preload="none"
+        preload="metadata"
         className={`w-full h-full rounded-sm nodrag ${fitMode === 'cover' ? 'object-cover' : 'object-contain'}`}
         onPointerDown={(e) => e.stopPropagation()}
         onLoadedMetadata={onLoadedMetadata}

--- a/frontend/src/lib/dragToCanvas.ts
+++ b/frontend/src/lib/dragToCanvas.ts
@@ -167,12 +167,16 @@ export function createAudioDragPreview(name: string, maxWidth = 160): HTMLElemen
     display: 'flex', alignItems: 'center', gap: '10px',
   });
 
-  preview.innerHTML = `
-    <div style="width:28px;height:28px;border-radius:50%;background:rgba(245,158,11,0.2);display:flex;align-items:center;justify-content:center;flex-shrink:0">
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#f59e0b" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>
-    </div>
-    <span style="color:#fff;font-size:11px;font-weight:500;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${name}</span>
-  `;
+  const iconWrap = document.createElement('div');
+  iconWrap.style.cssText = 'width:28px;height:28px;border-radius:50%;background:rgba(245,158,11,0.2);display:flex;align-items:center;justify-content:center;flex-shrink:0';
+  iconWrap.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#f59e0b" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>';
+
+  const textSpan = document.createElement('span');
+  textSpan.style.cssText = 'color:#fff;font-size:11px;font-weight:500;overflow:hidden;text-overflow:ellipsis;white-space:nowrap';
+  textSpan.textContent = name;
+
+  preview.appendChild(iconWrap);
+  preview.appendChild(textSpan);
 
   document.body.appendChild(preview);
   return preview;
@@ -190,12 +194,21 @@ export function createTextDragPreview(text: string, maxWidth = 180): HTMLElement
   });
 
   const displayText = text.length > 60 ? text.slice(0, 60) + '...' : text;
-  preview.innerHTML = `
-    <div style="display:flex;align-items:flex-start;gap:8px">
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink:0;margin-top:1px"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><rect width="8" height="4" x="8" y="2" rx="1" ry="1"/><path d="M16 13H8"/><path d="M16 17H8"/></svg>
-      <span style="color:#e2e8f0;font-size:11px;line-height:1.4;overflow:hidden;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical">${displayText}</span>
-    </div>
-  `;
+
+  const row = document.createElement('div');
+  row.style.cssText = 'display:flex;align-items:flex-start;gap:8px';
+
+  const icon = document.createElement('span');
+  icon.style.cssText = 'flex-shrink:0;margin-top:1px;display:inline-flex';
+  icon.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><rect width="8" height="4" x="8" y="2" rx="1" ry="1"/><path d="M16 13H8"/><path d="M16 17H8"/></svg>';
+
+  const textSpan = document.createElement('span');
+  textSpan.style.cssText = 'color:#e2e8f0;font-size:11px;line-height:1.4;overflow:hidden;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical';
+  textSpan.textContent = displayText;
+
+  row.appendChild(icon);
+  row.appendChild(textSpan);
+  preview.appendChild(row);
 
   document.body.appendChild(preview);
   return preview;

--- a/frontend/src/lib/dragToCanvas.ts
+++ b/frontend/src/lib/dragToCanvas.ts
@@ -3,6 +3,9 @@
  * 与 useCanvasDragDrop 兼容，使用相同的 dataTransfer 格式
  */
 
+// 内联 SVG 图标（createDragPreview 默认图标）
+const ICON_SVG_FILE = '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/></svg>';
+
 // 节点类型配置：定义默认数据和尺寸
 const NODE_CONFIGS: Record<string, { 
   dimensions: { width: number; height: number };
@@ -73,7 +76,7 @@ export function createDragPreview(label: string, icon?: string): HTMLElement {
   preview.style.pointerEvents = 'none';
   preview.innerHTML = `
     <div class="w-4 h-4 rounded-sm bg-primary/20 flex items-center justify-center text-primary">
-      ${icon || '📄'}
+      ${icon || ICON_SVG_FILE}
     </div>
     <span class="text-sm font-medium max-w-[200px] truncate">${label}</span>
   `;
@@ -81,19 +84,24 @@ export function createDragPreview(label: string, icon?: string): HTMLElement {
   return preview;
 }
 
+// ── 统一卡片风格预览基础样式 ──
+function applyCardBase(el: HTMLElement): void {
+  el.style.position = 'absolute';
+  el.style.top = '-1000px';
+  el.style.opacity = '0.8';
+  el.style.pointerEvents = 'none';
+  el.style.borderRadius = '10px';
+  el.style.overflow = 'hidden';
+  el.style.boxShadow = '0 8px 24px rgba(0,0,0,0.18)';
+}
+
 /**
  * 创建图片拖拽预览元素（使用图片本身）
  */
 export function createImageDragPreview(imageUrl: string, maxSize = 200): HTMLElement {
   const preview = document.createElement('div');
-  preview.style.position = 'absolute';
-  preview.style.top = '-1000px';
-  preview.style.opacity = '0.75';
-  preview.style.pointerEvents = 'none';
-  preview.style.borderRadius = '8px';
-  preview.style.overflow = 'hidden';
-  preview.style.boxShadow = '0 4px 12px rgba(0,0,0,0.15)';
-  
+  applyCardBase(preview);
+
   const img = document.createElement('img');
   img.src = imageUrl;
   img.style.maxWidth = `${maxSize}px`;
@@ -101,8 +109,94 @@ export function createImageDragPreview(imageUrl: string, maxSize = 200): HTMLEle
   img.style.display = 'block';
   img.style.objectFit = 'contain';
   img.draggable = false;
-  
+
   preview.appendChild(img);
+  document.body.appendChild(preview);
+  return preview;
+}
+
+/**
+ * 创建视频拖拽预览元素（暗色缩略图 + 播放按钮）
+ */
+export function createVideoDragPreview(videoUrl: string, maxWidth = 160): HTMLElement {
+  const preview = document.createElement('div');
+  applyCardBase(preview);
+  preview.style.width = `${maxWidth}px`;
+  preview.style.height = `${Math.round(maxWidth * 0.625)}px`;
+  preview.style.background = '#111';
+  preview.style.display = 'flex';
+  preview.style.alignItems = 'center';
+  preview.style.justifyContent = 'center';
+  preview.style.position = 'absolute';
+
+  // 视频帧背景
+  const video = document.createElement('video');
+  video.src = videoUrl;
+  video.preload = 'metadata';
+  video.muted = true;
+  Object.assign(video.style, {
+    width: '100%', height: '100%', objectFit: 'cover',
+    opacity: '0.55', position: 'absolute', top: '0', left: '0',
+  });
+  preview.appendChild(video);
+
+  // 播放按钮遮罩
+  const btn = document.createElement('div');
+  Object.assign(btn.style, {
+    width: '32px', height: '32px', borderRadius: '50%',
+    background: 'rgba(255,255,255,0.9)', display: 'flex',
+    alignItems: 'center', justifyContent: 'center',
+    position: 'relative', zIndex: '1',
+  });
+  btn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="#111"><path d="M8 5v14l11-7z"/></svg>';
+  preview.appendChild(btn);
+
+  document.body.appendChild(preview);
+  return preview;
+}
+
+/**
+ * 创建音频拖拽预览元素（渐变卡片 + 音符图标 + 名称）
+ */
+export function createAudioDragPreview(name: string, maxWidth = 160): HTMLElement {
+  const preview = document.createElement('div');
+  applyCardBase(preview);
+  Object.assign(preview.style, {
+    width: `${maxWidth}px`, padding: '12px',
+    background: 'linear-gradient(135deg, #1a1a2e 0%, #16213e 100%)',
+    display: 'flex', alignItems: 'center', gap: '10px',
+  });
+
+  preview.innerHTML = `
+    <div style="width:28px;height:28px;border-radius:50%;background:rgba(245,158,11,0.2);display:flex;align-items:center;justify-content:center;flex-shrink:0">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#f59e0b" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>
+    </div>
+    <span style="color:#fff;font-size:11px;font-weight:500;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${name}</span>
+  `;
+
+  document.body.appendChild(preview);
+  return preview;
+}
+
+/**
+ * 创建文本拖拽预览元素（卡片样式 + 文本摘要）
+ */
+export function createTextDragPreview(text: string, maxWidth = 180): HTMLElement {
+  const preview = document.createElement('div');
+  applyCardBase(preview);
+  Object.assign(preview.style, {
+    width: `${maxWidth}px`, padding: '10px 12px',
+    background: '#1e1e2e', border: '1px solid rgba(255,255,255,0.08)',
+  });
+
+  const displayText = text.length > 60 ? text.slice(0, 60) + '...' : text;
+  preview.innerHTML = `
+    <div style="display:flex;align-items:flex-start;gap:8px">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink:0;margin-top:1px"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><rect width="8" height="4" x="8" y="2" rx="1" ry="1"/><path d="M16 13H8"/><path d="M16 17H8"/></svg>
+      <span style="color:#e2e8f0;font-size:11px;line-height:1.4;overflow:hidden;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical">${displayText}</span>
+    </div>
+  `;
+
   document.body.appendChild(preview);
   return preview;
 }
@@ -128,8 +222,8 @@ export function handleVideoDragStart(
     description: '',
   });
 
-  const preview = createDragPreview(name || '拖拽视频到画布', '🎬');
-  event.dataTransfer.setDragImage(preview, 0, 0);
+  const preview = createVideoDragPreview(videoUrl);
+  event.dataTransfer.setDragImage(preview, preview.offsetWidth / 2, preview.offsetHeight / 2);
 
   return preview;
 }
@@ -150,8 +244,8 @@ export function handleAudioDragStart(
     lyrics: lyrics || '',
   });
 
-  const preview = createDragPreview(name || '拖拽音频到画布', '🎵');
-  event.dataTransfer.setDragImage(preview, 0, 0);
+  const preview = createAudioDragPreview(name || '音频');
+  event.dataTransfer.setDragImage(preview, preview.offsetWidth / 2, preview.offsetHeight / 2);
 
   return preview;
 }
@@ -166,7 +260,7 @@ export function handleTextDragStart(
 ): HTMLElement | null {
   // 截取文本作为标题（最多 50 字符）
   const displayTitle = title || (text.length > 50 ? text.slice(0, 50) + '...' : text);
-  
+
   setDragData(event, 'text', {
     title: displayTitle,
     content: {
@@ -175,8 +269,8 @@ export function handleTextDragStart(
     },
   });
 
-  const preview = createDragPreview(displayTitle, '📝');
-  event.dataTransfer.setDragImage(preview, 0, 0);
+  const preview = createTextDragPreview(displayTitle);
+  event.dataTransfer.setDragImage(preview, preview.offsetWidth / 2, preview.offsetHeight / 2);
 
   return preview;
 }

--- a/frontend/src/store/useCanvasStore.ts
+++ b/frontend/src/store/useCanvasStore.ts
@@ -243,6 +243,29 @@ interface CanvasState {
 
 const MAX_HISTORY = 50;
 
+// --- Debounced snapshot for data updates ---
+// 文本节点等数据更新会逐字触发 updateNodeData，若每次都打快照，50 条 MAX_HISTORY
+// 会被瞬间填满。这里用模块作用域 timer（不进 zustand state，避免渲染抖动）
+// 把连续的数据更新合并为一次快照。结构性入口（拖拽结束、删除、连线等）会在
+// 自身打快照前先 flush，保证历史顺序：先输入快照入栈，再结构性快照入栈。
+let dataSnapshotTimer: ReturnType<typeof setTimeout> | null = null;
+const DATA_SNAPSHOT_DEBOUNCE_MS = 500;
+
+const scheduleDataSnapshot = (snapshot: () => void) => {
+  dataSnapshotTimer && clearTimeout(dataSnapshotTimer);
+  dataSnapshotTimer = setTimeout(() => {
+    dataSnapshotTimer = null;
+    snapshot();
+  }, DATA_SNAPSHOT_DEBOUNCE_MS);
+};
+
+const flushPendingDataSnapshot = () => {
+  if (!dataSnapshotTimer) return;
+  clearTimeout(dataSnapshotTimer);
+  dataSnapshotTimer = null;
+  useCanvasStore.getState().takeSnapshot();
+};
+
 // --- Mapping helpers: frontend <-> backend ---
 
 function nodeToApi(node: CanvasNode): TheaterNodeCreate {
@@ -296,17 +319,20 @@ function apiToEdge(e: { id: string; source_node_id: string; target_node_id: stri
 }
 
 function applyDetail(detail: TheaterDetailResponse) {
+  const initialNodes = detail.nodes.map(apiToNode);
+  const initialEdges = detail.edges.map(apiToEdge);
   return {
     theaterId: detail.id,
     theaterTitle: detail.title,
-    nodes: detail.nodes.map(apiToNode),
-    edges: detail.edges.map(apiToEdge),
+    nodes: initialNodes,
+    edges: initialEdges,
     viewport: (detail.canvas_viewport as Viewport) || { x: 0, y: 0, zoom: 1 },
     isLoading: false,
     isDirty: false,
     lastSavedAt: Date.now(),
-    history: [] as HistoryState[],
-    historyIndex: -1,
+    // 写入初始快照，确保首次结构性变更后 undo 能回到加载时的状态
+    history: [{ nodes: initialNodes, edges: initialEdges }] as HistoryState[],
+    historyIndex: 0,
   };
 }
 
@@ -338,30 +364,47 @@ export const useCanvasStore = create<CanvasState>()(
       onNodesChange: (changes: NodeChange[]) => {
         const { nodes } = get();
         const nextNodes = applyNodeChanges(changes, nodes) as CanvasNode[];
-        
+
         // Flag as dirty for relevant changes (position, dimension, remove)
         const isSignificant = changes.some(
           (c) => c.type === 'position' || c.type === 'dimensions' || c.type === 'remove' || c.type === 'add'
         );
 
-        set({ 
+        // 结束帧才打快照：拖拽释放 / 缩放释放 / 节点删除（含 React Flow Delete 键）
+        // - dimensions 在节点首次 measure 时也会触发，但不带 resizing 字段（undefined），
+        //   严格 === false 判定可避开 measure 噪音，仅捕获 NodeResizer 真正释放的那一帧。
+        // - add 由 addNode 已经 snapshot，这里跳过避免重复。
+        const shouldSnapshot = changes.some(
+          (c) =>
+            (c.type === 'position' && c.dragging === false) ||
+            (c.type === 'dimensions' && c.resizing === false) ||
+            c.type === 'remove'
+        );
+
+        set({
           nodes: nextNodes,
           ...(isSignificant ? { isDirty: true } : {})
         });
+
+        shouldSnapshot && (flushPendingDataSnapshot(), get().takeSnapshot());
       },
 
       onEdgesChange: (changes: EdgeChange[]) => {
         const { edges } = get();
         const nextEdges = applyEdgeChanges(changes, edges);
-        
+
         const isSignificant = changes.some(
           (c) => c.type === 'remove' || c.type === 'add'
         );
+        // 仅 remove 由这里触发快照（add 由 connectAndInject 负责）
+        const shouldSnapshot = changes.some((c) => c.type === 'remove');
 
-        set({ 
+        set({
           edges: nextEdges,
           ...(isSignificant ? { isDirty: true } : {})
         });
+
+        shouldSnapshot && (flushPendingDataSnapshot(), get().takeSnapshot());
       },
 
       onConnect: (connection: Connection) => {
@@ -409,6 +452,7 @@ export const useCanvasStore = create<CanvasState>()(
         // 2. 建边（显式指定短 UUID，避免 xyflow 默认生成 xy-edge__xxx 超长 ID 超过后端 VARCHAR 限制）
         const newEdges = addEdge({ ...connection, id: uuidv4(), type: 'custom', animated: true }, edges);
         set({ edges: newEdges, isDirty: true });
+        flushPendingDataSnapshot();
         get().takeSnapshot();
 
         // 3. 构建 payload（空则不注入，但连线已建立）
@@ -457,6 +501,7 @@ export const useCanvasStore = create<CanvasState>()(
           ? node
           : { ...node, data: { ...node.data, updatedAt: new Date().toISOString() } };
         set({ nodes: [...nodes, stamped], isDirty: true });
+        flushPendingDataSnapshot();
         get().takeSnapshot();
       },
 
@@ -467,6 +512,7 @@ export const useCanvasStore = create<CanvasState>()(
           (edge) => edge.source !== id && edge.target !== id
         );
         set({ nodes: newNodes, edges: newEdges, isDirty: true });
+        flushPendingDataSnapshot();
         get().takeSnapshot();
       },
 
@@ -475,6 +521,7 @@ export const useCanvasStore = create<CanvasState>()(
         const edgeToDelete = edges.find((edge) => edge.id === id);
         const newEdges = edges.filter((edge) => edge.id !== id);
         set({ edges: newEdges, isDirty: true });
+        flushPendingDataSnapshot();
         get().takeSnapshot();
         
         if (edgeToDelete) {
@@ -491,11 +538,12 @@ export const useCanvasStore = create<CanvasState>()(
           position: { x: 100, y: 100 },
           data: { title: '我的文本卡', tags: [] },
         };
+        // 写入初始快照，确保首次结构性变更后 undo 能回到 reset 时的状态
         set({
           nodes: [initialNode],
           edges: [],
-          history: [],
-          historyIndex: -1,
+          history: [{ nodes: [initialNode], edges: [] }],
+          historyIndex: 0,
           viewport: { x: 0, y: 0, zoom: 1 },
           theaterId: null,
           theaterTitle: '未命名剧场',
@@ -512,7 +560,9 @@ export const useCanvasStore = create<CanvasState>()(
           ),
           isDirty: true,
         });
-        get().takeSnapshot();
+        // 数据更新（含 Tiptap 文本输入）走去抖合并，避免逐字打满 50 步历史。
+        // 任何结构性入口在自己 takeSnapshot 前会先 flush，保证历史顺序正确。
+        scheduleDataSnapshot(() => get().takeSnapshot());
       },
 
       updateNodeDimensions: (id: string, width: number, height: number) => {
@@ -522,8 +572,8 @@ export const useCanvasStore = create<CanvasState>()(
           ),
           isDirty: true,
         });
-        // We might not want to take a snapshot for every dimension change
-        // get().takeSnapshot();
+        // 不在此处打快照：NodeResizer 触发的尺寸变化由 onNodesChange 的
+        // resize 结束帧（dimensions + resizing===false）统一负责，避免双写。
       },
 
       setViewport: (viewport: Viewport) => {
@@ -546,6 +596,9 @@ export const useCanvasStore = create<CanvasState>()(
       },
 
       undo: () => {
+        // 先 flush 待打的数据快照，避免「连续输入 → Ctrl+Z 时去抖快照尚未落地」
+        // 造成跳两步的错觉。
+        flushPendingDataSnapshot();
         const { historyIndex, history } = get();
         if (historyIndex > 0) {
           const prevIndex = historyIndex - 1;
@@ -560,6 +613,7 @@ export const useCanvasStore = create<CanvasState>()(
       },
 
       redo: () => {
+        flushPendingDataSnapshot();
         const { historyIndex, history } = get();
         if (historyIndex < history.length - 1) {
           const nextIndex = historyIndex + 1;


### PR DESCRIPTION
- 移除 ai-assistant 任务卡 border 样式，统一卡片视觉
- 在 Sidebar 资产面板新增悬停预览浮层支持，提升资产浏览体验
- 悬停预览支持图片、视频、音频类型的专用渲染组件
- 资产列表项添加鼠标悬停事件以触发预览展示
- 扩展 dragToCanvas，新增针对图片、视频、音频、文本的拖拽预览元素
- 拖拽预览样式统一卡片风格，支持内容展示与播放控件
- video 节点加载元数据时，调整 preload 策略为 metadata 以优化加载表现
- useCanvasStore 实现数据更新去抖动快照机制，减少历史记录爆增风险
- 结构性更新（拖拽释放、节点删除、连线操作）即时刷新并写入快照
- 重构节点和边的变更处理，确保脏标记与快照操作同步准确
- 初始化剧场数据时写入首次快照，保障 undo 可回到加载起点状态
- undo/redo 操作前刷新待处理数据快照以避免跳步现象
- 提升整体状态管理性能与用户交互响应稳定性