### PR TITLE
feat(video): 增加视频首帧封面支持及前端加载优化

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,6 +19,9 @@ alembic>=1.18.4
 psycopg2-binary>=2.9.9
 requests>=2.33.1
 Pillow>=12.1.1
+# imageio-ffmpeg 提供静态 ffmpeg 二进制，用于视频首帧 poster 抽帧（media_utils.ensure_video_poster）。
+# 不安装也不影响主流程——ffmpeg 不可用时后端返回 404，前端 fallback 到黑底。
+imageio-ffmpeg>=0.6.0
 bcrypt>=4.0.0
 # python-jose 上游长期未处理 CVE-2024-33663 / CVE-2024-33664，迁移到 PyJWT
 PyJWT[crypto]>=2.12.1

--- a/backend/routers/media.py
+++ b/backend/routers/media.py
@@ -33,6 +33,7 @@ from services.media_utils import (
     ensure_thumbnail,
     ensure_video_poster,
     schedule_video_poster_generation,
+    is_within_directory,
 )
 from storage import get_storage_backend
 from config import settings
@@ -584,6 +585,9 @@ async def serve_video_poster(filename: str):
     )
     poster_path = await ensure_video_poster(filename)
     poster_path or (_ for _ in ()).throw(
+        HTTPException(status_code=404, detail="Poster not available")
+    )
+    is_within_directory(poster_path, MEDIA_DIR) or (_ for _ in ()).throw(
         HTTPException(status_code=404, detail="Poster not available")
     )
     return FileResponse(

--- a/backend/routers/media.py
+++ b/backend/routers/media.py
@@ -2,6 +2,7 @@
 from fastapi import APIRouter, HTTPException, Depends, Request, UploadFile, File, Form, Query, Body
 from fastapi.responses import FileResponse, RedirectResponse, StreamingResponse
 from pathlib import Path
+import asyncio
 import os
 import re
 import logging
@@ -25,7 +26,14 @@ from schemas import (
 from services.batch_image_gen import batch_generate_images, BatchImageConfig
 from services.xai_image_gen import batch_generate_xai_images, XAIBatchImageConfig
 from services.image_config_adapter import to_provider_config
-from services.media_utils import build_media_storage_path, resolve_media_filepath, MEDIA_DIR, ensure_thumbnail
+from services.media_utils import (
+    build_media_storage_path,
+    resolve_media_filepath,
+    MEDIA_DIR,
+    ensure_thumbnail,
+    ensure_video_poster,
+    schedule_video_poster_generation,
+)
 from storage import get_storage_backend
 from config import settings
 
@@ -46,6 +54,9 @@ _SAFE_FILENAME = re.compile(r'^[a-f0-9\-]{36}\.(png|jpg|jpeg|webp|gif|mp4|webm|m
 
 # 缩略图仅接受图片扩展名
 _SAFE_THUMB_FILENAME = re.compile(r'^[a-f0-9\-]{36}\.(png|jpg|jpeg|webp|gif)$')
+
+# 视频 poster 仅接受视频扩展名
+_SAFE_POSTER_FILENAME = re.compile(r'^[a-f0-9\-]{36}\.(mp4|webm|mov|ogg)$')
 
 
 async def _fallback_presign_post(
@@ -192,6 +203,9 @@ async def upload_media(
 
     await db.commit()
     await db.refresh(asset)
+
+    # 视频上传后 fire-and-forget 预热 poster，首次访问 /api/media/poster/* 即命中缓存
+    file_type == "video" and asyncio.create_task(schedule_video_poster_generation(new_filename))
 
     return {"url": f"/api/media/{new_filename}", "asset": _asset_to_response(asset)}
 
@@ -552,6 +566,31 @@ async def serve_media_thumbnail(filename: str):
     )
     handler = _THUMB_BACKEND_DISPATCH.get(settings.STORAGE_BACKEND, _serve_thumb_local)
     return await handler(filename)
+
+
+# ---------------------------------------------------------------------------
+# 视频 poster（首帧封面）路由 — 必须放在通配符 /{filename} 之前
+# ---------------------------------------------------------------------------
+
+@router.get("/poster/{filename}")
+async def serve_video_poster(filename: str):
+    """提供视频首帧封面（首次访问按需 ffmpeg 抽帧，后续命中磁盘缓存）。
+
+    请求示例：GET /api/media/poster/{uuid}.mp4 → 返回对应的 .jpg 首帧。
+    ffmpeg 不可用 / 抽帧失败 / 原视频不存在 → 404（前端 fallback 到黑底）。
+    """
+    _SAFE_POSTER_FILENAME.match(filename) or (_ for _ in ()).throw(
+        HTTPException(status_code=400, detail="Invalid poster filename")
+    )
+    poster_path = await ensure_video_poster(filename)
+    poster_path or (_ for _ in ()).throw(
+        HTTPException(status_code=404, detail="Poster not available")
+    )
+    return FileResponse(
+        poster_path,
+        media_type="image/jpeg",
+        headers={"Cache-Control": "public, max-age=31536000, immutable"},
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/services/media_utils.py
+++ b/backend/services/media_utils.py
@@ -355,7 +355,10 @@ async def ensure_video_poster(video_filename: str, max_size: int = POSTER_MAX_SI
         return None
 
     POSTER_DIR.mkdir(parents=True, exist_ok=True)
-    poster_path = POSTER_DIR / f"{video_filename}.jpg"
+    poster_path = (POSTER_DIR / f"{video_filename}.jpg").resolve()
+    if not is_within_directory(poster_path, POSTER_DIR):
+        logger.warning("Rejected unsafe poster path for filename: %s", video_filename)
+        return None
 
     # 已落盘 → 命中
     if poster_path.is_file():

--- a/backend/services/media_utils.py
+++ b/backend/services/media_utils.py
@@ -1,5 +1,7 @@
 """媒体文件保存工具 — 支持用户级目录隔离"""
 import asyncio
+import shutil
+import subprocess
 from pathlib import Path
 import uuid
 import logging
@@ -12,6 +14,13 @@ MEDIA_DIR = Path(__file__).resolve().parent.parent / "media"
 THUMB_DIR_NAME = "_thumbs"
 THUMB_DIR = MEDIA_DIR / THUMB_DIR_NAME
 THUMB_MAX_SIZE = 480  # 长边像素，覆盖 2x dpr 下卡片 ~240px 显示宽度
+
+# 视频 poster（首帧封面）缓存目录
+POSTER_DIR = THUMB_DIR / "poster"
+POSTER_MAX_SIZE = 480
+
+# 视频扩展名集合（用于 poster 生成判定）
+_VIDEO_EXTS = {"mp4", "webm", "mov", "ogg"}
 
 # 媒体 API 前缀（用于 URL 改写）
 MEDIA_URL_PREFIX = "/api/media/"
@@ -143,6 +152,11 @@ async def save_video_from_url(video_url: str, headers: dict | None = None, user_
         await asyncio.to_thread(filepath.write_bytes, resp.content)
 
     logger.info(f"Saved video: {filename} ({len(resp.content)} bytes) from {video_url}")
+
+    # 后台异步预热 poster（fire-and-forget，不阻塞调用方返回）
+    # 不取于 ffmpeg 是否可用 — 不可用时 schedule_video_poster_generation 会静默回退
+    asyncio.create_task(schedule_video_poster_generation(filename))
+
     return f"/api/media/{filename}"
 
 
@@ -255,3 +269,106 @@ async def ensure_thumbnail(filename: str, max_size: int = THUMB_MAX_SIZE) -> Pat
         return None
 
     return thumb_path
+
+
+# ---------------------------------------------------------------------------
+# 视频 poster（首帧封面）：ffmpeg 抽帧 + 落盘缓存
+# ---------------------------------------------------------------------------
+
+def _resolve_ffmpeg_binary() -> str | None:
+    """获取 ffmpeg 可执行文件路径。
+
+    优先使用 imageio-ffmpeg 提供的静态二进制（pip 安装自带，跨平台），
+    回退到系统 PATH 上的 ffmpeg。两者都不存在返回 None。
+    """
+    try:
+        from imageio_ffmpeg import get_ffmpeg_exe
+        return get_ffmpeg_exe()
+    except Exception:
+        return shutil.which("ffmpeg")
+
+
+def _generate_video_poster(src: Path, dst: Path, max_size: int) -> bool:
+    """同步抽取视频首帧作为 poster JPG。写临时文件再原子替换，避免并发读到半成品。
+
+    成功返回 True；ffmpeg 不可用 / 抽帧失败返回 False。
+    """
+    ffmpeg = _resolve_ffmpeg_binary()
+    if not ffmpeg:
+        logger.debug("ffmpeg binary not available, skip poster generation: %s", src.name)
+        return False
+
+    tmp = dst.with_suffix(dst.suffix + f".{uuid.uuid4().hex}.tmp")
+    # -ss 1 跳到 1 秒位置抽帧（避开常见黑帧开场）；视频不足 1 秒 ffmpeg 会回退到首帧。
+    # scale='min(W,iw)':-2 保证长边 ≤ W 且高度为偶数。
+    cmd = [
+        ffmpeg,
+        "-y",
+        "-ss", "1",
+        "-i", str(src),
+        "-frames:v", "1",
+        "-vf", f"scale='min({max_size},iw)':-2",
+        "-q:v", "6",
+        "-loglevel", "error",
+        str(tmp),
+    ]
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, timeout=30)
+        success = result.returncode == 0 and tmp.is_file() and tmp.stat().st_size > 0
+        if not success:
+            tmp.exists() and tmp.unlink(missing_ok=True)
+            logger.warning(
+                "ffmpeg poster generation failed for %s: rc=%s stderr=%s",
+                src.name, result.returncode, (result.stderr or b"").decode(errors="ignore")[:300],
+            )
+            return False
+        tmp.replace(dst)
+        return True
+    except subprocess.TimeoutExpired:
+        tmp.exists() and tmp.unlink(missing_ok=True)
+        logger.warning("ffmpeg poster generation timeout: %s", src.name)
+        return False
+    except Exception as exc:
+        tmp.exists() and tmp.unlink(missing_ok=True)
+        logger.warning("ffmpeg poster generation error for %s: %s", src.name, exc)
+        return False
+
+
+async def ensure_video_poster(video_filename: str, max_size: int = POSTER_MAX_SIZE) -> Path | None:
+    """确保视频 poster 已生成，返回 poster 磁盘路径。
+
+    - 缓存路径：MEDIA_DIR / _thumbs / poster / {video_filename}.jpg
+    - 原文件缺失 / ffmpeg 不可用 / 非视频扩展名 → 返回 None
+    """
+    ext = video_filename.rsplit(".", 1)[-1].lower() if "." in video_filename else ""
+    if ext not in _VIDEO_EXTS:
+        return None
+
+    POSTER_DIR.mkdir(parents=True, exist_ok=True)
+    poster_path = POSTER_DIR / f"{video_filename}.jpg"
+
+    # 已落盘 → 命中
+    if poster_path.is_file():
+        return poster_path
+
+    src = resolve_media_filepath(video_filename)
+    if src is None:
+        return None
+
+    ok = await asyncio.to_thread(_generate_video_poster, src, poster_path, max_size)
+    return poster_path if ok else None
+
+
+async def schedule_video_poster_generation(video_filename: str) -> None:
+    """fire-and-forget 预热：在后台异步生成视频 poster，失败不抛异常。
+
+    调用位置：
+      - 用户上传视频成功后
+      - AI 生成视频保存完成后
+    提前生成使前端首次访问 /api/media/poster/* 即命中缓存。
+    """
+    try:
+        await ensure_video_poster(video_filename)
+    except Exception as exc:
+        logger.warning("Background video poster generation failed for %s: %s", video_filename, exc)

--- a/backend/services/media_utils.py
+++ b/backend/services/media_utils.py
@@ -5,6 +5,7 @@ import subprocess
 from pathlib import Path
 import uuid
 import logging
+import re
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +31,9 @@ POSTER_MAX_SIZE = 480
 
 # 视频扩展名集合（用于 poster 生成判定）
 _VIDEO_EXTS = {"mp4", "webm", "mov", "ogg"}
+
+# 服务层二次校验：仅允许 UUID + 视频扩展名
+_SAFE_POSTER_FILENAME = re.compile(r'^[a-f0-9\-]{36}\.(mp4|webm|mov|ogg)$')
 
 # 媒体 API 前缀（用于 URL 改写）
 MEDIA_URL_PREFIX = "/api/media/"
@@ -350,6 +354,10 @@ async def ensure_video_poster(video_filename: str, max_size: int = POSTER_MAX_SI
     - 缓存路径：MEDIA_DIR / _thumbs / poster / {video_filename}.jpg
     - 原文件缺失 / ffmpeg 不可用 / 非视频扩展名 → 返回 None
     """
+    if not _SAFE_POSTER_FILENAME.match(video_filename):
+        logger.warning("Rejected unsafe poster filename: %s", video_filename)
+        return None
+
     ext = video_filename.rsplit(".", 1)[-1].lower() if "." in video_filename else ""
     if ext not in _VIDEO_EXTS:
         return None

--- a/backend/services/media_utils.py
+++ b/backend/services/media_utils.py
@@ -358,12 +358,22 @@ async def ensure_video_poster(video_filename: str, max_size: int = POSTER_MAX_SI
         logger.warning("Rejected unsafe poster filename: %s", video_filename)
         return None
 
-    ext = video_filename.rsplit(".", 1)[-1].lower() if "." in video_filename else ""
+    if "." not in video_filename:
+        return None
+    stem, ext = video_filename.rsplit(".", 1)
+    ext = ext.lower()
     if ext not in _VIDEO_EXTS:
         return None
+    try:
+        safe_stem = str(uuid.UUID(stem))
+    except ValueError:
+        logger.warning("Rejected unsafe poster stem: %s", video_filename)
+        return None
+
+    safe_video_filename = f"{safe_stem}.{ext}"
 
     POSTER_DIR.mkdir(parents=True, exist_ok=True)
-    poster_path = (POSTER_DIR / f"{video_filename}.jpg").resolve()
+    poster_path = (POSTER_DIR / f"{safe_video_filename}.jpg").resolve()
     if not is_within_directory(poster_path, POSTER_DIR):
         logger.warning("Rejected unsafe poster path for filename: %s", video_filename)
         return None

--- a/backend/services/media_utils.py
+++ b/backend/services/media_utils.py
@@ -8,6 +8,15 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
+def is_within_directory(path: Path, base_dir: Path) -> bool:
+    """检查 path 归一化后是否位于 base_dir 内。"""
+    try:
+        path.resolve().relative_to(base_dir.resolve())
+        return True
+    except ValueError:
+        return False
+
 MEDIA_DIR = Path(__file__).resolve().parent.parent / "media"
 
 # 缩略图缓存目录（首页/列表场景使用，原图保持不变）

--- a/frontend/src/components/canvas/VideoNode.tsx
+++ b/frontend/src/components/canvas/VideoNode.tsx
@@ -28,7 +28,7 @@ import {
   MIN_HEIGHT,
   VIDEO_ACCEPT,
 } from './VideoNode/constants';
-import { normalizeVideoUrl } from './VideoNode/utils';
+import { normalizeVideoUrl, deriveVideoPosterUrl } from './VideoNode/utils';
 import { NodeHeader } from './VideoNode/NodeHeader';
 import { VideoDisplay } from './VideoNode/VideoDisplay';
 import { GenerationOverlay } from './VideoNode/GenerationOverlay';
@@ -171,9 +171,15 @@ const VideoNode = ({ id, data, selected }: NodeProps<Node<VideoNodeData>>) => {
   }, [upload]);
 
   // ── 视频尺寸自适应 ──
+  // 防重复触发：记录已经为哪些 videoUrl 同步过节点尺寸，同一 url 只调一次
+  // updateNodeDimensions。避免：进入画布 → N 个视频 metadata 几乎同时完成 → N 次
+  // store 写入 + ReactFlow 重算 layout 冲击主线程。
+  const sizedUrlRef = useRef<string | null>(null);
   const handleLoadedMetadata = useCallback((e: React.SyntheticEvent<HTMLVideoElement>) => {
     const video = e.currentTarget;
     if (!video.videoWidth || !video.videoHeight) return;
+    // 已经为同一 url 同步过尺寸 → 跳过
+    if (sizedUrlRef.current === data.videoUrl) return;
     const aspectRatio = video.videoWidth / video.videoHeight;
     let newWidth: number;
     let newHeight: number;
@@ -191,8 +197,10 @@ const VideoNode = ({ id, data, selected }: NodeProps<Node<VideoNodeData>>) => {
     const currentWidth = currentNode.width ?? 0;
     const currentHeight = currentNode.height ?? 0;
     const shouldResize = Math.abs(currentWidth - newWidth) > 5 || Math.abs(currentHeight - newHeight) > 5;
+    // 记录已处理该 url（无论尺寸是否实际变化），后续重复事件不再踏入 store
+    sizedUrlRef.current = data.videoUrl || null;
     shouldResize && updateNodeDimensions(id, Math.round(newWidth), Math.round(newHeight));
-  }, [getNode, id, updateNodeDimensions]);
+  }, [data.videoUrl, getNode, id, updateNodeDimensions]);
 
   // ── 历史拖放 ──
   const historyVideos = data.generatedVideos || [];
@@ -289,6 +297,7 @@ const VideoNode = ({ id, data, selected }: NodeProps<Node<VideoNodeData>>) => {
             {data.videoUrl && (
               <VideoDisplay
                 videoUrl={data.videoUrl}
+                posterUrl={deriveVideoPosterUrl(data.videoUrl)}
                 fitMode={fitMode}
                 quality={videoTask.status?.quality}
                 onLoadedMetadata={handleLoadedMetadata}

--- a/frontend/src/components/canvas/VideoNode/HistorySidebar.tsx
+++ b/frontend/src/components/canvas/VideoNode/HistorySidebar.tsx
@@ -4,6 +4,7 @@ import React, { type DragEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 import type { VideoGenHistoryEntry } from '@/store/useCanvasStore';
+import { deriveVideoPosterUrl } from './utils';
 
 interface Props {
   historyVideos: VideoGenHistoryEntry[];
@@ -30,45 +31,58 @@ export function HistorySidebar({
   const { t } = useTranslation();
   if (historyVideos.length === 0) return null;
 
+  // 性能：showHistory 为 false 时整体不渲染缩略图列表，避免 <video preload="metadata">
+  // 在隐藏状态下偷偷加载占用浏览器同源连接池。
   return (
     <>
-      <div
-        className={cn(
-          'absolute right-full top-0 bottom-0 mr-4 flex flex-col nodrag nopan z-10 transition-all duration-200',
-          showHistory ? 'w-[80px] opacity-100' : 'w-0 opacity-0 pointer-events-none',
-        )}
-      >
-        <div className="flex-1 overflow-y-auto overflow-x-hidden custom-scrollbar flex flex-col gap-1.5 py-1">
-          {historyVideos.map((v, i) => (
-            <div
-              key={`${v.url}-${i}`}
-              draggable
-              onDragStart={(e) => onDragStart(e, v)}
-              onDragEnd={(e) => onDragEnd(e, v)}
-              onClick={() => onClick(v.url)}
-              className={cn(
-                'w-[72px] h-[56px] rounded-md border overflow-hidden cursor-grab active:cursor-grabbing shrink-0 relative group/hist transition-all',
-                currentVideoUrl === v.url
-                  ? 'border-primary ring-1 ring-primary/50'
-                  : 'border-border/50 hover:border-primary/50',
-              )}
-              title={v.prompt || v.quality || t('canvas.node.video.aiGenerated')}
-            >
-              <video
-                src={v.url}
-                className="w-full h-full object-cover pointer-events-none"
-                muted
-                preload="metadata"
-              />
-              {v.quality && (
-                <span className="absolute bottom-0 right-0 px-1 py-px text-[8px] font-medium bg-black/70 text-white rounded-tl">
-                  {v.quality}
-                </span>
-              )}
-            </div>
-          ))}
+      {showHistory && (
+        <div className="absolute right-full top-0 bottom-0 mr-4 flex flex-col nodrag nopan z-10 w-[80px] transition-all duration-200">
+          <div className="flex-1 overflow-y-auto overflow-x-hidden custom-scrollbar flex flex-col gap-1.5 py-1">
+            {historyVideos.map((v, i) => {
+              const poster = deriveVideoPosterUrl(v.url);
+              return (
+                <div
+                  key={`${v.url}-${i}`}
+                  draggable
+                  onDragStart={(e) => onDragStart(e, v)}
+                  onDragEnd={(e) => onDragEnd(e, v)}
+                  onClick={() => onClick(v.url)}
+                  className={cn(
+                    'w-[72px] h-[56px] rounded-md border overflow-hidden cursor-grab active:cursor-grabbing shrink-0 relative group/hist transition-all',
+                    currentVideoUrl === v.url
+                      ? 'border-primary ring-1 ring-primary/50'
+                      : 'border-border/50 hover:border-primary/50',
+                  )}
+                  title={v.prompt || v.quality || t('canvas.node.video.aiGenerated')}
+                >
+                  {/* 优先用 poster 静态封面（一张图，比加载视频 metadata 轻得多）；缺失时 fallback 到 <video preload="none"> */}
+                  {poster ? (
+                    <img
+                      src={poster}
+                      alt={v.prompt || ''}
+                      className="w-full h-full object-cover pointer-events-none"
+                      loading="lazy"
+                      decoding="async"
+                    />
+                  ) : (
+                    <video
+                      src={v.url}
+                      className="w-full h-full object-cover pointer-events-none"
+                      muted
+                      preload="none"
+                    />
+                  )}
+                  {v.quality && (
+                    <span className="absolute bottom-0 right-0 px-1 py-px text-[8px] font-medium bg-black/70 text-white rounded-tl">
+                      {v.quality}
+                    </span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
         </div>
-      </div>
+      )}
 
       <button
         type="button"

--- a/frontend/src/components/canvas/VideoNode/VideoDisplay.tsx
+++ b/frontend/src/components/canvas/VideoNode/VideoDisplay.tsx
@@ -1,29 +1,122 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import {
+  acquireVideoSlot,
+  isVideoMetadataLoaded,
+  markVideoMetadataLoaded,
+} from '@/lib/canvas/videoLoadQueue';
 
 interface Props {
   videoUrl: string;
+  /**
+   * 可选 poster（首帧封面）。视频未加载 metadata 前显示，避免黑屏空等。
+   * 通常由父组件根据 videoUrl 派生（例如 `/api/media/<uuid>.mp4` →
+   * `/api/media/poster/<uuid>.jpg`）。
+   */
+  posterUrl?: string;
   fitMode: 'cover' | 'contain';
   quality?: string;
   onLoadedMetadata: (e: React.SyntheticEvent<HTMLVideoElement>) => void;
 }
 
 /**
- * 视频播放区域：video 元素 + 拖拽遮罩 + 右上分辨率徽章
+ * 视频播放区域：video 元素 + 拖拽遮罩 + 右上分辨率徽章。
+ *
+ * 性能优化：
+ *   1. IntersectionObserver 视口懒加载 — 视口外不挂载 <video>，避免占用浏览器
+ *      同源连接池（HTTP/1.1 默认 6 个），不阻塞 AI 面板等其他请求。
+ *   2. 全局并发队列（acquireVideoSlot）— 即使多个节点同时进入视口，也限制最多
+ *      3 个并发加载 metadata，错峰排队。
+ *   3. metadata 加载后通过 markVideoMetadataLoaded 缓存 URL；同一视频再次进入
+ *      视口时直接放行，无需排队。
  */
-export function VideoDisplay({ videoUrl, fitMode, quality, onLoadedMetadata }: Props) {
+export function VideoDisplay({ videoUrl, posterUrl, fitMode, quality, onLoadedMetadata }: Props) {
   const { t } = useTranslation();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const releaseRef = useRef<(() => void) | null>(null);
+
+  // 是否进入视口（IntersectionObserver 控制）
+  const [isInView, setIsInView] = useState(false);
+  // 是否已获得队列槽位、可以挂载真实 <video src>
+  const [canLoad, setCanLoad] = useState<boolean>(() => isVideoMetadataLoaded(videoUrl));
+
+  // 切换 videoUrl 时重置加载状态：已知 url 直接放行，未知则等待视口+队列
+  useEffect(() => {
+    setCanLoad(isVideoMetadataLoaded(videoUrl));
+  }, [videoUrl]);
+
+  // 视口检测：进入视口（含 200px 预热边界）后置 isInView=true，永久保持
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      (entries) => entries.forEach((entry) => entry.isIntersecting && setIsInView(true)),
+      { rootMargin: '200px 200px 200px 200px', threshold: 0.01 },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  // 进入视口后通过全局队列获取加载槽位
+  useEffect(() => {
+    const need = isInView && !canLoad && !!videoUrl;
+    if (!need) return;
+    let cancelled = false;
+    acquireVideoSlot().then((release) => {
+      cancelled
+        ? release()
+        : ((releaseRef.current = release), setCanLoad(true));
+    });
+    return () => {
+      cancelled = true;
+      releaseRef.current?.();
+      releaseRef.current = null;
+    };
+  }, [isInView, canLoad, videoUrl]);
+
+  // 卸载时释放槽位（兜底，正常应在 onLoadedMetadata 中释放）
+  useEffect(() => {
+    return () => {
+      releaseRef.current?.();
+      releaseRef.current = null;
+    };
+  }, []);
+
+  const handleLoadedMetadata = (e: React.SyntheticEvent<HTMLVideoElement>) => {
+    const video = e.currentTarget;
+    markVideoMetadataLoaded(videoUrl);
+    releaseRef.current?.();
+    releaseRef.current = null;
+    // 自动 seek 到 0.1 秒，触发浏览器渲染该帧（解决 preload="metadata" 黑屏问题）。
+    // 仅在暂停 + 未 seek 过时执行，避免打断正在播放或用户已手动 seek 的视频。
+    // 视频不足 0.1 秒时浏览器会自动 clamp 到末帧，不会报错。
+    video.paused && !video.currentTime && (video.currentTime = 0.1);
+    onLoadedMetadata(e);
+  };
+
+  // 加载失败兜底释放（避免一个坏 URL 永久占据槽位）
+  const handleError = () => {
+    releaseRef.current?.();
+    releaseRef.current = null;
+  };
+
   return (
-    <div className="w-full h-full flex flex-col items-center justify-center relative group/video">
+    <div
+      ref={containerRef}
+      className="w-full h-full flex flex-col items-center justify-center relative group/video"
+    >
+      {/* video 元素：仅在获得槽位后才设置 src，避免占用连接池 */}
       <video
-        src={videoUrl}
+        src={canLoad ? videoUrl : undefined}
+        poster={posterUrl || undefined}
         controls
         preload="metadata"
         className={`w-full h-full rounded-sm nodrag ${fitMode === 'cover' ? 'object-cover' : 'object-contain'}`}
         onPointerDown={(e) => e.stopPropagation()}
-        onLoadedMetadata={onLoadedMetadata}
+        onLoadedMetadata={handleLoadedMetadata}
+        onError={handleError}
       />
 
       {/* 拖拽遮罩 — 覆盖顶部播放区域但避开控制条 */}

--- a/frontend/src/components/canvas/VideoNode/utils.ts
+++ b/frontend/src/components/canvas/VideoNode/utils.ts
@@ -5,3 +5,16 @@ export function normalizeVideoUrl(raw: string): string {
   const needsPrefix = !!raw && !raw.startsWith('http') && !raw.startsWith('/api/media/') && !raw.startsWith('data:');
   return needsPrefix ? `/api/media/${raw}` : raw;
 }
+
+/**
+ * 由视频 URL 派生 poster（首帧封面）URL：
+ *   /api/media/<uuid>.mp4  →  /api/media/poster/<uuid>.mp4
+ *
+ * - 仅对本地媒体（/api/media/ 前缀）生效；外部 URL / data URL / 空字符串返回 null
+ * - 后端 /api/media/poster/{filename} 端点会按需生成 .jpg 缩略封面并缓存
+ */
+export function deriveVideoPosterUrl(videoUrl: string | undefined | null): string | undefined {
+  const raw = (videoUrl || '').trim();
+  const isLocalMedia = raw.startsWith('/api/media/') && !raw.startsWith('/api/media/poster/');
+  return isLocalMedia ? raw.replace('/api/media/', '/api/media/poster/') : undefined;
+}

--- a/frontend/src/lib/canvas/videoLoadQueue.ts
+++ b/frontend/src/lib/canvas/videoLoadQueue.ts
@@ -1,0 +1,76 @@
+/**
+ * 视频元数据加载并发队列
+ *
+ * 解决问题：
+ *   画布初始化时，N 个 <video preload="metadata"> 会同时发起请求，
+ *   塞满浏览器 HTTP/1.1 同源连接池（默认 6 个），导致 AI 面板的 fetch / SSE
+ *   请求被排到队尾，表现为"打开 AI 面板对话需要等待"。
+ *
+ * 设计：
+ *   - 全局最多 MAX_CONCURRENT 个 acquire 同时持有"加载槽位"
+ *   - acquire() 返回 release 回调；持有期间允许该 url 设置 <video src>
+ *   - release() 自动唤醒下一个等待者（FIFO）
+ *   - markLoaded(url) 记录已加载过 metadata 的 url，再次访问可立即放行（跳过排队）
+ */
+const MAX_CONCURRENT = 3;
+
+type Releaser = () => void;
+type Starter = () => void;
+
+let activeCount = 0;
+const waiting: Starter[] = [];
+const loadedUrls = new Set<string>();
+
+/**
+ * 申请一个视频元数据加载槽位。
+ * - 槽位空闲：立刻返回 release 回调
+ * - 槽位已满：返回 Promise，等待前置释放后才 resolve
+ *
+ * 调用方应在 metadata 加载完成 / 出错 / 组件卸载时调用 release()。
+ * 重复调用 release() 是安全的（内部幂等）。
+ */
+export function acquireVideoSlot(): Promise<Releaser> {
+  return new Promise<Releaser>((resolve) => {
+    let released = false;
+    const release: Releaser = () => {
+      released && (() => {})();
+      released || ((released = true), activeCount--, drainNext());
+    };
+
+    const start: Starter = () => {
+      activeCount++;
+      resolve(release);
+    };
+
+    activeCount < MAX_CONCURRENT ? start() : waiting.push(start);
+  });
+}
+
+function drainNext() {
+  const next = waiting.shift();
+  next?.();
+}
+
+/**
+ * 标记某个视频 URL 的 metadata 已加载完成。
+ * 该 URL 之后再次进入视口时，可直接放行（不需排队）。
+ */
+export function markVideoMetadataLoaded(url: string) {
+  url && loadedUrls.add(url);
+}
+
+/**
+ * 查询某个 URL 是否已加载过 metadata。
+ */
+export function isVideoMetadataLoaded(url: string): boolean {
+  return !!url && loadedUrls.has(url);
+}
+
+/**
+ * 仅供测试/调试使用：重置队列状态。
+ */
+export function _resetVideoLoadQueueForTest() {
+  activeCount = 0;
+  waiting.length = 0;
+  loadedUrls.clear();
+}


### PR DESCRIPTION
- 后端新增 /api/media/poster/{filename} 路由，动态生成并缓存视频首帧封面
- 引入 imageio-ffmpeg 依赖，优先使用其静态 ffmpeg 二进制抽帧，失败则返回 404
- 上传或生成视频后后台异步预热视频封面，提升首次访问性能
- media_utils 新增视频封面生成、缓存路径及抽帧实现
- 前端 VideoNode 组件新增 deriveVideoPosterUrl，优先展示视频封面图片
- 历史侧边栏视频列表支持封面图，隐藏时避免视频 metadata 预加载
- VideoDisplay 组件引入视口懒加载及并发队列，限制视频元数据加载数，防止阻塞其他请求
- 实现视频元数据加载队列，避免并发请求过多导致浏览器连接池排满
- 优化 VideoNode 尺寸自适应，避免同一视频处理多次更新布局