### PR TITLE
fix(image-gen): 修复 OpenRouter 图像生成接口兼容性问题

### DIFF
--- a/backend/admin/next-env.d.ts
+++ b/backend/admin/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/backend/routers/images.py
+++ b/backend/routers/images.py
@@ -69,6 +69,7 @@ async def _dispatch_image_generation(
     adapted: dict,
     n: int,
     user_id: str,
+    mask_url: Optional[str] = None,
 ) -> tuple[list[str], dict]:
     """按 mode 分派到 text-to-image 生成器或 edit handler。
 

--- a/backend/services/openrouter_image_gen.py
+++ b/backend/services/openrouter_image_gen.py
@@ -174,14 +174,19 @@ async def batch_generate_openrouter_images(
     prompt: str,
     aspect_ratio: str | None = None,
     quality: str | None = None,
+    output_format: str | None = None,
+    output_compression: int | None = None,
+    background: str | None = None,
+    moderation: str | None = None,
     n: int = 1,
     user_id: str | None = None,
 ) -> list[str]:
     """文生图统一入口。
 
     注：output_format/output_compression/background/moderation 在 OpenRouter 上不生效，
-    保留签名以向上层保持接口兼容。
+    显式声明形参以向上层保持接口兼容（静默忽略）。
     """
+    _ = (output_format, output_compression, background, moderation)  # silently ignored
     return await _dispatch_generate(
         api_key=api_key,
         base_url=base_url,

--- a/backend/services/tool_manager/providers/image_gen.py
+++ b/backend/services/tool_manager/providers/image_gen.py
@@ -204,9 +204,9 @@ async def _generate_via_ark(
 async def _generate_via_openrouter(
     api_key: str, base_url: str | None, model: str,
     prompt: str, config: dict, n: int, user_id: str | None = None,
-) -> list[str]:
+) -> tuple[list[str], dict]:
     img_cfg = config.get("image_config") or {}
-    return await batch_generate_openrouter_images(
+    urls = await batch_generate_openrouter_images(
         api_key=api_key,
         base_url=base_url,
         model=model,
@@ -220,6 +220,8 @@ async def _generate_via_openrouter(
         n=max(1, n),
         user_id=user_id,
     )
+    # OpenRouter chat 返回的 usage 不含图像 token 估算，统一返回零值
+    return urls, {"input_tokens": 0, "output_tokens": 0}
 
 
 # Handler dispatch map (no if-chains)


### PR DESCRIPTION
- 修正了 next-env 引用路径，适配开发环境类型定义
- 在图像生成函数添加了 mask_url 参数支持
- 文生图入口函数增加多个接口参数以保持接口兼容，避免上层调用失败
- 调整 OpenRouter 图像生成函数返回类型，增加使用量返回结构并默认零值
- 统一忽略 OpenRouter 不支持的参数，防止运行时警告或错误