### PR TITLE
perf(stream): 优化客户端重用，提升多进程性能

### DIFF
--- a/backend/services/llm_stream.py
+++ b/backend/services/llm_stream.py
@@ -62,6 +62,49 @@ DEFAULT_BASE_URLS = {
 # 供应商注册表：provider_type -> stream handler
 _PROVIDER_REGISTRY: Dict[str, Callable] = {}
 
+# ---------------------------------------------------------------------------
+# 模块级 HTTP 客户端缓存（复用连接池，避免每次请求重建 TLS 握手）
+# 客户端实例在 fork 后惰性创建，各 worker 独立持有自己的连接池
+# ---------------------------------------------------------------------------
+_HTTP_CLIENT_CACHE: Dict[str, Any] = {}
+
+
+def _get_openai_client(api_key: str, base_url: str | None) -> Any:
+    """获取或创建缓存的 AsyncOpenAI 客户端实例。"""
+    from openai import AsyncOpenAI
+    cache_key = f"openai:{api_key[:16]}:{base_url or ''}"
+    client = _HTTP_CLIENT_CACHE.get(cache_key)
+    if not client:
+        client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+        _HTTP_CLIENT_CACHE[cache_key] = client
+    return client
+
+
+def _get_azure_client(api_key: str, azure_endpoint: str) -> Any:
+    """获取或创建缓存的 AsyncAzureOpenAI 客户端实例。"""
+    from openai import AsyncAzureOpenAI
+    cache_key = f"azure:{api_key[:16]}:{azure_endpoint}"
+    client = _HTTP_CLIENT_CACHE.get(cache_key)
+    if not client:
+        client = AsyncAzureOpenAI(
+            api_key=api_key,
+            api_version="2023-05-15",
+            azure_endpoint=azure_endpoint,
+        )
+        _HTTP_CLIENT_CACHE[cache_key] = client
+    return client
+
+
+def _get_anthropic_client(api_key: str, base_url: str | None) -> Any:
+    """获取或创建缓存的 AsyncAnthropic 客户端实例。"""
+    from anthropic import AsyncAnthropic
+    cache_key = f"anthropic:{api_key[:16]}:{base_url or ''}"
+    client = _HTTP_CLIENT_CACHE.get(cache_key)
+    if not client:
+        client = AsyncAnthropic(api_key=api_key, base_url=base_url)
+        _HTTP_CLIENT_CACHE[cache_key] = client
+    return client
+
 
 def register_provider(*provider_types: str):
     """装饰器：注册供应商处理器"""
@@ -84,11 +127,8 @@ def get_effective_base_url(ctx: StreamContext) -> str | None:
 async def stream_openai(ctx: StreamContext, result: StreamResult) -> AsyncGenerator[str, None]:
     """OpenAI/DeepSeek/OpenRouter 流式调用（支持 tool calling）"""
     from openai import AsyncOpenAI
-    
-    client = AsyncOpenAI(
-        api_key=ctx.api_key,
-        base_url=get_effective_base_url(ctx),
-    )
+
+    client = _get_openai_client(ctx.api_key, get_effective_base_url(ctx))
     
     create_params = {
         "model": ctx.model,
@@ -175,10 +215,7 @@ async def _stream_xai_text(ctx: StreamContext, result: StreamResult) -> AsyncGen
     """xAI/Grok 文本模型流式调用（推理模式 + tool calling）"""
     from openai import AsyncOpenAI
 
-    client = AsyncOpenAI(
-        api_key=ctx.api_key,
-        base_url=get_effective_base_url(ctx),
-    )
+    client = _get_openai_client(ctx.api_key, get_effective_base_url(ctx))
 
     create_params = {
         "model": ctx.model,
@@ -325,10 +362,7 @@ async def _stream_xai_image(ctx: StreamContext, result: StreamResult) -> AsyncGe
         return
 
     # 图像生成模式：使用 AsyncOpenAI SDK images.generate()
-    client = AsyncOpenAI(
-        api_key=ctx.api_key,
-        base_url=base_url,
-    )
+    client = _get_openai_client(ctx.api_key, base_url)
 
     generate_params: Dict[str, Any] = {
         "model": ctx.model,
@@ -451,7 +485,7 @@ async def _stream_ark_image(ctx: StreamContext, result: StreamResult) -> AsyncGe
     from services.media_utils import save_image_from_url
 
     base_url = get_effective_base_url(ctx) or "https://ark.cn-beijing.volces.com/api/v3"
-    client = AsyncOpenAI(api_key=ctx.api_key, base_url=base_url)
+    client = _get_openai_client(ctx.api_key, base_url)
 
     # 从最后一条 user 消息提取 prompt
     prompt_text, _ = _extract_xai_user_input(ctx.messages)
@@ -499,12 +533,8 @@ async def stream_ark(ctx: StreamContext, result: StreamResult) -> AsyncGenerator
 async def stream_azure(ctx: StreamContext, result: StreamResult) -> AsyncGenerator[str, None]:
     """Azure OpenAI 流式调用"""
     from openai import AsyncAzureOpenAI
-    
-    client = AsyncAzureOpenAI(
-        api_key=ctx.api_key,
-        api_version="2023-05-15",
-        azure_endpoint=ctx.base_url,
-    )
+
+    client = _get_azure_client(ctx.api_key, ctx.base_url)
     
     stream = await client.chat.completions.create(
         model=ctx.model,
@@ -532,11 +562,8 @@ async def stream_azure(ctx: StreamContext, result: StreamResult) -> AsyncGenerat
 async def stream_anthropic(ctx: StreamContext, result: StreamResult) -> AsyncGenerator[str, None]:
     """Anthropic/MiniMax 流式调用（支持 tool calling）"""
     from anthropic import AsyncAnthropic
-    
-    client = AsyncAnthropic(
-        api_key=ctx.api_key,
-        base_url=get_effective_base_url(ctx),
-    )
+
+    client = _get_anthropic_client(ctx.api_key, get_effective_base_url(ctx))
     
     # 提取 system message
     system_content = ""

--- a/deploy/backend.Dockerfile
+++ b/deploy/backend.Dockerfile
@@ -68,11 +68,12 @@ USER app
 
 EXPOSE 8000
 
-# tini 作为 PID 1 负责信号转发与僵尸回收；uvicorn 单进程（2C4G 推荐）
+# tini 作为 PID 1 负责信号转发与僵尸回收；uvicorn 2 进程（双核并行，AI 长连接互不阻塞）
+# 注意：多 worker 依赖 Redis 做跨进程事件路由（dispatcher.py），生产已配置 REDIS_URL
 ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["uvicorn", "main:app", \
      "--host", "0.0.0.0", \
      "--port", "8000", \
-     "--workers", "1", \
+     "--workers", "2", \
      "--proxy-headers", \
      "--forwarded-allow-ips=*"]

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -174,11 +174,12 @@ services:
       timeout: 5s
       retries: 5
       start_period: 30s
+    # 生产模式 next start 轻量，降低配额给 Backend 多进程计算使用
     deploy:
       resources:
         limits:
-          cpus: "0.5"
-          memory: 512M
+          cpus: "0.3"
+          memory: 384M
     restart: unless-stopped
     networks: [kunflix_net]
 
@@ -205,11 +206,12 @@ services:
       timeout: 5s
       retries: 5
       start_period: 30s
+    # Admin 低频内部工具，降低配额给 Backend 多进程计算使用
     deploy:
       resources:
         limits:
-          cpus: "0.5"
-          memory: 512M
+          cpus: "0.2"
+          memory: 256M
     restart: unless-stopped
     networks: [kunflix_net]
 


### PR DESCRIPTION
- 添加模块级 HTTP 客户端缓存，复用连接池减少 TLS 握手开销
- 新增获取缓存客户端的工厂函数，支持 OpenAI、Azure 和 Anthropic
- 替换原有直接创建客户端实例的代码，改为复用缓存客户端
- docker 后端服务启动时由单 worker 调整为双 worker，支持多核并行
- docker-compose 降低后台和管理服务的资源配额，保障多进程效率
- 说明多 worker 环境下需依赖 Redis 做跨进程事件路由，完善注释