### PR TITLE
fix(canvas): 修改 image 到 audio 的边缘规则为允许

### DIFF
--- a/backend/services/tool_manager/providers/_canvas_edge_rules.py
+++ b/backend/services/tool_manager/providers/_canvas_edge_rules.py
@@ -36,7 +36,7 @@ EDGE_LEGALITY_MATRIX: dict[str, dict[str, EdgeLegality]] = {
         "text": "allow", "image": "allow", "video": "allow", "audio": "allow", "storyboard": "allow",
     },
     "image": {
-        "text": "deferred", "image": "allow", "video": "allow", "audio": "forbid", "storyboard": "allow",
+        "text": "deferred", "image": "allow", "video": "allow", "audio": "allow", "storyboard": "allow",
     },
     "video": {
         "text": "deferred", "image": "allow", "video": "allow", "audio": "deferred", "storyboard": "allow",

--- a/backend/skills/active_skills/canvas_tools/SKILL.md
+++ b/backend/skills/active_skills/canvas_tools/SKILL.md
@@ -119,7 +119,7 @@ Both `create_canvas_edge` and the frontend `onConnect` handler MUST validate aga
 | Source \\ Target | text | image | video | audio | storyboard |
 |---|---|---|---|---|---|
 | **text**       | allow (append/continue) | allow (fill prompt)         | allow (fill prompt)           | allow (fill lyrics/TTS)    | allow (append row / column text) |
-| **image**      | deferred (OCR/caption)  | allow (image-to-image ref)  | allow (first-frame / ref)     | forbid                     | allow (fill media column)        |
+| **image**      | deferred (OCR/caption)  | allow (image-to-image ref)  | allow (first-frame / ref)     | allow (reference image)    | allow (fill media column)        |
 | **video**      | deferred (subtitle)     | allow (frame extract)       | allow (style/continuation)    | deferred (audio extract)   | allow (fill media column)        |
 | **audio**      | deferred (ASR)          | forbid                      | allow (voiceover input)       | deferred (mix)             | allow (fill media column)        |
 | **storyboard** | allow (flatten rows)    | allow (batch generate)      | allow (batch generate)        | allow (batch generate)     | allow (append/merge rows)        |

--- a/frontend/src/components/canvas/AudioGeneratePanel/AttachmentPreviews.tsx
+++ b/frontend/src/components/canvas/AudioGeneratePanel/AttachmentPreviews.tsx
@@ -43,7 +43,7 @@ export function AttachmentPreviews({
           <img
             src={r.url}
             alt={r.name || ''}
-            className="h-12 w-12 rounded-md object-cover border border-border/50"
+            className="h-14 w-14 rounded-md object-cover"
           />
           <button
             type="button"

--- a/frontend/src/lib/canvas/__tests__/edgeRules.test.ts
+++ b/frontend/src/lib/canvas/__tests__/edgeRules.test.ts
@@ -121,10 +121,9 @@ describe('validateEdge 矩阵', () => {
     existingEdges: noEdges,
   } as const;
 
-  it('image→audio：forbid', () => {
+  it('image→audio：allow', () => {
     const r = validateEdge({ ...base, sourceType: 'image', targetType: 'audio' });
-    expect(r.ok).toBe(false);
-    expect(r.reason).toBe('forbidden_type_combination');
+    expect(r.ok).toBe(true);
   });
 
   it('audio→image：forbid', () => {
@@ -162,8 +161,8 @@ describe('validateEdge 矩阵', () => {
 });
 
 describe('getEdgeLegality', () => {
-  it('image→audio = forbid', () => {
-    expect(getEdgeLegality('image', 'audio')).toBe('forbid');
+  it('image→audio = allow', () => {
+    expect(getEdgeLegality('image', 'audio')).toBe('allow');
   });
   it('video→text = deferred', () => {
     expect(getEdgeLegality('video', 'text')).toBe('deferred');

--- a/frontend/src/lib/canvas/edgePayload.ts
+++ b/frontend/src/lib/canvas/edgePayload.ts
@@ -267,8 +267,8 @@ function injectToVideo(_targetNode: CanvasNode, payload: EdgePayload, sourceNode
   return handler ? handler() : emptyResult;
 }
 
-/** 下游 audio：text→lyrics 追加；image 由矩阵拦截；video/audio 为 deferred */
-function injectToAudio(targetNode: CanvasNode, payload: EdgePayload): InjectionResult {
+/** 下游 audio：text→lyrics 追加；image→smart-image-inject（仅多模态音频模型生效）；video/audio 为 deferred */
+function injectToAudio(targetNode: CanvasNode, payload: EdgePayload, sourceNodeId: string): InjectionResult {
   const data = targetNode.data as AudioNodeData;
   const handlers: Partial<Record<EdgePayload['kind'], () => InjectionResult>> = {
     text: () => {
@@ -276,6 +276,18 @@ function injectToAudio(targetNode: CanvasNode, payload: EdgePayload): InjectionR
       const existing = data.lyrics || '';
       const next = existing.trim().length > 0 ? `${existing}\n\n${p.content}` : p.content;
       return { dataPatch: { lyrics: next.slice(0, TEXT_PROMPT_MAX) } };
+    },
+    image: () => {
+      const p = payload as Extract<EdgePayload, { kind: 'image' }>;
+      // 与 image→image / image→video 一致：派发 smart-image-inject，
+      // 面板按 urls.length 自处理（AudioGeneratePanel 已订阅；仅 Lyria 等多模态模型渲染参考图区）
+      return {
+        panelEvents: [{
+          type: 'smart-image-inject',
+          sourceNodeId,
+          urls: p.urls,
+        }],
+      };
     },
   };
   const handler = handlers[payload.kind];
@@ -362,7 +374,7 @@ export function injectPayload(
     text: () => injectToText(targetNode, payload),
     image: () => injectToImage(targetNode, payload, sourceNodeId),
     video: () => injectToVideo(targetNode, payload, sourceNodeId),
-    audio: () => injectToAudio(targetNode, payload),
+    audio: () => injectToAudio(targetNode, payload, sourceNodeId),
     storyboard: () => injectToStoryboard(targetNode, payload),
   };
   const handler = targetNode.type ? dispatch[targetNode.type] : null;

--- a/frontend/src/lib/canvas/edgeRules.ts
+++ b/frontend/src/lib/canvas/edgeRules.ts
@@ -47,7 +47,7 @@ export const EDGE_LEGALITY_MATRIX: Record<NodeType, Record<NodeType, EdgeLegalit
     text: 'deferred',
     image: 'allow',
     video: 'allow',
-    audio: 'forbid',
+    audio: 'allow',
     storyboard: 'allow',
   },
   video: {


### PR DESCRIPTION
- 修正后端_canvas_edge_rules中 image→audio 由 forbid 改为 allow
- 更新文档 SKILL.md 中 image→audio 描述为 allow（参考图像）
- 前端 canvas 的 edgeRules 同步调整 image→audio 为 allow
- 相关测试用例更新，image→audio 验证通过
- edgePayload 中音频注入函数增加对图像类型的 smart-image-inject 派发支持
- 调整 AudioGeneratePanel 附件预览图片尺寸样式，去除边框显示