### PR TITLE
feat(billing): 增加余额不足时扣至零机制并前端即时同步余额,修改日志输出。

### DIFF
--- a/backend/routers/images.py
+++ b/backend/routers/images.py
@@ -317,8 +317,10 @@ async def generate_images(
         + rate_per_image    * len(image_urls)
     )
 
+    _billing_underpaid = False  # 本次扣费是否不足被兜底扣到 0
+    _remaining_credits: Optional[float] = None  # 本次扣费后用户余额
     try:
-        (credit_cost > 0) and await deduct_credits_atomic(
+        tx = (credit_cost > 0) and await deduct_credits_atomic(
             user_id=entity_id,
             cost=credit_cost,
             session=db,
@@ -337,14 +339,23 @@ async def generate_images(
             },
             transaction_type="consumption",
         )
+        # 同步最新余额到响应，前端即时刷新 user.credits
+        tx and hasattr(tx, 'balance_after') and (_remaining_credits := float(tx.balance_after))
     except InsufficientCreditsError:
-        raise BizError.insufficient_credits()
+        # 图像已生成、已注册资产；deduct_credits_atomic 已把余额兜底扣到 0。
+        # 为了让用户拿到已生成的图像，不再抛 402，仅设置 billing_underpaid 标志由响应传递给前端。
+        _billing_underpaid = True
+        _remaining_credits = 0.0
+        logger.warning(
+            "Image generation underpaid: user=%s provider=%s model=%s cost=%.4f, balance drained to 0",
+            entity_id, provider.id, payload.model, credit_cost,
+        )
 
     await db.commit()
 
     logger.info(
-        "Image generated: user=%s provider=%s model=%s count=%d cost=%.4f",
-        entity_id, provider.id, payload.model, len(image_urls), credit_cost,
+        "Image generated: user=%s provider=%s model=%s count=%d cost=%.4f underpaid=%s",
+        entity_id, provider.id, payload.model, len(image_urls), credit_cost, _billing_underpaid,
     )
 
     return ImageGenerateResponse(
@@ -355,6 +366,8 @@ async def generate_images(
         provider_name=provider.name,
         credit_cost=credit_cost,
         created_at=datetime.now(timezone.utc),
+        billing_underpaid=_billing_underpaid,
+        remaining_credits=_remaining_credits,
     )
 
 

--- a/backend/routers/images.py
+++ b/backend/routers/images.py
@@ -354,8 +354,8 @@ async def generate_images(
     await db.commit()
 
     logger.info(
-        "Image generated: user=...%s model=%s count=%d underpaid=%s",
-        entity_id[-8:], payload.model, len(image_urls), _billing_underpaid,
+        "Image generated: user=...%s model=%s count=%d",
+        entity_id[-8:], payload.model, len(image_urls),
     )
 
     return ImageGenerateResponse(

--- a/backend/routers/images.py
+++ b/backend/routers/images.py
@@ -347,15 +347,15 @@ async def generate_images(
         _billing_underpaid = True
         _remaining_credits = 0.0
         logger.warning(
-            "Image generation underpaid: user=%s provider=%s model=%s cost=%.4f, balance drained to 0",
-            entity_id, provider.id, payload.model, credit_cost,
+            "Image generation underpaid: user=...%s model=%s, balance drained to 0",
+            entity_id[-8:], payload.model,
         )
 
     await db.commit()
 
     logger.info(
-        "Image generated: user=%s provider=%s model=%s count=%d cost=%.4f underpaid=%s",
-        entity_id, provider.id, payload.model, len(image_urls), credit_cost, _billing_underpaid,
+        "Image generated: user=...%s model=%s count=%d underpaid=%s",
+        entity_id[-8:], payload.model, len(image_urls), _billing_underpaid,
     )
 
     return ImageGenerateResponse(

--- a/backend/routers/media.py
+++ b/backend/routers/media.py
@@ -1,7 +1,8 @@
 """媒体文件服务路由"""
-from fastapi import APIRouter, HTTPException, Depends, UploadFile, File, Form, Query, Body
-from fastapi.responses import FileResponse, RedirectResponse
+from fastapi import APIRouter, HTTPException, Depends, Request, UploadFile, File, Form, Query, Body
+from fastapi.responses import FileResponse, RedirectResponse, StreamingResponse
 from pathlib import Path
+import os
 import re
 import logging
 import uuid
@@ -558,8 +559,8 @@ async def serve_media_thumbnail(filename: str):
 # ---------------------------------------------------------------------------
 
 @router.get("/{filename}")
-async def serve_media(filename: str, db: AsyncSession = Depends(get_db)):
-    """安全地提供媒体文件（支持本地后端 + S3 预签名重定向）"""
+async def serve_media(request: Request, filename: str, db: AsyncSession = Depends(get_db)):
+    """安全地提供媒体文件（支持本地后端 + S3 预签名重定向 + HTTP Range）"""
     # 优先精确匹配（带扩展名）
     matched = _SAFE_FILENAME.match(filename)
     matched or _UUID_ONLY.match(filename) or (_ for _ in ()).throw(
@@ -569,7 +570,7 @@ async def serve_media(filename: str, db: AsyncSession = Depends(get_db)):
     # S3 后端：根据 Asset 查出 key 后重定向到预签名/公网 URL
     s3_handlers = {
         "s3": lambda: _serve_s3(filename, db),
-        "local": lambda: _serve_local(filename),
+        "local": lambda: _serve_local(filename, request),
     }
     handler = s3_handlers.get(settings.STORAGE_BACKEND, s3_handlers["local"])
     return await handler()
@@ -585,31 +586,71 @@ async def _serve_s3(filename: str, db: AsyncSession):
     return RedirectResponse(url=target_url, status_code=302)
 
 
-async def _serve_local(filename: str):
-    """本地后端：保持原有逆向查找逻辑。"""
+_RANGE_RE = re.compile(r"bytes=(\d+)-(\d*)")
+
+
+async def _serve_local(filename: str, request: Request):
+    """本地后端：支持 HTTP Range 请求的文件服务（视频渐进式播放）。"""
+    # 解析文件路径
+    filepath: Path | None = None
+    ext = ""
+
     matched = _SAFE_FILENAME.match(filename)
-    if matched:
-        filepath = resolve_media_filepath(filename)
-        filepath or (_ for _ in ()).throw(HTTPException(status_code=404, detail="File not found"))
-        ext = filename.rsplit(".", 1)[-1]
-        return FileResponse(
-            filepath,
-            media_type=_EXT_MIME.get(ext, "application/octet-stream"),
-            headers={"Cache-Control": "public, max-age=31536000"},
-        )
+    matched and (filepath := resolve_media_filepath(filename))
+    matched and filepath and (ext := filename.rsplit(".", 1)[-1])
 
     # 回退：纯 UUID（LLM 模型可能在回复中截断文件扩展名）
-    if _UUID_ONLY.match(filename):
-        for ext in _FALLBACK_EXTS:
-            candidate = resolve_media_filepath(f"{filename}.{ext}")
-            if candidate:
-                return FileResponse(
-                    candidate,
-                    media_type=_EXT_MIME.get(ext, "application/octet-stream"),
-                    headers={"Cache-Control": "public, max-age=31536000"},
-                )
+    (not filepath) and _UUID_ONLY.match(filename) and next(
+        (
+            (filepath := candidate) and (ext := e)
+            for e in _FALLBACK_EXTS
+            if (candidate := resolve_media_filepath(f"{filename}.{e}"))
+        ),
+        None,
+    )
 
-    raise HTTPException(status_code=400, detail="Invalid filename")
+    filepath or (_ for _ in ()).throw(
+        HTTPException(status_code=404, detail="File not found")
+    )
+
+    media_type = _EXT_MIME.get(ext, "application/octet-stream")
+    file_size = os.path.getsize(filepath)
+    base_headers = {"Cache-Control": "public, max-age=31536000", "Accept-Ranges": "bytes"}
+
+    # Range 请求处理 → 206 Partial Content（视频/音频渐进式播放）
+    range_header = request.headers.get("range", "")
+    range_match = _RANGE_RE.match(range_header) if range_header else None
+
+    if range_match:
+        start = int(range_match.group(1))
+        end = int(range_match.group(2)) if range_match.group(2) else file_size - 1
+        end = min(end, file_size - 1)
+        chunk_size = end - start + 1
+
+        def _iter_range():
+            with open(filepath, "rb") as f:
+                f.seek(start)
+                remaining = chunk_size
+                while remaining > 0:
+                    buf = f.read(min(remaining, 65536))
+                    if not buf:
+                        break
+                    remaining -= len(buf)
+                    yield buf
+
+        return StreamingResponse(
+            _iter_range(),
+            status_code=206,
+            media_type=media_type,
+            headers={
+                **base_headers,
+                "Content-Range": f"bytes {start}-{end}/{file_size}",
+                "Content-Length": str(chunk_size),
+            },
+        )
+
+    # 无 Range → 完整文件 + Accept-Ranges 告知客户端支持分段请求
+    return FileResponse(filepath, media_type=media_type, headers=base_headers)
 
 
 @router.post("/batch-generate", response_model=BatchImageGenerateResponse)

--- a/backend/routers/music.py
+++ b/backend/routers/music.py
@@ -9,7 +9,7 @@ from typing import Optional
 import logging
 
 from database import get_db
-from models import LLMProvider, MusicTask
+from models import LLMProvider, MusicTask, User, Admin
 from schemas import MusicTaskResponse, MusicGenerateRequest, MusicGenerateResponse
 from auth import get_current_active_user_or_admin, scoped_query
 from services.music_providers import extract_music_provider_type
@@ -49,7 +49,7 @@ _MODEL_CAPS: dict[str, dict] = {
 # Response builder
 # ---------------------------------------------------------------------------
 
-def _build_task_response(task: MusicTask, provider_name: str = None) -> MusicTaskResponse:
+def _build_task_response(task: MusicTask, provider_name: str = None, remaining_credits: Optional[float] = None) -> MusicTaskResponse:
     """构建音乐任务响应"""
     return MusicTaskResponse(
         id=task.id,
@@ -66,6 +66,7 @@ def _build_task_response(task: MusicTask, provider_name: str = None) -> MusicTas
         input_image_count=task.input_image_count or 0,
         created_at=task.created_at,
         completed_at=task.completed_at,
+        remaining_credits=remaining_credits,
     )
 
 
@@ -93,7 +94,16 @@ async def get_music_task_status(
         )
     )
 
-    return _build_task_response(task, provider_name=provider_name)
+    # 轮询到 completed 时查一次当前用户余额，供前端同步 user.credits。
+    # 后台任务扣费在另一个 session 中发生，这里补一次查询是让用户拿不到 push event 时仍能同步余额。
+    remaining_credits: Optional[float] = None
+    if task.status == "completed":
+        user_row = (await db.execute(select(User.credits).where(User.id == current_user.id))).scalar()
+        admin_row = user_row is None and (await db.execute(select(Admin.credits).where(Admin.id == current_user.id))).scalar()
+        balance = user_row if user_row is not None else admin_row
+        balance is not None and balance is not False and (remaining_credits := float(balance))
+
+    return _build_task_response(task, provider_name=provider_name, remaining_credits=remaining_credits)
 
 
 @router.get("/session/{session_id}", response_model=list[MusicTaskResponse])

--- a/backend/routers/videos.py
+++ b/backend/routers/videos.py
@@ -233,6 +233,8 @@ async def get_video_task_status(
     timed_out and setattr(task, "error_message", poll_result.error or "Timeout")
 
     # 完成处理：下载视频 + 计费
+    _billing_underpaid = False  # 本次扣费是否不足被兜底扣到 0
+    _remaining_credits: Optional[float] = None  # 本次扣费后余额，用于前端即时同步
     if poll_result.status == "completed" and poll_result.video_url:
         try:
             # Gemini 需要 API key 下载视频
@@ -253,22 +255,29 @@ async def get_video_task_status(
             credit_cost, billing_metadata = calculate_video_credit_cost(task, rate_map)
             task.credit_cost = credit_cost
 
-            # 扣费
-            (credit_cost > 0) and await deduct_credits_atomic(
-                user_id=entity_id,
-                cost=credit_cost,
-                session=db,
-                metadata=billing_metadata,
-                transaction_type="consumption",
-                idempotency_key=f"video:{task.id}",
-            )
+            # 扣费：生成已发生，扣费不足时 deduct_credits_atomic 会把余额兜底扣到 0 + 抛 InsufficientCreditsError。
+            # 为了让用户拿到已生成的结果，task.status 保持 completed，仅设置 billing_underpaid 标志由响应/push 渠道传递给前端。
+            try:
+                tx = (credit_cost > 0) and await deduct_credits_atomic(
+                    user_id=entity_id,
+                    cost=credit_cost,
+                    session=db,
+                    metadata=billing_metadata,
+                    transaction_type="consumption",
+                    idempotency_key=f"video:{task.id}",
+                )
+                # 同步最新余额到响应，前端即时刷新 user.credits
+                tx and hasattr(tx, 'balance_after') and (_remaining_credits := float(tx.balance_after))
+            except InsufficientCreditsError:
+                _billing_underpaid = True
+                _remaining_credits = 0.0  # 兜底已扣到 0
+                logger.warning(
+                    f"Video {task.id} underpaid: cost={credit_cost}, user balance drained to 0; delivering result"
+                )
 
             # 在聊天会话中插入视频消息
             task.session_id and await _insert_video_chat_message(db, task)
 
-        except InsufficientCreditsError:
-            task.status = "failed"
-            task.error_message = "Insufficient credits"
         except Exception as e:
             logger.error(f"Video completion processing failed: {e}")
             task.status = "failed"
@@ -285,13 +294,13 @@ async def get_video_task_status(
 
     # 终态实时推送到客户端（有 Redis 跨实例、无 Redis 退化本地）
     _terminal_push = {
-        "completed": lambda: push_to_user(task.user_id, "video.completed", _build_task_response(task, provider_name=provider.name).model_dump()),
+        "completed": lambda: push_to_user(task.user_id, "video.completed", _build_task_response(task, provider_name=provider.name, billing_underpaid=_billing_underpaid, remaining_credits=_remaining_credits).model_dump()),
         "failed":    lambda: push_to_user(task.user_id, "video.failed",    _build_task_response(task, provider_name=provider.name).model_dump()),
     }
     pusher = _terminal_push.get(task.status)
     pusher and task.user_id and await pusher()
 
-    return _build_task_response(task, provider_name=provider.name)
+    return _build_task_response(task, provider_name=provider.name, billing_underpaid=_billing_underpaid, remaining_credits=_remaining_credits)
 
 
 async def _register_video_asset(local_url: str, user_id: str, db: AsyncSession) -> None:
@@ -435,7 +444,7 @@ def _try_delete_local_file(media_url: str):
     logger.info(f"Deleted local file: {filepath}")
 
 
-def _build_task_response(task: VideoTask, provider_name: str = None) -> VideoTaskResponse:
+def _build_task_response(task: VideoTask, provider_name: str = None, billing_underpaid: bool = False, remaining_credits: Optional[float] = None) -> VideoTaskResponse:
     """构建视频任务响应"""
     return VideoTaskResponse(
         id=task.id,
@@ -456,6 +465,8 @@ def _build_task_response(task: VideoTask, provider_name: str = None) -> VideoTas
         image_url=task.image_url,
         created_at=task.created_at,
         completed_at=task.completed_at,
+        billing_underpaid=billing_underpaid,
+        remaining_credits=remaining_credits,
     )
 
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -738,6 +738,10 @@ class VideoTaskResponse(BaseModel):
     image_url: Optional[str] = None
     created_at: Any
     completed_at: Optional[Any] = None
+    # 仅在本次扣费不足、余额被兜底扣到 0 时为 true（不持久化）
+    billing_underpaid: bool = False
+    # 本次扣费后用户最新余额（不持久化，用于前端即时同步）
+    remaining_credits: Optional[float] = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -1054,6 +1058,10 @@ class MusicTaskResponse(BaseModel):
     input_image_count: int = 0
     created_at: Any
     completed_at: Optional[Any] = None
+    # 仅在本次扣费不足、余额被兜底扣到 0 时为 true（不持久化）
+    billing_underpaid: bool = False
+    # 用户最新余额（不持久化，用于前端即时同步）
+    remaining_credits: Optional[float] = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -1100,6 +1108,10 @@ class ImageGenerateResponse(BaseModel):
     provider_name: Optional[str] = None
     credit_cost: float = 0.0
     created_at: Any
+    # 仅在本次扣费不足、余额被兜底扣到 0 时为 true（不持久化）
+    billing_underpaid: bool = False
+    # 本次扣费后用户最新余额（不持久化，用于前端即时同步）
+    remaining_credits: Optional[float] = None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/services/billing.py
+++ b/backend/services/billing.py
@@ -147,7 +147,7 @@ async def require_positive_balance(user_id: str, session: AsyncSession, min_cred
         if row.is_balance_frozen:
             raise BalanceFrozenError(f"User {user_id} balance is frozen")
         if float(row.credits or 0) <= min_credits:
-            raise InsufficientCreditsError("Insufficient credits. Please recharge to continue.11")
+            raise InsufficientCreditsError("Insufficient credits. Please recharge to continue.")
         return
 
     # 2. Admin 路径（无冻结字段）
@@ -341,6 +341,52 @@ async def refund_credits_atomic(
     
     return transaction
 
+async def _drain_balance_to_zero(
+    session: AsyncSession,
+    entity_model,
+    entity_id: str,
+    current_balance: Decimal,
+    attempted_cost: Decimal,
+    metadata: Optional[Dict],
+    transaction_type: str,
+    idempotency_key: Optional[str],
+    is_admin: bool,
+) -> None:
+    """生成已发生但余额不足时，把余额清零并落 underpaid 流水。
+
+    使用 WHERE credits == current_balance 的乐观锁，避免与并发扣费冲突；
+    若并发已把余额改动，跳过本次清零（其他请求已处理）。
+    """
+    if current_balance <= 0:
+        return
+    stmt_clear = (
+        update(entity_model)
+        .where(entity_model.id == entity_id)
+        .where(entity_model.credits == current_balance)
+        .values(credits=0)
+        .execution_options(synchronize_session="fetch")
+    )
+    res = await session.execute(stmt_clear)
+    if res.rowcount <= 0:
+        return  # 并发竞争：其他请求已扣，无需重复
+    tx_meta = dict(metadata or {})
+    tx_meta.update({
+        "underpaid": True,
+        "attempted_cost": float(attempted_cost),
+    })
+    transaction = CreditTransaction(
+        user_id=None if is_admin else entity_id,
+        admin_id=entity_id if is_admin else None,
+        amount=-float(current_balance),
+        balance_before=float(current_balance),
+        balance_after=0,
+        transaction_type=transaction_type,
+        metadata_json=tx_meta,
+        idempotency_key=idempotency_key,
+    )
+    session.add(transaction)
+
+
 async def deduct_credits_atomic(
     user_id: str, 
     cost: float, 
@@ -454,8 +500,23 @@ async def deduct_credits_atomic(
     if row:
         if row.is_balance_frozen:
             raise BalanceFrozenError(f"User {user_id} balance is frozen")
-        if float(row.credits or 0) < float(cost_val):
-            logger.warning(f"Insufficient credits for user {user_id}. Cost: {cost}")
+        current_balance_user = float(row.credits or 0)
+        if current_balance_user < float(cost_val):
+            # 兜底：扣到 0，避免生成已发生但用户余额未变的白嫖漏洞
+            await _drain_balance_to_zero(
+                session=session,
+                entity_model=User,
+                entity_id=user_id,
+                current_balance=Decimal(str(row.credits or 0)),
+                attempted_cost=cost_val,
+                metadata=metadata,
+                transaction_type=transaction_type,
+                idempotency_key=idempotency_key,
+                is_admin=False,
+            )
+            logger.warning(
+                f"Insufficient credits for user {user_id}. Cost: {cost}, drained {current_balance_user}"
+            )
             raise InsufficientCreditsError(f"Insufficient credits. Required: {cost}")
     
     stmt_check_admin = select(Admin.credits).where(Admin.id == user_id)
@@ -463,7 +524,22 @@ async def deduct_credits_atomic(
     row_admin = res_check_admin.scalar()
     
     if row_admin is not None and float(row_admin or 0) < float(cost_val):
-        logger.warning(f"Insufficient credits for admin {user_id}. Cost: {cost}")
+        current_balance_admin = float(row_admin or 0)
+        # 兜底：扣到 0，避免生成已发生但管理员余额未变的白嫖漏洞
+        await _drain_balance_to_zero(
+            session=session,
+            entity_model=Admin,
+            entity_id=user_id,
+            current_balance=Decimal(str(row_admin or 0)),
+            attempted_cost=cost_val,
+            metadata=metadata,
+            transaction_type=transaction_type,
+            idempotency_key=idempotency_key,
+            is_admin=True,
+        )
+        logger.warning(
+            f"Insufficient credits for admin {user_id}. Cost: {cost}, drained {current_balance_admin}"
+        )
         raise InsufficientCreditsError(f"Insufficient credits. Required: {cost}")
     
     if not row and row_admin is None:

--- a/backend/services/chat_generation.py
+++ b/backend/services/chat_generation.py
@@ -632,7 +632,7 @@ async def generate_single_agent(
                     billing_event["credit_cost"] = round(credit_cost, 6)
 
                     try:
-                        (credit_cost > 0) and await deduct_credits_atomic(
+                        tx = (credit_cost > 0) and await deduct_credits_atomic(
                             user_id=entity_id,
                             cost=credit_cost,
                             session=session,
@@ -640,8 +640,13 @@ async def generate_single_agent(
                             transaction_type="consumption",
                             idempotency_key=f"chat:{assistant_msg_id}",
                         )
+                        # 同步最新余额到 SSE 事件，前端即时刷新顶栏积分
+                        tx and hasattr(tx, 'balance_after') and billing_event.update(
+                            {"remaining_credits": round(float(tx.balance_after), 6)}
+                        )
                     except InsufficientCreditsError:
                         billing_event["insufficient"] = True
+                        billing_event["remaining_credits"] = 0  # 兜底已扣到 0
                         logger.warning(f"Credits depleted for {'admin' if is_admin else 'user'} {entity_id}. Cost: {credit_cost}")
                     except BalanceFrozenError:
                         billing_event["frozen"] = True

--- a/backend/services/music_generation.py
+++ b/backend/services/music_generation.py
@@ -99,7 +99,7 @@ async def _do_register_music_asset(audio_url: str, mime_type: str, user_id: str,
 # 实时通知辅助
 # ---------------------------------------------------------------------------
 
-async def _push_music_event(user_id: str, task) -> None:
+async def _push_music_event(user_id: str, task, billing_underpaid: bool = False, remaining_credits: Optional[float] = None) -> None:
     """将音乐任务终态推送给前端（安静失败）。"""
     try:
         from realtime.dispatcher import push_to_user
@@ -111,6 +111,8 @@ async def _push_music_event(user_id: str, task) -> None:
                 "status": task.status,
                 "audio_url": task.result_audio_url,
                 "lyrics": task.lyrics,
+                "billing_underpaid": billing_underpaid,
+                "remaining_credits": remaining_credits,
             },
         )
     except Exception as exc:  # noqa: BLE001
@@ -166,8 +168,10 @@ async def execute_music_task_background(
         # ---- 计费 ----
         credit_cost = 0.0
         billing_metadata: dict = {}
+        billing_underpaid = False  # 本次扣费是否不足被兜底扣到 0
+        remaining_credits: Optional[float] = None  # 扣费后用户余额
         try:
-            credit_cost, billing_metadata = await _calculate_and_deduct(
+            credit_cost, billing_metadata, billing_underpaid, remaining_credits = await _calculate_and_deduct(
                 db, provider_id, music_ctx.model, user_id, task_id,
             )
         except Exception as exc:
@@ -182,15 +186,15 @@ async def execute_music_task_background(
         await db.commit()
 
         logger.info(
-            "Music task %s completed: %s (cost=%.4f)",
-            task_id, audio_url, credit_cost,
+            "Music task %s completed: %s (cost=%.4f, underpaid=%s, remaining=%s)",
+            task_id, audio_url, credit_cost, billing_underpaid, remaining_credits,
         )
 
         # ---- 画布音频节点创建（可选） ----
         theater_id and await _create_canvas_audio_node(db, theater_id, audio_url, task)
 
         # ---- 实时通知前端（兼容 arq worker 和 fallback 路径） ----
-        await _push_music_event(user_id, task)
+        await _push_music_event(user_id, task, billing_underpaid=billing_underpaid, remaining_credits=remaining_credits)
 
     except Exception:
         logger.exception("Music background task %s crashed", task_id)
@@ -218,9 +222,14 @@ async def _calculate_and_deduct(
     model: str,
     user_id: str,
     task_id: str,
-) -> tuple[float, dict]:
-    """计算音乐生成费用并原子扣费。"""
-    from services.billing import deduct_credits_atomic, load_pricing
+) -> tuple[float, dict, bool, Optional[float]]:
+    """计算音乐生成费用并原子扣费。
+
+    返回 (cost, metadata, underpaid, remaining_credits)：
+    - underpaid=True 表示本次扣费不足、余额被兜底扣到 0
+    - remaining_credits 为扣费后用户最新余额（免费任务为 None）
+    """
+    from services.billing import deduct_credits_atomic, load_pricing, InsufficientCreditsError
 
     # 从 ModelPricing（供应商, 模型）读取积分卖价
     rate_map = await load_pricing(provider_id, model, db)
@@ -235,17 +244,29 @@ async def _calculate_and_deduct(
         "task_id": task_id,
     }
 
-    # 仅在有费用时扣费
-    total_cost > 0 and await deduct_credits_atomic(
-        user_id=user_id,
-        cost=total_cost,
-        session=db,
-        metadata=metadata,
-        transaction_type="consumption",
-        idempotency_key=f"music:{task_id}",
-    )
+    # 仅在有费用时扣费；扣费不足时 deduct_credits_atomic 会把余额兜底扣到 0 并抛 InsufficientCreditsError
+    underpaid = False
+    remaining_credits: Optional[float] = None
+    try:
+        tx = total_cost > 0 and await deduct_credits_atomic(
+            user_id=user_id,
+            cost=total_cost,
+            session=db,
+            metadata=metadata,
+            transaction_type="consumption",
+            idempotency_key=f"music:{task_id}",
+        )
+        # 同步最新余额供上层推送给前端
+        tx and hasattr(tx, 'balance_after') and (remaining_credits := float(tx.balance_after))
+    except InsufficientCreditsError:
+        underpaid = True
+        remaining_credits = 0.0
+        logger.warning(
+            "Music task %s underpaid: user=%s cost=%.4f, balance drained to 0",
+            task_id, user_id, total_cost,
+        )
 
-    return total_cost, metadata
+    return total_cost, metadata, underpaid, remaining_credits
 
 
 # ---------------------------------------------------------------------------

--- a/backend/services/music_generation.py
+++ b/backend/services/music_generation.py
@@ -186,8 +186,8 @@ async def execute_music_task_background(
         await db.commit()
 
         logger.info(
-            "Music task %s completed: %s (cost=%.4f, underpaid=%s, remaining=%s)",
-            task_id, audio_url, credit_cost, billing_underpaid, remaining_credits,
+            "Music task %s completed: %s (cost=%.4f, remaining=%s)",
+            task_id, audio_url, credit_cost, remaining_credits,
         )
 
         # ---- 画布音频节点创建（可选） ----

--- a/frontend/src/components/ai-assistant/MessageInput.tsx
+++ b/frontend/src/components/ai-assistant/MessageInput.tsx
@@ -34,6 +34,7 @@ import type { CanvasNode } from '@/store/useCanvasStore';
 import { selectNodesByUpdatedDesc } from '@/store/useCanvasStore';
 import { extractNodeAttachment } from '@/lib/nodeAttachmentUtils';
 import { NodePickerDropdown, type NodePickerItem } from '@/components/canvas/NodePickerDropdown';
+import { useCreditsGuard } from '@/hooks/useCreditsGuard';
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 const MAX_FILES = 10;
@@ -320,6 +321,7 @@ export function MessageInput({
   maxFileSize = MAX_FILE_SIZE,
 }: MessageInputProps) {
   const { t } = useTranslation();
+  const { creditsExhausted, tooltipText } = useCreditsGuard();
   const resolvedPlaceholder = placeholder ?? t('ai.inputPlaceholder');
   const resolvedAgentName = agentName ?? t('ai.title');
   const [inputValue, setInputValue] = useState('');
@@ -768,14 +770,14 @@ export function MessageInput({
                 <Button
                   type="submit"
                   size="icon"
-                  disabled={!canSend || isDisabled}
+                  disabled={!canSend || isDisabled || creditsExhausted}
                   className={cn(
                     'h-8 w-8 rounded-lg transition-all duration-200',
-                    !canSend || isDisabled
+                    !canSend || isDisabled || creditsExhausted
                       ? 'bg-muted text-muted-foreground cursor-not-allowed'
                       : 'bg-primary hover:bg-primary/90 text-primary-foreground shadow-sm hover:shadow-md'
                   )}
-                  title={t('ai.send')}
+                  title={creditsExhausted ? tooltipText : t('ai.send')}
                 >
                   <Send className="h-4 w-4" />
                 </Button>

--- a/frontend/src/components/ai-assistant/MusicTaskCard.tsx
+++ b/frontend/src/components/ai-assistant/MusicTaskCard.tsx
@@ -3,9 +3,11 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Music, Loader2, CheckCircle2, XCircle, Clock, Download } from 'lucide-react';
 import { motion } from 'framer-motion';
+import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import api from '@/lib/api';
 import { handleAudioDragStart, cleanupDragPreview } from '@/lib/dragToCanvas';
+import { useAuth } from '@/context/AuthContext';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -29,6 +31,10 @@ interface MusicTaskStatus {
   model?: string;
   lyrics?: string;
   output_format?: string;
+  // 后端扣费不足、余额被兜底扣到 0 时为 true（不持久化，仅响应携带）
+  billing_underpaid?: boolean;
+  // 本次扣费后用户余额（不持久化，用于前端同步 user.credits）
+  remaining_credits?: number | null;
 }
 
 // Terminal states that stop polling
@@ -140,6 +146,9 @@ export function MusicTaskCard({ task, className }: MusicTaskCardProps) {
 
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const mountedRef = useRef(true);
+  // 仅提示一次余额被兜底扣到 0 的事件
+  const underpaidNotifiedRef = useRef(false);
+  const { updateCredits } = useAuth();
 
   const pollStatus = useCallback(async () => {
     try {
@@ -158,6 +167,18 @@ export function MusicTaskCard({ task, className }: MusicTaskCardProps) {
     data.error_message && setErrorMsg(data.error_message);
     data.model && setModel(data.model);
     data.lyrics && setLyrics(data.lyrics);
+
+    // 后端扣费后同步最新余额到 AuthContext，驱动 useCreditsGuard 即时生效
+    data.remaining_credits != null && updateCredits(data.remaining_credits);
+
+    // 后端扣费不足、余额被兜底扣到 0 时提示一次
+    data.billing_underpaid && !underpaidNotifiedRef.current && (
+      (underpaidNotifiedRef.current = true),
+      toast.warning(
+        '本次操作已扣除您剩余的全部积分，余额已为 0。请充值后继续使用。',
+        { duration: 4500 },
+      )
+    );
 
     TERMINAL_STATES.has(data.status) && stopPolling();
   };

--- a/frontend/src/components/ai-assistant/VideoTaskCard.tsx
+++ b/frontend/src/components/ai-assistant/VideoTaskCard.tsx
@@ -3,9 +3,11 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Film, Loader2, CheckCircle2, XCircle, Clock, Download } from 'lucide-react';
 import { motion } from 'framer-motion';
+import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import api from '@/lib/api';
 import { handleVideoDragStart, cleanupDragPreview } from '@/lib/dragToCanvas';
+import { useAuth } from '@/context/AuthContext';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -32,6 +34,10 @@ interface VideoTaskStatus {
   error_message?: string;
   video_mode?: string;
   model?: string;
+  // 后端扣费不足、余额被兜底扣到 0 时为 true（不持久化，仅响应携带）
+  billing_underpaid?: boolean;
+  // 本次扣费后用户余额（不持久化，用于前端同步 user.credits）
+  remaining_credits?: number | null;
 }
 
 // Terminal states that stop polling
@@ -142,6 +148,9 @@ export function VideoTaskCard({ task, className }: VideoTaskCardProps) {
 
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const mountedRef = useRef(true);
+  // 仅提示一次余额被兜底扣到 0 的事件
+  const underpaidNotifiedRef = useRef(false);
+  const { updateCredits } = useAuth();
 
   const pollStatus = useCallback(async () => {
     try {
@@ -162,6 +171,18 @@ export function VideoTaskCard({ task, className }: VideoTaskCardProps) {
     data.error_message && setErrorMsg(data.error_message);
     data.video_mode && setVideoMode(data.video_mode);
     data.model && setModel(data.model);
+
+    // 后端扣费后同步最新余额到 AuthContext，驱动 useCreditsGuard 即时生效
+    data.remaining_credits != null && updateCredits(data.remaining_credits);
+
+    // 后端扣费不足、余额被兜底扣到 0 时提示一次
+    data.billing_underpaid && !underpaidNotifiedRef.current && (
+      (underpaidNotifiedRef.current = true),
+      toast.warning(
+        '本次操作已扣除您剩余的全部积分，余额已为 0。请充值后继续使用。',
+        { duration: 4500 },
+      )
+    );
 
     // Stop polling on terminal state
     TERMINAL_STATES.has(data.status) && stopPolling();

--- a/frontend/src/components/ai-assistant/hooks/useSSEHandler.ts
+++ b/frontend/src/components/ai-assistant/hooks/useSSEHandler.ts
@@ -645,9 +645,10 @@ export function useSSEHandler() {
           return prev;
         });
         // 积分不足友好提醒（多智能体模式）
+        // 后端在扣费不足时已将剩余余额扣到 0，文案应准确反映该语义
         (d.billing_status === 'insufficient') && setMessages((prev) => [
           ...prev,
-          { role: 'ai', content: '提示：您的积分余额已不足，本次消耗未能完全扣除。请及时充值以继续使用。', status: 'complete' },
+          { role: 'ai', content: '提示：本次消耗已扣除您剩余的全部积分，余额已为 0。请充值后继续使用。', status: 'complete' },
         ]);
       },
 
@@ -668,9 +669,10 @@ export function useSSEHandler() {
         // 实时更新用户积分余额
         (d.remaining_credits !== undefined) && updateCredits(d.remaining_credits);
         // 积分不足友好提醒
+        // 后端在扣费不足时已将剩余余额扣到 0，文案应准确反映该语义
         d.insufficient && setMessages((prev) => [
           ...prev,
-          { role: 'ai', content: '提示：您的积分余额已不足，本次消耗未能扣除。请及时充值以继续使用。', status: 'complete' },
+          { role: 'ai', content: '提示：本次消耗已扣除您剩余的全部积分，余额已为 0。请充值后继续使用。', status: 'complete' },
         ]);
         // 账户冻结提醒
         d.frozen && setMessages((prev) => [

--- a/frontend/src/components/canvas/AudioGeneratePanel/PanelActionButtons.tsx
+++ b/frontend/src/components/canvas/AudioGeneratePanel/PanelActionButtons.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { Settings2, Send, Square, ArrowRight } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
+import { useCreditsGuard } from '@/hooks/useCreditsGuard';
 
 interface Props {
   taskActive: boolean;
@@ -26,6 +27,9 @@ export function PanelActionButtons({
   onSubmit,
 }: Props) {
   const { t } = useTranslation();
+  const { creditsExhausted, tooltipText } = useCreditsGuard();
+  const submitDisabled = !canSubmit || creditsExhausted;
+  const submitTitle = creditsExhausted ? tooltipText : t('canvas.node.audio.submit', '生成音乐');
 
   return (
     <>
@@ -57,14 +61,14 @@ export function PanelActionButtons({
         <button
           type="button"
           onClick={onSubmit}
-          disabled={!canSubmit}
+          disabled={submitDisabled}
           className={cn(
             'h-8 w-8 rounded-lg transition-all duration-200 flex items-center justify-center',
-            canSubmit
-              ? 'bg-primary hover:bg-primary/90 text-primary-foreground shadow-sm hover:shadow-md'
-              : 'bg-muted text-muted-foreground cursor-not-allowed',
+            submitDisabled
+              ? 'bg-muted text-muted-foreground cursor-not-allowed'
+              : 'bg-primary hover:bg-primary/90 text-primary-foreground shadow-sm hover:shadow-md',
           )}
-          title={t('canvas.node.audio.submit', '生成音乐')}
+          title={submitTitle}
         >
           <Send className="h-4 w-4" />
         </button>

--- a/frontend/src/components/canvas/ImageGeneratePanel/PanelActionButtons.tsx
+++ b/frontend/src/components/canvas/ImageGeneratePanel/PanelActionButtons.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { Settings2, Send, Square, ArrowRight } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
+import { useCreditsGuard } from '@/hooks/useCreditsGuard';
 
 interface Props {
   taskActive: boolean;
@@ -25,6 +26,9 @@ export function PanelActionButtons({
   onSubmit,
 }: Props) {
   const { t } = useTranslation();
+  const { creditsExhausted, tooltipText } = useCreditsGuard();
+  const submitDisabled = !canSubmit || creditsExhausted;
+  const submitTitle = creditsExhausted ? tooltipText : t('canvas.node.image.submit', '开始生成');
 
   return (
     <>
@@ -57,14 +61,14 @@ export function PanelActionButtons({
         <button
           type="button"
           onClick={onSubmit}
-          disabled={!canSubmit}
+          disabled={submitDisabled}
           className={cn(
             'h-8 w-8 rounded-lg transition-all duration-200 flex items-center justify-center',
-            canSubmit
-              ? 'bg-primary hover:bg-primary/90 text-primary-foreground shadow-sm hover:shadow-md'
-              : 'bg-muted text-muted-foreground cursor-not-allowed',
+            submitDisabled
+              ? 'bg-muted text-muted-foreground cursor-not-allowed'
+              : 'bg-primary hover:bg-primary/90 text-primary-foreground shadow-sm hover:shadow-md',
           )}
-          title={t('canvas.node.image.submit', '开始生成')}
+          title={submitTitle}
         >
           <Send className="h-4 w-4" />
         </button>

--- a/frontend/src/components/canvas/VideoGeneratePanel/PanelActionButtons.tsx
+++ b/frontend/src/components/canvas/VideoGeneratePanel/PanelActionButtons.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { Settings2, Send, Square, ArrowRight } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
+import { useCreditsGuard } from '@/hooks/useCreditsGuard';
 
 interface Props {
   taskActive: boolean;
@@ -26,6 +27,9 @@ export function PanelActionButtons({
   onSubmit,
 }: Props) {
   const { t } = useTranslation();
+  const { creditsExhausted, tooltipText } = useCreditsGuard();
+  const submitDisabled = !canSubmit || creditsExhausted;
+  const submitTitle = creditsExhausted ? tooltipText : t('canvas.node.video.submit');
 
   return (
     <>
@@ -57,14 +61,14 @@ export function PanelActionButtons({
         <button
           type="button"
           onClick={onSubmit}
-          disabled={!canSubmit}
+          disabled={submitDisabled}
           className={cn(
             'h-8 w-8 rounded-lg transition-all duration-200 flex items-center justify-center',
-            canSubmit
-              ? 'bg-primary hover:bg-primary/90 text-primary-foreground shadow-sm hover:shadow-md'
-              : 'bg-muted text-muted-foreground cursor-not-allowed',
+            submitDisabled
+              ? 'bg-muted text-muted-foreground cursor-not-allowed'
+              : 'bg-primary hover:bg-primary/90 text-primary-foreground shadow-sm hover:shadow-md',
           )}
-          title={t('canvas.node.video.submit')}
+          title={submitTitle}
         >
           <Send className="h-4 w-4" />
         </button>

--- a/frontend/src/hooks/useCreditsGuard.ts
+++ b/frontend/src/hooks/useCreditsGuard.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useAuth } from '@/context/AuthContext';
+import { useTranslation } from 'react-i18next';
+
+// 与后端 require_positive_balance 的 min_credits 保持一致
+const MIN_CREDITS_THRESHOLD = 0.0001;
+
+/**
+ * 前端积分耗尽预拦截 hook。
+ *
+ * - creditsExhausted：用户积分 <= 0.0001 时为 true，付费入口（视频/图像/音频/AI 对话）应当 disabled
+ * - tooltipText：i18n 文案，hover 提示用户去充值
+ *
+ * 状态来源：AuthContext 的 user.credits，由 SSE billing 事件实时刷新；
+ * 后端「兜底扣到 0」分支会下发 remaining_credits=0，因此本 hook 会随之立即变化。
+ */
+export function useCreditsGuard() {
+  const { user } = useAuth();
+  const { t } = useTranslation();
+  const creditsExhausted = (user?.credits ?? 0) <= MIN_CREDITS_THRESHOLD;
+  const tooltipText = t('errors.creditsEmpty');
+  return { creditsExhausted, tooltipText };
+}

--- a/frontend/src/hooks/useImageGeneration.ts
+++ b/frontend/src/hooks/useImageGeneration.ts
@@ -1,8 +1,10 @@
 'use client';
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { toast } from 'sonner';
 import api from '@/lib/api';
 import { reportError } from '@/lib/canvas/toast';
+import { useAuth } from '@/context/AuthContext';
 
 // ---------------------------------------------------------------------------
 // Types（与后端 routers/images.py 对齐）
@@ -65,6 +67,10 @@ export interface ImageGenerateResponse {
   provider_name?: string;
   credit_cost: number;
   created_at: string;
+  // 后端扣费不足、余额被兜底扣到 0 时为 true（不持久化，仅本次响应携带）
+  billing_underpaid?: boolean;
+  // 本次扣费后用户余额（不持久化，用于前端同步 user.credits）
+  remaining_credits?: number | null;
 }
 
 export interface ImageModel {
@@ -257,6 +263,7 @@ export function useImageGenerationTask() {
   // 最近一次生成的总耗时（ms），导出给节点显示
   const [lastDurationMs, setLastDurationMs] = useState<number | null>(null);
   const mountedRef = useRef(true);
+  const { updateCredits } = useAuth();
 
   useEffect(() => {
     mountedRef.current = true;
@@ -274,6 +281,13 @@ export function useImageGenerationTask() {
       const { data } = await api.post<ImageGenerateResponse>('/images/generate', params);
       const duration = Date.now() - start;
       mountedRef.current && (setResult(data), setLastDurationMs(duration));
+      // 后端扣费后同步最新余额到 AuthContext，驱动 useCreditsGuard 即时生效
+      data.remaining_credits != null && updateCredits(data.remaining_credits);
+      // 后端扣费不足、余额被兜底扣到 0 时提示一次
+      data.billing_underpaid && toast.warning(
+        '本次操作已扣除您剩余的全部积分，余额已为 0。请充值后继续使用。',
+        { duration: 4500 },
+      );
       return data;
     } catch (e: any) {
       const normalized = reportError(e);
@@ -282,7 +296,7 @@ export function useImageGenerationTask() {
     } finally {
       mountedRef.current && (setIsSubmitting(false), setStartedAt(null));
     }
-  }, []);
+  }, [updateCredits]);
 
   const reset = useCallback(() => {
     setResult(null);

--- a/frontend/src/hooks/useMusicGeneration.ts
+++ b/frontend/src/hooks/useMusicGeneration.ts
@@ -1,8 +1,10 @@
 'use client';
 
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import { toast } from 'sonner';
 import api from '@/lib/api';
 import { reportError } from '@/lib/canvas/toast';
+import { useAuth } from '@/context/AuthContext';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -69,6 +71,10 @@ export interface MusicTaskStatus {
   input_image_count?: number;
   created_at: string;
   completed_at?: string;
+  // 后端扣费不足、余额被兜底扣到 0 时为 true（不持久化）
+  billing_underpaid?: boolean;
+  // 本次扣费后用户余额（不持久化，用于前端同步 user.credits）
+  remaining_credits?: number | null;
 }
 
 export interface MusicSubmitResponse {
@@ -277,6 +283,9 @@ export function useMusicTask() {
   const [error, setError] = useState<string | null>(null);
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const mountedRef = useRef(true);
+  // 仅提示一次余额被兜底扣到 0 的事件
+  const underpaidNotifiedRef = useRef(false);
+  const { updateCredits } = useAuth();
 
   const stopPolling = useCallback(() => {
     pollingRef.current && clearInterval(pollingRef.current);
@@ -287,11 +296,21 @@ export function useMusicTask() {
     try {
       const { data } = await api.get<MusicTaskStatus>(`/music/${id}/status`);
       mountedRef.current && setStatus(data);
+      // 后端扣费后同步最新余额到 AuthContext，驱动 useCreditsGuard 即时生效
+      mountedRef.current && data.remaining_credits != null && updateCredits(data.remaining_credits);
+      // 后端扣费不足、余额被兜底扣到 0 时提示一次
+      mountedRef.current && data.billing_underpaid && !underpaidNotifiedRef.current && (
+        (underpaidNotifiedRef.current = true),
+        toast.warning(
+          '本次操作已扣除您剩余的全部积分，余额已为 0。请充值后继续使用。',
+          { duration: 4500 },
+        )
+      );
       TERMINAL_STATES.has(data.status) && stopPolling();
     } catch {
       // keep polling on transient error
     }
-  }, [stopPolling]);
+  }, [stopPolling, updateCredits]);
 
   const submit = useCallback(async (params: MusicCreateParams) => {
     setIsSubmitting(true);

--- a/frontend/src/hooks/useVideoGeneration.ts
+++ b/frontend/src/hooks/useVideoGeneration.ts
@@ -1,8 +1,10 @@
 'use client';
 
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import { toast } from 'sonner';
 import api from '@/lib/api';
 import { reportError } from '@/lib/canvas/toast';
+import { useAuth } from '@/context/AuthContext';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -67,6 +69,10 @@ export interface VideoTaskStatus {
   video_mode?: string;
   model?: string;
   prompt?: string;
+  // 后端扣费不足、余额被兜底扣到 0 时为 true（不持久化，仅响应携带）
+  billing_underpaid?: boolean;
+  // 本次扣费后用户余额（不持久化，用于前端即时同步 user.credits）
+  remaining_credits?: number | null;
 }
 
 // Label maps
@@ -307,6 +313,9 @@ export function useVideoTask() {
   const [error, setError] = useState<string | null>(null);
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const mountedRef = useRef(true);
+  // 仅提示一次余额被兜底扣到 0 的事件
+  const underpaidNotifiedRef = useRef(false);
+  const { updateCredits } = useAuth();
 
   const stopPolling = useCallback(() => {
     pollingRef.current && clearInterval(pollingRef.current);
@@ -317,16 +326,27 @@ export function useVideoTask() {
     try {
       const { data } = await api.get<VideoTaskStatus>(`/videos/${id}/status`);
       mountedRef.current && setStatus(data);
+      // 后端扣费后同步最新余额到 AuthContext，驱动 useCreditsGuard 即时生效
+      mountedRef.current && data.remaining_credits != null && updateCredits(data.remaining_credits);
+      // 后端扣费不足、余额被兜底扣到 0 时提示一次
+      mountedRef.current && data.billing_underpaid && !underpaidNotifiedRef.current && (
+        (underpaidNotifiedRef.current = true),
+        toast.warning(
+          '本次操作已扣除您剩余的全部积分，余额已为 0。请充值后继续使用。',
+          { duration: 4500 },
+        )
+      );
       TERMINAL_STATES.has(data.status) && stopPolling();
     } catch {
       // keep polling on network error
     }
-  }, [stopPolling]);
+  }, [stopPolling, updateCredits]);
 
   const submit = useCallback(async (params: VideoCreateParams) => {
     setIsSubmitting(true);
     setError(null);
     setStatus(null);
+    underpaidNotifiedRef.current = false;
     stopPolling();
 
     try {
@@ -352,6 +372,7 @@ export function useVideoTask() {
     setStatus(null);
     setError(null);
     setIsSubmitting(false);
+    underpaidNotifiedRef.current = false;
   }, [stopPolling]);
 
   useEffect(() => {

--- a/frontend/src/i18n/locales/en-US.json
+++ b/frontend/src/i18n/locales/en-US.json
@@ -755,6 +755,7 @@
     "TIMEOUT": "Request timed out, please retry",
     "REQUEST_CANCELLED": "Request cancelled",
     "UNKNOWN": "Unknown error, please try again",
+    "creditsEmpty": "Credits depleted. Please top up to continue.",
     "retry": "Retry"
   }
 }

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -755,6 +755,7 @@
     "TIMEOUT": "请求超时，请重试",
     "REQUEST_CANCELLED": "请求已取消",
     "UNKNOWN": "未知错误，请重试",
+    "creditsEmpty": "积分余额已用尽，请充值后继续",
     "retry": "重试"
   }
 }


### PR DESCRIPTION
feat(billing): 增加余额不足时扣至零机制并前端即时同步余额
- 在扣费不足导致余额被兜底扣到0时，后端不抛错而是标记billing_underpaid
- 返回remaining_credits字段以便前端即时同步用户最新积分余额
- 扣费逻辑中新增 _drain_balance_to_zero 方法实现余额清零事务
- 图像、视频、音乐任务响应中增加billing_underpaid和remaining_credits字段
- 相关前端组件和hooks根据余额状态禁用操作按钮并给出充值提示
- 支持媒体文件路由HTTP Range请求以实现视频渐进式加载播放
- 后端推送事件同步余额变更，前端toast提醒用户余额已扣至0
- 优化日志记录余额不足及扣费情况，防止生成资源白嫖漏洞