### PR TITLE
feat(canvas): 新增全景图节点支持

### DIFF
--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -4,7 +4,8 @@ from datetime import datetime
 
 
 # 画布节点类型常量
-NODE_TYPES = {"script", "character", "storyboard", "video"}
+# 注：保留 "script"/"character" 旧名以兼容历史数据；新节点统一使用迁移后名称。
+NODE_TYPES = {"script", "character", "storyboard", "video", "panorama"}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/services/tool_manager/providers/_canvas_edge_rules.py
+++ b/backend/services/tool_manager/providers/_canvas_edge_rules.py
@@ -9,9 +9,13 @@ Canvas edge rules — mirror of frontend/src/lib/canvas/edgeRules.ts.
  - 前端拒绝 → 后端放行：Agent 工具绕过校验
 
 设计原则：
- 1. 矩阵写死为纯常量；5x5 结构与前端逐字母一致。
+ 1. 矩阵写死为纯常量；6x6 结构与前端逐字母一致。
  2. validate_edge 只判定合法性；不处理内容注入（后端当前版本仅做建边）。
  3. 所有检查走早返回，避免嵌套 if。
+
+Panorama 节点说明：
+ - panorama 行/列在 MVP 阶段全部为 'deferred'（仅自环 allow），表示与其他节点
+   类型的连线注入语义尚未在前端 edgePayload.ts 中实现；后续迭代再按需放行。
 """
 from __future__ import annotations
 
@@ -28,24 +32,27 @@ EdgeRejectReason = Literal[
     "unknown_type",
 ]
 
-NODE_TYPES: tuple[str, ...] = ("text", "image", "video", "audio", "storyboard")
+NODE_TYPES: tuple[str, ...] = ("text", "image", "video", "audio", "storyboard", "panorama")
 
-# 5x5 合法性矩阵（Source → Target）——必须与 edgeRules.md 第 4 节逐格对齐。
+# 6x6 合法性矩阵（Source → Target）——必须与前端 edgeRules.ts 逐格对齐。
 EDGE_LEGALITY_MATRIX: dict[str, dict[str, EdgeLegality]] = {
     "text": {
-        "text": "allow", "image": "allow", "video": "allow", "audio": "allow", "storyboard": "allow",
+        "text": "allow", "image": "allow", "video": "allow", "audio": "allow", "storyboard": "allow", "panorama": "deferred",
     },
     "image": {
-        "text": "deferred", "image": "allow", "video": "allow", "audio": "allow", "storyboard": "allow",
+        "text": "deferred", "image": "allow", "video": "allow", "audio": "allow", "storyboard": "allow", "panorama": "deferred",
     },
     "video": {
-        "text": "deferred", "image": "allow", "video": "allow", "audio": "deferred", "storyboard": "allow",
+        "text": "deferred", "image": "allow", "video": "allow", "audio": "deferred", "storyboard": "allow", "panorama": "deferred",
     },
     "audio": {
-        "text": "deferred", "image": "forbid", "video": "allow", "audio": "deferred", "storyboard": "allow",
+        "text": "deferred", "image": "forbid", "video": "allow", "audio": "deferred", "storyboard": "allow", "panorama": "deferred",
     },
     "storyboard": {
-        "text": "allow", "image": "allow", "video": "allow", "audio": "allow", "storyboard": "allow",
+        "text": "allow", "image": "allow", "video": "allow", "audio": "allow", "storyboard": "allow", "panorama": "deferred",
+    },
+    "panorama": {
+        "text": "deferred", "image": "deferred", "video": "deferred", "audio": "deferred", "storyboard": "deferred", "panorama": "allow",
     },
 }
 

--- a/backend/services/tool_manager/providers/canvas.py
+++ b/backend/services/tool_manager/providers/canvas.py
@@ -49,6 +49,7 @@ NODE_TYPE_SCHEMA = {
     "video":      {"name": str, "description": str, "videoUrl": str, "fitMode": str},
     "audio":      {"name": str, "description": str, "audioUrl": str, "lyrics": str},
     "storyboard": {"shotNumber": str, "description": str, "duration": int, "pivotConfig": Any, "tableData": Any, "tableColumns": Any},
+    "panorama":   {"name": str, "description": str, "panoramaUrl": str},
 }
 
 _DEFAULT_NODE_WIDTH = 420

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@e965/xlsx": "^0.20.3",
         "@floating-ui/react": "^0.27.19",
         "@paper-design/shaders-react": "^0.0.76",
+        "@photo-sphere-viewer/core": "^5.14.1",
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -2806,6 +2807,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@photo-sphere-viewer/core": {
+      "version": "5.14.1",
+      "resolved": "https://registry.npmmirror.com/@photo-sphere-viewer/core/-/core-5.14.1.tgz",
+      "integrity": "sha512-qrwUudrX9YZms4c2shlY/H3jUP0oh9FyGEqIDr/95ulNZgKbhQ6C/i8zDQ4j8ooFR4+z5FDORQtGvLgPyX8VCA==",
+      "license": "MIT",
+      "dependencies": {
+        "three": "^0.179.0"
       }
     },
     "node_modules/@pixi/colord": {
@@ -50936,6 +50946,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/three": {
+      "version": "0.179.1",
+      "resolved": "https://registry.npmmirror.com/three/-/three-0.179.1.tgz",
+      "integrity": "sha512-5y/elSIQbrvKOISxpwXCR4sQqHtGiOI+MKLc3SsBdDXA2hz3Mdp3X59aUp8DyybMa34aeBwbFTpdoLJaUDEWSw==",
+      "license": "MIT"
     },
     "node_modules/throttle-debounce": {
       "version": "5.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@e965/xlsx": "^0.20.3",
     "@floating-ui/react": "^0.27.19",
     "@paper-design/shaders-react": "^0.0.76",
+    "@photo-sphere-viewer/core": "^5.14.1",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/frontend/src/app/theater/[id]/page.tsx
+++ b/frontend/src/app/theater/[id]/page.tsx
@@ -27,6 +27,7 @@ import CharacterNode from '@/components/canvas/ImageNode';
 import StoryboardNode from '@/components/canvas/StoryboardNode';
 import VideoNode from '@/components/canvas/VideoNode';
 import AudioNode from '@/components/canvas/AudioNode';
+import PanoramaNode from '@/components/canvas/PanoramaNode';
 import GhostNode from '@/components/canvas/GhostNode';
 import { CustomEdge } from '@/components/canvas/CustomEdge';
 import { AIAssistantPanel } from '@/components/canvas/AIAssistantPanel';
@@ -50,6 +51,7 @@ const nodeTypes = {
   storyboard: StoryboardNode,
   video: VideoNode,
   audio: AudioNode,
+  panorama: PanoramaNode,
   ghost: GhostNode,
 } as unknown as NodeTypes;
 

--- a/frontend/src/components/canvas/ImageGeneratePanel.tsx
+++ b/frontend/src/components/canvas/ImageGeneratePanel.tsx
@@ -57,6 +57,20 @@ export default function ImageGeneratePanel(props: ImageGeneratePanelProps) {
 
   const [showConfig, setShowConfig] = useState(false);
 
+  // 响应 modeRequest 中的 prompt / aspectRatio overrides（一键场景如“生成全景图”）
+  // - token 驱动：同一 token 只应用一次，避免覆盖用户后续修改
+  const appliedOverrideTokenRef = useRef<number | null>(null);
+  useEffect(() => {
+    const tok = modeRequest?.token ?? null;
+    const should = tok !== null && appliedOverrideTokenRef.current !== tok;
+    should && (() => {
+      appliedOverrideTokenRef.current = tok;
+      modeRequest!.promptOverride && form.setPrompt(modeRequest!.promptOverride);
+      modeRequest!.aspectRatioOverride && form.setAspectRatio(modeRequest!.aspectRatioOverride);
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [modeRequest]);
+
   // 图像节点连线到图像节点的注入处理：
   // 设计原则：连线 == 「源节点加入参考图列表」，**不**主动切换生成模式，由用户手动选择。
   // - 源节点可能有多张图，这里只取第一张作为该源对应的参考图（一个源节点 → 一个参考图条目）。

--- a/frontend/src/components/canvas/ImageGeneratePanel/types.ts
+++ b/frontend/src/components/canvas/ImageGeneratePanel/types.ts
@@ -12,11 +12,14 @@ export interface ImageRef {
  * 外部触发的模式切换请求（用于 ImageNode 工具条快捷按钮）。
  * - token 变化视为一次新的请求；相同 token 不重复应用。
  * - preselectImages 用于自动预设一或多张参考图（单图编辑传 1 张，多图参考传多张）。
+ * - promptOverride / aspectRatioOverride 用于一键场景（如“生成全景图”）自动填充提示词与画面比例。
  */
 export interface ImagePanelModeRequest {
   mode: ImageMode;
   token: number;
   preselectImages?: ImageRef[];
+  promptOverride?: string;
+  aspectRatioOverride?: string;
 }
 
 export interface ImageGeneratePanelProps {

--- a/frontend/src/components/canvas/ImageNode.tsx
+++ b/frontend/src/components/canvas/ImageNode.tsx
@@ -11,6 +11,7 @@ import {
   CharacterNodeData,
   CanvasNode,
   ImageGenHistoryEntry,
+  type PanoramaNodeData,
 } from '@/store/useCanvasStore';
 import { useAIAssistantStore } from '@/store/useAIAssistantStore';
 import { useResourceStore } from '@/store/useResourceStore';
@@ -65,7 +66,50 @@ const CharacterNode = ({ id, data, selected }: NodeProps<Node<CharacterNodeData>
   }, [data.images, data.imageUrl]);
 
   // ── AI 生成 ──
-  const gen = useImageGenerationApply(id, data);
+  // panoramaPendingRef：一键“生成全景图”意图标记。点击全景按钮后置 true；
+  // 生成完成时 onCustomApply 消费该标记并创建全景节点。其他快捷模式点击会重置为 false。
+  const panoramaPendingRef = useRef(false);
+
+  const handleCustomApply = useCallback((urls: string[]): boolean => {
+    const isPanorama = panoramaPendingRef.current;
+    panoramaPendingRef.current = false;
+    if (!isPanorama || urls.length === 0) return false;
+
+    // 创建全景节点（右侧偏移）
+    const currentNode = getNode(id);
+    const posX = (currentNode?.position.x ?? 0) + (currentNode?.measured?.width ?? 512) + 80;
+    const posY = currentNode?.position.y ?? 0;
+    const panoramaNodeId = uuidv4();
+    const panoramaNode: CanvasNode = {
+      id: panoramaNodeId,
+      type: 'panorama',
+      position: { x: posX, y: posY },
+      width: 512,
+      height: 320,
+      data: {
+        name: t('canvas.node.image.panoramaGenName', '生成全景图'),
+        panoramaUrl: urls[0],
+        uploading: false,
+      } as PanoramaNodeData,
+    };
+    addNode(panoramaNode);
+
+    // 程序化连线（绕过 deferred 矩阵校验）
+    const { edges } = useCanvasStore.getState();
+    const newEdge = {
+      id: uuidv4(),
+      source: id,
+      target: panoramaNodeId,
+      sourceHandle: 'right-source',
+      targetHandle: 'left-target',
+      type: 'custom' as const,
+      animated: true,
+    };
+    useCanvasStore.setState({ edges: [...edges, newEdge], isDirty: true });
+    return true;
+  }, [id, addNode, getNode, t]);
+
+  const gen = useImageGenerationApply(id, data, { onCustomApply: handleCustomApply });
   const { imageTask, taskActive, taskDone, taskFailed, elapsedMs, prevImagesRef } = gen;
 
   // ── 连线维护 ──
@@ -93,6 +137,19 @@ const CharacterNode = ({ id, data, selected }: NodeProps<Node<CharacterNodeData>
 
   // ── 快捷模式切换 ──
   const quick = useQuickImageMode(id, data, imageList, normalizeImageUrl);
+
+  // ── 一键生成全景图：填充面板参数，用户手动提交 ──
+  const handleGeneratePanoramaClick = useCallback((e?: React.MouseEvent) => {
+    e?.stopPropagation();
+    panoramaPendingRef.current = true;
+    quick.handleGeneratePanorama(e);
+  }, [quick]);
+
+  // 其他快捷模式点击：重置全景意图标记（避免跨点击变为全景生成）
+  const handleQuickModeWrapped = useCallback((mode: 'text_to_image' | 'edit' | 'reference_images', e?: React.MouseEvent) => {
+    panoramaPendingRef.current = false;
+    quick.handleQuickMode(mode, e);
+  }, [quick]);
 
   // ── 节点级 UI 状态 ──
   const [imageDimensions, setImageDimensions] = useState<{ width: number; height: number } | null>(null);
@@ -359,8 +416,9 @@ const CharacterNode = ({ id, data, selected }: NodeProps<Node<CharacterNodeData>
                 imageList={imageList}
                 showEditPicker={quick.showEditPicker}
                 pickerRef={quick.editPickerRef}
-                onQuickMode={quick.handleQuickMode}
+                onQuickMode={handleQuickModeWrapped}
                 onPickEditImage={quick.handlePickEditImage}
+                onGeneratePanorama={handleGeneratePanoramaClick}
               />
             )}
 

--- a/frontend/src/components/canvas/ImageNode/QuickModeSwitcher.tsx
+++ b/frontend/src/components/canvas/ImageNode/QuickModeSwitcher.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { Wand2, Images } from 'lucide-react';
+import { Wand2, Images, Globe } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 import type { ImageMode } from '@/hooks/useImageGeneration';
@@ -13,6 +13,8 @@ interface Props {
   pickerRef: React.RefObject<HTMLDivElement | null>;
   onQuickMode: (mode: ImageMode, e?: React.MouseEvent) => void;
   onPickEditImage: (url: string, e?: React.MouseEvent) => void;
+  /** 一键生成全景图：填充面板的参数（edit 模式 + 21:9 + 全景提示词） */
+  onGeneratePanorama?: (e?: React.MouseEvent) => void;
 }
 
 /**
@@ -26,6 +28,7 @@ export function QuickModeSwitcher({
   pickerRef,
   onQuickMode,
   onPickEditImage,
+  onGeneratePanorama,
 }: Props) {
   const { t } = useTranslation();
   return (
@@ -93,6 +96,17 @@ export function QuickModeSwitcher({
         >
           <Images className="h-3.5 w-3.5" />
         </button>
+        {onGeneratePanorama && (
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); onGeneratePanorama(e); }}
+            onPointerDown={(e) => e.stopPropagation()}
+            title={t('canvas.node.image.generatePanorama', '生成全景图')}
+            className="h-7 w-7 rounded-full bg-background/90 backdrop-blur-md border border-border/60 shadow-sm text-muted-foreground hover:text-foreground hover:bg-secondary active:scale-90 transition-all flex items-center justify-center"
+          >
+            <Globe className="h-3.5 w-3.5" />
+          </button>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/canvas/PanoramaNode.tsx
+++ b/frontend/src/components/canvas/PanoramaNode.tsx
@@ -1,0 +1,483 @@
+'use client';
+
+import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import { NodeProps, Node, NodeResizer, useReactFlow } from '@xyflow/react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Globe, Upload, FolderOpen, Maximize2, Camera, Copy, Trash2, Loader2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useCanvasStore, type PanoramaNodeData, type CanvasNode, type CharacterNodeData } from '@/store/useCanvasStore';
+import { useResourceStore } from '@/store/useResourceStore';
+import NodeEffectOverlay from './NodeEffectOverlay';
+import { NodeToolbar, type ToolbarAction } from './NodeToolbar';
+import { Input } from '@/components/ui/input';
+
+// ── Hooks ──
+import { useInlineTitleEdit } from '@/hooks/useInlineTitleEdit';
+
+// ── 子组件 ──
+import { EdgeHandles } from './PanoramaNode/EdgeHandles';
+import { FullscreenPortal } from './PanoramaNode/FullscreenPortal';
+import { AssetPickerPortal } from './PanoramaNode/AssetPickerPortal';
+import { PromptBuilder } from './PanoramaNode/PromptBuilder';
+import {
+  MIN_WIDTH,
+  MIN_HEIGHT,
+  PANORAMA_ACCEPT,
+  PANORAMA_MAX_BYTES,
+  PANORAMA_MIME_TYPES,
+} from './PanoramaNode/constants';
+
+const PanoramaNode = ({ id, data, selected }: NodeProps<Node<PanoramaNodeData>>) => {
+  const { t } = useTranslation();
+  const updateNodeData = useCanvasStore((s) => s.updateNodeData);
+  const deleteNode = useCanvasStore((s) => s.deleteNode);
+  const addNode = useCanvasStore((s) => s.addNode);
+  const { getNode, screenToFlowPosition } = useReactFlow();
+
+  // ── 标题编辑 ──
+  const commitTitle = useCallback((name: string) => {
+    updateNodeData(id, { name });
+  }, [id, updateNodeData]);
+  const title = useInlineTitleEdit(data.name || '', commitTitle);
+
+  // ── 节点级 UI 状态 ──
+  const [showAddMenu, setShowAddMenu] = useState(false);
+  const [showAssetPicker, setShowAssetPicker] = useState(false);
+  const [showFullscreen, setShowFullscreen] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [uploadProgress, setUploadProgress] = useState(0);
+
+  const nodeRef = useRef<HTMLDivElement>(null);
+  const addMenuRef = useRef<HTMLDivElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const isUploading = !!data.uploading;
+  const hasPanorama = !!data.panoramaUrl;
+
+  // ── 级联菜单外部点击关闭 ──
+  useEffect(() => {
+    if (!showAddMenu) return;
+    const handle = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      addMenuRef.current && !addMenuRef.current.contains(target) && !target.closest('[data-node-toolbar]') && setShowAddMenu(false);
+    };
+    document.addEventListener('mousedown', handle);
+    return () => document.removeEventListener('mousedown', handle);
+  }, [showAddMenu]);
+
+  // ── 上传逻辑 ──
+  const openFileDialog = useCallback(() => fileInputRef.current?.click(), []);
+
+  const handleFileChange = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const isValidType = (PANORAMA_MIME_TYPES as readonly string[]).includes(file.type);
+    if (!isValidType) {
+      setUploadError(t('canvas.node.upload.imageFormatError', '不支持的图片格式'));
+      fileInputRef.current && (fileInputRef.current.value = '');
+      return;
+    }
+    if (file.size > PANORAMA_MAX_BYTES) {
+      setUploadError(t('canvas.node.panorama.sizeError', '全景图过大（上限 30 MB）'));
+      fileInputRef.current && (fileInputRef.current.value = '');
+      return;
+    }
+
+    setUploadError(null);
+    setUploadProgress(0);
+
+    const objectUrl = URL.createObjectURL(file);
+    updateNodeData(id, { panoramaUrl: objectUrl, uploading: true });
+
+    try {
+      const xhr = new XMLHttpRequest();
+      xhr.open('POST', '/api/media/upload');
+      const token = localStorage.getItem('access_token');
+      token && xhr.setRequestHeader('Authorization', `Bearer ${token}`);
+      xhr.upload.onprogress = (ev) => {
+        ev.lengthComputable && setUploadProgress((ev.loaded / ev.total) * 100);
+      };
+
+      const formData = new FormData();
+      formData.append('file', file);
+
+      const response = await new Promise<{ url?: string; error?: string }>((resolve, reject) => {
+        xhr.onload = () => {
+          try {
+            const res = xhr.responseText ? JSON.parse(xhr.responseText) : {};
+            xhr.status >= 200 && xhr.status < 300
+              ? resolve(res || {})
+              : resolve({ error: res?.error || `上传失败 (HTTP ${xhr.status})` });
+          } catch {
+            resolve({ error: `解析响应失败: ${xhr.status} ${xhr.statusText}` });
+          }
+        };
+        xhr.onerror = () => reject(new Error('网络请求失败或跨域错误'));
+        xhr.send(formData);
+      });
+
+      if (response.error) throw new Error(response.error);
+      updateNodeData(id, { panoramaUrl: response.url || objectUrl, uploading: false });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : t('canvas.node.upload.uploadFailed', '上传失败');
+      setUploadError(message);
+      updateNodeData(id, { panoramaUrl: null, uploading: false });
+    } finally {
+      URL.revokeObjectURL(objectUrl);
+      fileInputRef.current && (fileInputRef.current.value = '');
+    }
+  }, [id, t, updateNodeData]);
+
+  // ── 工具栏 ──
+  const handleAddClick = useCallback((e?: React.MouseEvent) => {
+    e?.stopPropagation();
+    setShowAddMenu((p) => !p);
+  }, []);
+
+  const handleUploadClick = useCallback((e?: React.MouseEvent) => {
+    e?.stopPropagation();
+    setShowAddMenu(false);
+    openFileDialog();
+  }, [openFileDialog]);
+
+  const handlePickFromLibrary = useCallback((e?: React.MouseEvent) => {
+    e?.stopPropagation();
+    setShowAddMenu(false);
+    setShowAssetPicker(true);
+    useResourceStore.getState().fetchAssets({ pageSize: 100, typeFilter: 'image' });
+  }, []);
+
+  const handleSelectFromAssets = useCallback((url: string) => {
+    updateNodeData(id, { panoramaUrl: url });
+  }, [id, updateNodeData]);
+
+  const handleEnterFullscreen = useCallback((e?: React.MouseEvent) => {
+    e?.stopPropagation();
+    hasPanorama && setShowFullscreen(true);
+  }, [hasPanorama]);
+
+  const handleNodeDoubleClick = useCallback(() => {
+    // 标题区域已经 stopPropagation，这里只处理非编辑双击
+    !title.isEditing && hasPanorama && setShowFullscreen(true);
+  }, [hasPanorama, title.isEditing]);
+
+  /** 通用的事件阻況 callback，需统一类型以避免内联 lambda 被 eslint 标为 any。 */
+  const stopEvent = useCallback((e: React.SyntheticEvent) => e.stopPropagation(), []);
+
+  // 截图导出到画布：dataURL → 上传后端 → 创建 image 节点 → 连线
+  const handleScreenshotToCanvas = useCallback(async (dataUrl: string) => {
+    // 1. dataURL 转 blob
+    const res = await fetch(dataUrl);
+    const blob = await res.blob();
+    const file = new File([blob], 'panorama-screenshot.png', { type: 'image/png' });
+
+    // 2. 上传到后端
+    const formData = new FormData();
+    formData.append('file', file);
+    const xhr = new XMLHttpRequest();
+    xhr.open('POST', '/api/media/upload');
+    const token = localStorage.getItem('access_token');
+    token && xhr.setRequestHeader('Authorization', `Bearer ${token}`);
+
+    const uploadResult = await new Promise<{ url?: string; error?: string }>((resolve, reject) => {
+      xhr.onload = () => {
+        try {
+          const r = xhr.responseText ? JSON.parse(xhr.responseText) : {};
+          xhr.status >= 200 && xhr.status < 300 ? resolve(r) : resolve({ error: r?.error || `上传失败 (${xhr.status})` });
+        } catch { resolve({ error: '响应解析失败' }); }
+      };
+      xhr.onerror = () => reject(new Error('网络错误'));
+      xhr.send(formData);
+    });
+
+    if (uploadResult.error || !uploadResult.url) return;
+
+    // 3. 获取当前 panorama 节点位置，在右侧创建 image 节点
+    const panoramaNode = getNode(id);
+    const posX = (panoramaNode?.position.x ?? 0) + (panoramaNode?.width ?? 512) + 60;
+    const posY = panoramaNode?.position.y ?? 0;
+    const imageNodeId = uuidv4();
+    const imageNode: CanvasNode = {
+      id: imageNodeId,
+      type: 'image',
+      position: { x: posX, y: posY },
+      width: 512,
+      height: 384,
+      data: {
+        name: t('canvas.node.panorama.screenshotName', '全景截图'),
+        description: data.name || '',
+        images: [uploadResult.url],
+        imageUrl: uploadResult.url,
+        uploading: false,
+      } as CharacterNodeData,
+    };
+    addNode(imageNode);
+
+    // 4. 创建 panorama → image 连线（程序化操作，绕过 deferred 矩阵校验）
+    const { edges } = useCanvasStore.getState();
+    const newEdge = {
+      id: uuidv4(),
+      source: id,
+      target: imageNodeId,
+      sourceHandle: 'right-source',
+      targetHandle: 'left-target',
+      type: 'custom' as const,
+      animated: true,
+    };
+    useCanvasStore.setState({ edges: [...edges, newEdge], isDirty: true });
+  }, [id, data.name, addNode, getNode, t]);
+
+  const handleDelete = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    confirm(t('canvas.node.deleteConfirm.panorama', '确定删除该全景节点吗？')) && deleteNode(id);
+  }, [deleteNode, id, t]);
+
+  const handleDuplicate = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    const node = getNode(id);
+    if (!node) return;
+    const currentData = node.data as PanoramaNodeData;
+    const currentName = currentData.name || t('canvas.node.unnamedPanoramaCard', '未命名全景图');
+    const newNode: CanvasNode = {
+      ...(node as CanvasNode),
+      id: uuidv4(),
+      position: { x: node.position.x + 50, y: node.position.y + 50 },
+      selected: false,
+      data: {
+        ...currentData,
+        name: t('canvas.node.copySuffix', { name: currentName }),
+        uploading: false,
+      },
+    };
+    addNode(newNode);
+  }, [addNode, getNode, id, t]);
+
+  // ── 工具栏 actions ──
+  const toolbarActions: ToolbarAction[] = [
+    {
+      icon: <Maximize2 className="h-3.5 w-3.5" />,
+      onClick: handleEnterFullscreen,
+      title: t('canvas.node.panorama.enterFullscreen', '进入全屏浏览'),
+      disabled: !hasPanorama,
+      variant: 'primary',
+    },
+    {
+      icon: <Camera className="h-3.5 w-3.5" />,
+      onClick: (e: React.MouseEvent) => { e.stopPropagation(); hasPanorama && setShowFullscreen(true); },
+      title: t('canvas.node.panorama.screenshot', '截图导出到图像节点'),
+      disabled: !hasPanorama,
+    },
+    {
+      icon: <Upload className="h-3.5 w-3.5" />,
+      onClick: handleAddClick,
+      title: t('canvas.node.panorama.changePanorama', '更换全景图'),
+    },
+    {
+      icon: <Copy className="h-3.5 w-3.5" />,
+      onClick: handleDuplicate,
+      title: t('canvas.node.toolbar.duplicate', '复制'),
+    },
+    {
+      icon: <Trash2 className="h-3.5 w-3.5" />,
+      onClick: handleDelete,
+      title: t('canvas.node.toolbar.delete', '删除'),
+      variant: 'danger',
+    },
+  ];
+
+  return (
+    <>
+      <NodeResizer
+        color="#6d6d6d"
+        isVisible={selected}
+        minWidth={MIN_WIDTH}
+        minHeight={MIN_HEIGHT}
+        lineStyle={{ display: 'none' }}
+        handleStyle={{
+          width: '8px',
+          height: '8px',
+          borderRadius: '4px',
+          border: '1px solid #6d6d6d',
+          background: '#fff',
+          opacity: selected ? 1 : 0,
+          transition: 'opacity 0.2s',
+        }}
+      />
+
+      <input
+        type="file"
+        ref={fileInputRef}
+        className="hidden"
+        accept={PANORAMA_ACCEPT}
+        onChange={handleFileChange}
+        aria-label={t('canvas.node.panorama.uploadPanorama', '上传全景图')}
+        data-testid="panorama-upload-input"
+      />
+
+      <div
+        ref={nodeRef}
+        className={`panorama-node-wrapper w-full h-full flex flex-col group relative ${isUploading ? 'nodrag' : ''}`}
+        onDoubleClick={handleNodeDoubleClick}
+      >
+        <NodeEffectOverlay nodeId={id} />
+
+        {/* 标题条 */}
+        <div className="absolute bottom-full left-0 right-0 mb-1 px-1 flex items-center justify-between gap-2 min-h-[28px] nodrag">
+          <div className="flex-1 min-w-0 flex items-center">
+            {title.isEditing ? (
+              <Input
+                ref={title.inputRef}
+                value={title.value}
+                onChange={(e) => title.onChange(e.target.value)}
+                className="font-bold text-sm h-7 bg-transparent border-0 focus-visible:ring-0 focus-visible:ring-offset-0 focus:border-0 focus:outline-none px-0 shadow-none cursor-text select-text rounded-none leading-none"
+                placeholder={t('canvas.node.unnamedPanoramaCard', '未命名全景图')}
+                onClick={stopEvent}
+                onPointerDown={stopEvent}
+                onKeyDown={title.onKeyDown}
+                autoFocus
+              />
+            ) : (
+              <h3
+                className="font-bold text-sm h-7 flex items-center truncate text-foreground/90 cursor-text select-text hover:text-primary leading-none"
+                title={data.name || ''}
+                onPointerDown={stopEvent}
+                onDoubleClick={title.enterEdit}
+              >
+                <Globe className="w-4 h-4 text-cyan-500 mr-2 shrink-0" />
+                {data.name || t('canvas.node.unnamedPanoramaCard', '未命名全景图')}
+              </h3>
+            )}
+          </div>
+        </div>
+
+        <Card className={`w-full h-full flex flex-col bg-card ${selected ? 'ring-2 ring-primary' : ''} overflow-hidden relative z-[2]`}>
+          <CardContent className="flex flex-col items-center justify-center relative custom-scrollbar flex-1 p-0 overflow-hidden">
+            {/* 空态：提示词生成器 + 上传入口 */}
+            {!hasPanorama && !isUploading && (
+              <div className="flex flex-col items-center justify-center w-full h-full py-4">
+                <PromptBuilder />
+                <div className="flex items-center gap-3 mt-2">
+                  <button
+                    type="button"
+                    onClick={handleUploadClick}
+                    className="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    <Upload className="w-3 h-3" />
+                    {t('canvas.node.panorama.uploadPanorama', '上传全景图')}
+                  </button>
+                  <span className="text-muted-foreground/40 text-[10px]">|</span>
+                  <button
+                    type="button"
+                    onClick={handlePickFromLibrary}
+                    className="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    <FolderOpen className="w-3 h-3" />
+                    {t('canvas.node.upload.fromLibrary', '从资产库选择')}
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {/* 已上传：等距柱状缩略（静态 img，避免节点内实例化 WebGL） */}
+            {hasPanorama && (
+              <div className="relative w-full h-full bg-black/60">
+                <img
+                  src={data.panoramaUrl as string}
+                  alt={data.name || t('canvas.node.unnamedPanoramaCard', '未命名全景图')}
+                  draggable={false}
+                  className="w-full h-full object-cover"
+                />
+                {/* 浮层：双击进入全屏提示 */}
+                <div className="absolute inset-0 flex items-end justify-center pb-3 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
+                  <div className="px-3 py-1.5 bg-black/60 backdrop-blur-md text-white text-[11px] rounded-full border border-white/15 flex items-center gap-1.5">
+                    <Maximize2 className="w-3 h-3" />
+                    {t('canvas.node.panorama.doubleClickToFullscreen', '双击进入 720° 全景浏览')}
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* 上传中 */}
+            {isUploading && (
+              <div className="absolute inset-0 flex flex-col items-center justify-center bg-background/80 backdrop-blur-sm gap-2">
+                <Loader2 className="w-6 h-6 animate-spin text-cyan-500" />
+                <div className="w-2/3 h-1 bg-secondary rounded-full overflow-hidden">
+                  <div className="h-full bg-cyan-500 transition-all" style={{ width: `${uploadProgress}%` }} />
+                </div>
+                <span className="text-[11px] text-muted-foreground">{Math.round(uploadProgress)}%</span>
+              </div>
+            )}
+
+            {/* 上传错误 */}
+            {uploadError && !isUploading && (
+              <div className="absolute inset-x-2 bottom-2 px-3 py-2 bg-destructive/10 border border-destructive/30 rounded-md text-[11px] text-destructive flex items-center justify-between gap-2">
+                <span className="truncate">{uploadError}</span>
+                <button
+                  type="button"
+                  onClick={(e) => { e.stopPropagation(); setUploadError(null); openFileDialog(); }}
+                  className="shrink-0 text-[10px] underline hover:no-underline"
+                >
+                  {t('canvas.node.upload.retry', '重试')}
+                </button>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* 工具栏 */}
+        <NodeToolbar
+          className={`!bottom-auto !-top-[64px] !-translate-y-1 group-hover:!translate-y-0 ${showAddMenu ? '!opacity-100 !pointer-events-auto !translate-y-0' : ''}`}
+          actions={toolbarActions}
+        />
+
+        {/* Plus 级联：上传 / 从资产库 */}
+        {showAddMenu && (
+          <div
+            ref={addMenuRef}
+            className="absolute left-1/2 -translate-x-1/2 -top-[108px] flex items-center bg-background/95 backdrop-blur-md border border-border/60 rounded-full px-1 py-1 shadow-lg pointer-events-auto nodrag animate-in fade-in zoom-in-95 duration-150 z-30"
+          >
+            <button
+              className="w-7 h-7 flex items-center justify-center rounded-full text-muted-foreground hover:text-foreground hover:bg-secondary transition-all"
+              onClick={handleUploadClick}
+              title={t('canvas.node.panorama.uploadPanorama', '上传全景图')}
+            >
+              <Upload className="w-3.5 h-3.5" />
+            </button>
+            <div className="w-px h-4 bg-border/50" />
+            <button
+              className="w-7 h-7 flex items-center justify-center rounded-full text-muted-foreground hover:text-foreground hover:bg-secondary transition-all"
+              onClick={handlePickFromLibrary}
+              title={t('canvas.node.upload.fromLibrary', '从资产库选择')}
+            >
+              <FolderOpen className="w-3.5 h-3.5" />
+            </button>
+          </div>
+        )}
+
+        <EdgeHandles />
+      </div>
+
+      <AssetPickerPortal
+        open={showAssetPicker}
+        currentUrl={data.panoramaUrl}
+        onSelect={handleSelectFromAssets}
+        onClose={() => setShowAssetPicker(false)}
+      />
+
+      <FullscreenPortal
+        open={showFullscreen}
+        panoramaUrl={data.panoramaUrl}
+        nodeName={data.name || ''}
+        defaultYaw={data.defaultYaw}
+        defaultPitch={data.defaultPitch}
+        defaultFov={data.defaultFov}
+        onClose={() => setShowFullscreen(false)}
+        onScreenshot={handleScreenshotToCanvas}
+      />
+    </>
+  );
+};
+
+export default memo(PanoramaNode);

--- a/frontend/src/components/canvas/PanoramaNode.tsx
+++ b/frontend/src/components/canvas/PanoramaNode.tsx
@@ -33,7 +33,7 @@ const PanoramaNode = ({ id, data, selected }: NodeProps<Node<PanoramaNodeData>>)
   const updateNodeData = useCanvasStore((s) => s.updateNodeData);
   const deleteNode = useCanvasStore((s) => s.deleteNode);
   const addNode = useCanvasStore((s) => s.addNode);
-  const { getNode, screenToFlowPosition } = useReactFlow();
+  const { getNode } = useReactFlow();
 
   // ── 标题编辑 ──
   const commitTitle = useCallback((name: string) => {

--- a/frontend/src/components/canvas/PanoramaNode/AssetPickerPortal.tsx
+++ b/frontend/src/components/canvas/PanoramaNode/AssetPickerPortal.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import React, { useEffect, useMemo } from 'react';
+import { createPortal } from 'react-dom';
+import { X, FolderOpen, Loader2, Globe } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useResourceStore } from '@/store/useResourceStore';
+
+interface Props {
+  open: boolean;
+  currentUrl: string | null | undefined;
+  onSelect: (url: string) => void;
+  onClose: () => void;
+}
+
+/**
+ * 全景节点的资产库选择弹窗（单图选择，简化版）。
+ * 资产类型与图片节点共用 image，由用户自行判断是否为等距柱状全景图。
+ */
+export function AssetPickerPortal({ open, currentUrl, onSelect, onClose }: Props) {
+  const { t } = useTranslation();
+  const assets = useResourceStore((s) => s.assets);
+  const isLoading = useResourceStore((s) => s.isLoading);
+  const imageAssets = useMemo(() => assets.filter(a => a.file_type === 'image'), [assets]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => { e.key === 'Escape' && onClose(); };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [open, onClose]);
+
+  if (!open || typeof document === 'undefined') return null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[9998] flex items-center justify-center bg-black/60 backdrop-blur-sm animate-in fade-in duration-150"
+      onClick={onClose}
+    >
+      <div
+        className="bg-background border border-border/50 rounded-xl w-full max-w-lg max-h-[70vh] flex flex-col overflow-hidden shadow-xl animate-in zoom-in-95 duration-200"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-4 py-3 border-b border-border/50">
+          <div className="flex items-center gap-2">
+            <FolderOpen className="w-4 h-4 text-cyan-500" />
+            <span className="text-sm font-semibold">{t('canvas.node.upload.fromLibrary', '从资产库选择')}</span>
+          </div>
+          <button
+            className="w-6 h-6 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
+            onClick={onClose}
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-4 custom-scrollbar">
+          {isLoading && (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+            </div>
+          )}
+
+          {!isLoading && imageAssets.length === 0 && (
+            <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+              <Globe className="w-10 h-10 mb-3 opacity-20" />
+              <span className="text-sm">{t('sidebar.noImages', '暂无图片资产')}</span>
+            </div>
+          )}
+
+          {!isLoading && imageAssets.length > 0 && (
+            <div className="grid grid-cols-3 gap-2">
+              {imageAssets.map((asset) => {
+                const isCurrent = currentUrl === asset.url;
+                return (
+                  <button
+                    key={asset.id}
+                    disabled={isCurrent}
+                    onClick={() => { onSelect(asset.url); onClose(); }}
+                    className={`relative group rounded-lg border overflow-hidden aspect-[2/1] transition-all ${
+                      isCurrent
+                        ? 'opacity-40 cursor-not-allowed border-border/30'
+                        : 'border-border/50 hover:border-cyan-500/60 hover:ring-1 hover:ring-cyan-500/30 cursor-pointer'
+                    }`}
+                  >
+                    <img
+                      src={asset.url}
+                      alt={asset.original_name || asset.filename}
+                      loading="lazy"
+                      draggable={false}
+                      className="w-full h-full object-cover"
+                    />
+                    {isCurrent && (
+                      <div className="absolute inset-0 bg-background/60 flex items-center justify-center">
+                        <span className="text-[10px] font-medium text-muted-foreground">
+                          {t('canvas.node.upload.alreadyAdded', '已选择')}
+                        </span>
+                      </div>
+                    )}
+                    <div className="absolute inset-x-0 bottom-0 bg-black/50 backdrop-blur-sm p-1 translate-y-full group-hover:translate-y-0 transition-transform">
+                      <span className="text-[10px] text-white font-medium truncate block">
+                        {asset.original_name || asset.filename}
+                      </span>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/frontend/src/components/canvas/PanoramaNode/EdgeHandles.tsx
+++ b/frontend/src/components/canvas/PanoramaNode/EdgeHandles.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import React from 'react';
+import { Handle, Position } from '@xyflow/react';
+
+/**
+ * 全景节点左右两侧的连线把手（target + source 并排，hover 可见）。
+ * 与 ImageNode/EdgeHandles 的结构完全一致，确保连线把手在所有节点上视觉/行为统一。
+ */
+export function EdgeHandles() {
+  return (
+    <>
+      <div className="edge-handle-wrapper right group/handle pointer-events-auto">
+        <Handle type="target" position={Position.Right} id="right-target" />
+        <Handle type="source" position={Position.Right} id="right-source" />
+        <div className="edge-handle-inner">
+          <div className="edge-handle-line" />
+          <div className="edge-handle-dot" />
+        </div>
+      </div>
+
+      <div className="edge-handle-wrapper left group/handle pointer-events-auto">
+        <Handle type="target" position={Position.Left} id="left-target" />
+        <Handle type="source" position={Position.Left} id="left-source" />
+        <div className="edge-handle-inner">
+          <div className="edge-handle-line" />
+          <div className="edge-handle-dot" />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/canvas/PanoramaNode/FullscreenPortal.tsx
+++ b/frontend/src/components/canvas/PanoramaNode/FullscreenPortal.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Camera, RotateCcw, X, Loader2, AlertTriangle } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { PanoramaViewer, type PanoramaViewerHandle } from './PanoramaViewer';
+
+interface Props {
+  open: boolean;
+  panoramaUrl: string | null | undefined;
+  nodeName: string;
+  defaultYaw?: number;
+  defaultPitch?: number;
+  defaultFov?: number;
+  onClose: () => void;
+  /** 截图回调：传入 dataURL，由外层决定是下载还是导出到画布 */
+  onScreenshot: (dataUrl: string) => void;
+}
+
+type ViewerStatus = 'loading' | 'ready' | 'error';
+
+/**
+ * 全屏全景浏览门户：
+ * - createPortal 到 document.body，覆盖整个视口
+ * - 内嵌 PanoramaViewer 占满（用 panoramaUrl 作为 key 在换图时强制重建）
+ * - 顶部右侧浮动工具栏：截图 / 复位视角 / 退出
+ * - ESC 键退出
+ * - 打开时锁定 body 滚动
+ * - 通过 PSV 事件回调维护 status（loading/ready/error），事件回调里 setState 合法
+ */
+export function FullscreenPortal({
+  open,
+  panoramaUrl,
+  nodeName,
+  defaultYaw,
+  defaultPitch,
+  defaultFov,
+  onClose,
+  onScreenshot,
+}: Props) {
+  const { t } = useTranslation();
+  const viewerRef = useRef<PanoramaViewerHandle>(null);
+  const [status, setStatus] = useState<ViewerStatus>('loading');
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const handleReady = useCallback(() => {
+    setStatus('ready');
+    setErrorMsg(null);
+  }, []);
+
+  const handleError = useCallback((msg: string) => {
+    setStatus('error');
+    setErrorMsg(msg);
+  }, []);
+
+  // ESC 退出
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => { e.key === 'Escape' && onClose(); };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [open, onClose]);
+
+  // 锁定 body 滚动
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => { document.body.style.overflow = prev; };
+  }, [open]);
+
+  const handleScreenshot = useCallback(() => {
+    const dataUrl = viewerRef.current?.takeScreenshot();
+    dataUrl && onScreenshot(dataUrl);
+  }, [onScreenshot]);
+
+  const handleReset = useCallback(() => {
+    viewerRef.current?.resetView();
+  }, []);
+
+  if (!open || typeof document === 'undefined') return null;
+
+  // 使用 panoramaUrl 作为 key 让 PanoramaViewer 在换图时强制卸载重建。
+  // 状态由 PanoramaViewer 通过 onReady/onError 事件回调向外驱动（事件回调内 setState 合法）。
+  const viewerKey = panoramaUrl || 'empty';
+  const hasUrl = !!panoramaUrl;
+  const ready = status === 'ready';
+
+  return createPortal(
+    <div className="fixed inset-0 z-[9999] bg-black animate-in fade-in duration-200">
+      {/* Viewer 容器 */}
+      {hasUrl ? (
+        <PanoramaViewer
+          key={viewerKey}
+          ref={viewerRef}
+          panoramaUrl={panoramaUrl as string}
+          className="w-full h-full"
+          defaultYaw={defaultYaw}
+          defaultPitch={defaultPitch}
+          defaultFov={defaultFov}
+          onReady={handleReady}
+          onError={handleError}
+        />
+      ) : (
+        <div className="w-full h-full flex items-center justify-center text-white/60 text-sm">
+          {t('canvas.node.panorama.noPanorama', '未上传全景图')}
+        </div>
+      )}
+
+      {/* 加载中指示 */}
+      {hasUrl && status === 'loading' && (
+        <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none gap-3">
+          <Loader2 className="w-8 h-8 text-white/80 animate-spin" />
+          <span className="text-white/70 text-sm">{t('canvas.node.panorama.loading', '正在加载全景图…')}</span>
+        </div>
+      )}
+
+      {/* 加载错误 */}
+      {hasUrl && status === 'error' && (
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 px-6 pointer-events-none">
+          <AlertTriangle className="w-10 h-10 text-amber-400" />
+          <div className="text-white/90 text-sm font-medium">
+            {t('canvas.node.panorama.loadError', '全景图加载失败')}
+          </div>
+          {errorMsg && (
+            <div className="text-white/50 text-xs max-w-md text-center break-all">{errorMsg}</div>
+          )}
+          <div className="text-white/40 text-[11px] mt-2 text-center max-w-md">
+            {t('canvas.node.panorama.loadErrorHint', '请确认图像可访问且为等距柱状投影（推荐 2:1 长宽比，例如 4096×2048）')}
+          </div>
+        </div>
+      )}
+
+      {/* 顶部工具栏 */}
+      <div className="absolute top-4 right-4 flex items-center gap-1 bg-black/50 backdrop-blur-md border border-white/10 rounded-full px-1.5 py-1.5 pointer-events-auto">
+        <button
+          type="button"
+          onClick={handleScreenshot}
+          disabled={!ready}
+          title={t('canvas.node.panorama.screenshot', '截图保存')}
+          aria-label={t('canvas.node.panorama.screenshot', '截图保存')}
+          className="w-9 h-9 rounded-full flex items-center justify-center text-white/80 hover:text-white hover:bg-white/10 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+        >
+          <Camera className="w-4 h-4" />
+        </button>
+        <button
+          type="button"
+          onClick={handleReset}
+          disabled={!ready}
+          title={t('canvas.node.panorama.resetView', '复位视角')}
+          aria-label={t('canvas.node.panorama.resetView', '复位视角')}
+          className="w-9 h-9 rounded-full flex items-center justify-center text-white/80 hover:text-white hover:bg-white/10 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+        >
+          <RotateCcw className="w-4 h-4" />
+        </button>
+        <div className="w-px h-5 bg-white/15 mx-0.5" />
+        <button
+          type="button"
+          onClick={onClose}
+          title={t('canvas.node.panorama.exit', '退出全屏 (ESC)')}
+          aria-label={t('canvas.node.panorama.exit', '退出全屏')}
+          className="w-9 h-9 rounded-full flex items-center justify-center text-white/80 hover:text-white hover:bg-white/10 transition-colors"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+
+      {/* 节点名 + 操作提示 */}
+      <div className="absolute top-4 left-4 flex flex-col gap-1 pointer-events-none">
+        <div className="text-white/90 text-sm font-medium px-3 py-1.5 bg-black/40 backdrop-blur-md rounded-full border border-white/10 truncate max-w-md">
+          {nodeName || t('canvas.node.unnamedPanoramaCard', '未命名全景图')}
+        </div>
+        <div className="text-white/50 text-[11px] px-3">
+          {t('canvas.node.panorama.hint', '拖拽改视角 · 滚轮缩放 · ESC 退出')}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/frontend/src/components/canvas/PanoramaNode/PanoramaViewer.tsx
+++ b/frontend/src/components/canvas/PanoramaNode/PanoramaViewer.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import React, { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
+import { Viewer } from '@photo-sphere-viewer/core';
+import '@photo-sphere-viewer/core/index.css';
+import { DEFAULT_FOV, DEFAULT_PITCH, DEFAULT_YAW } from './constants';
+
+export interface PanoramaViewerHandle {
+  /** 截取当前 WebGL canvas 像素 → dataURL（image/png） */
+  takeScreenshot: () => string | null;
+  /** 旋转到指定视角（弧度） */
+  rotate: (yaw: number, pitch: number) => void;
+  /** 设置 FOV（度） */
+  zoom: (fov: number) => void;
+  /** 复位到初始默认视角 */
+  resetView: () => void;
+}
+
+interface PanoramaViewerProps {
+  panoramaUrl: string;
+  className?: string;
+  defaultYaw?: number;
+  defaultPitch?: number;
+  defaultFov?: number;
+  /** Viewer ready 事件回调（PSV 第一次加载完成） */
+  onReady?: () => void;
+  /** 加载/初始化失败回调；msg 为可读错误描述 */
+  onError?: (msg: string) => void;
+}
+
+/** 加载超时毫秒数 - 超过此时间视为失败 */
+const LOAD_TIMEOUT_MS = 20_000;
+
+/**
+ * Photo Sphere Viewer 的轻量 React 封装。
+ * 
+ * 关键设计：在构造函数中直接传入 panorama URL（PSV 5.x 需要在构造时传入
+ * panorama 来触发完整的 Three.js renderer 初始化流程，否则 setPanorama 
+ * 可能永远处于 pending）。通过 ready 事件 + 超时检测驱动外层状态。
+ */
+export const PanoramaViewer = forwardRef<PanoramaViewerHandle, PanoramaViewerProps>(
+  function PanoramaViewer(
+    {
+      panoramaUrl,
+      className,
+      defaultYaw = DEFAULT_YAW,
+      defaultPitch = DEFAULT_PITCH,
+      defaultFov = DEFAULT_FOV,
+      onReady,
+      onError,
+    },
+    ref,
+  ) {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const viewerRef = useRef<Viewer | null>(null);
+    const initialRef = useRef({ yaw: defaultYaw, pitch: defaultPitch, fov: defaultFov });
+
+    useEffect(() => {
+      const wrapper = containerRef.current;
+      if (!wrapper || !panoramaUrl) return;
+
+
+
+      let cancelled = false;
+      let viewer: Viewer | null = null;
+      let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+      const psvContainer = document.createElement('div');
+      psvContainer.style.width = '100%';
+      psvContainer.style.height = '100%';
+      wrapper.appendChild(psvContainer);
+
+      const done = (success: boolean, msg?: string) => {
+        if (cancelled) return;
+        cancelled = true;
+        timeoutId && clearTimeout(timeoutId);
+        success ? onReady?.() : onError?.(msg || '加载失败');
+      };
+
+      // 策略：先用原生 Image 预加载图片并创建 blob URL，
+      // 再拿 blob URL 传给 PSV。如此绕开 Three.js TextureLoader 通过 Next.js 代理加载时可能遇到的
+      // crossOrigin / 响应头兼容性问题。
+      const img = new Image();
+      img.crossOrigin = 'anonymous';
+
+      img.onload = () => {
+        if (cancelled) return;
+
+
+        // 绘制到 canvas 再转 blob URL，确保 PSV 可以以 blob: 协议加载（无网络请求）
+        const cvs = document.createElement('canvas');
+        cvs.width = img.naturalWidth;
+        cvs.height = img.naturalHeight;
+        const ctx = cvs.getContext('2d');
+        ctx?.drawImage(img, 0, 0);
+        cvs.toBlob((blob) => {
+          if (cancelled || !blob) {
+            !cancelled && done(false, '图片转码失败');
+            return;
+          }
+          const blobUrl = URL.createObjectURL(blob);
+
+
+          try {
+            viewer = new Viewer({
+              container: psvContainer,
+              panorama: blobUrl,
+              navbar: false,
+              mousewheel: true,
+              mousemove: true,
+              keyboard: 'always',
+              defaultYaw,
+              defaultPitch,
+              defaultZoomLvl: fovToZoomLevel(defaultFov),
+              // preserveDrawingBuffer 必须为 true，否则 canvas.toDataURL 截图为全黑
+              rendererParameters: { preserveDrawingBuffer: true, alpha: true },
+            });
+
+
+            viewerRef.current = viewer;
+
+            viewer.addEventListener('ready', () => done(true), { once: true });
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : 'Viewer 初始化失败';
+            done(false, msg);
+          } finally {
+            // blob URL 在 PSV 内部加载完后即可释放（texture 已拷贝到 GPU）
+            // 但为了安全，延迟 5s 后释放
+            setTimeout(() => URL.revokeObjectURL(blobUrl), 5000);
+          }
+        }, 'image/jpeg', 0.95);
+      };
+
+      img.onerror = () => {
+        if (cancelled) return;
+        done(false, '图片加载失败，请检查 URL 是否可访问');
+      };
+
+      img.src = panoramaUrl;
+
+      timeoutId = setTimeout(() => {
+        done(false, `加载超时（${LOAD_TIMEOUT_MS / 1000}s），请检查图片是否可访问`);
+      }, LOAD_TIMEOUT_MS);
+
+      return () => {
+        cancelled = true;
+        timeoutId && clearTimeout(timeoutId);
+        img.onload = null;
+        img.onerror = null;
+        viewer?.destroy();
+        viewerRef.current = null;
+        wrapper.contains(psvContainer) && wrapper.removeChild(psvContainer);
+      };
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    useImperativeHandle(ref, () => ({
+      takeScreenshot: () => {
+        const canvas = containerRef.current?.querySelector('canvas') as HTMLCanvasElement | null;
+        return canvas ? canvas.toDataURL('image/png') : null;
+      },
+      rotate: (yaw, pitch) => {
+        viewerRef.current?.rotate({ yaw, pitch });
+      },
+      zoom: (fov) => {
+        viewerRef.current?.zoom(fovToZoomLevel(fov));
+      },
+      resetView: () => {
+        const v = viewerRef.current;
+        if (!v) return;
+        v.rotate({ yaw: initialRef.current.yaw, pitch: initialRef.current.pitch });
+        v.zoom(fovToZoomLevel(initialRef.current.fov));
+      },
+    }), []);
+
+    return <div ref={containerRef} className={className} />;
+  },
+);
+
+/** PSV 的 zoomLvl 取值 0~100；FOV 在 30~90 之间近似线性映射。 */
+function fovToZoomLevel(fov: number): number {
+  const clamped = Math.max(30, Math.min(90, fov));
+  return Math.round((90 - clamped) / 60 * 100);
+}

--- a/frontend/src/components/canvas/PanoramaNode/PromptBuilder.tsx
+++ b/frontend/src/components/canvas/PanoramaNode/PromptBuilder.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import React, { useCallback, useState } from 'react';
+import { Sparkles, Copy, Check } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/utils';
+
+/** 固定的全景格式前缀 */
+const PROMPT_PREFIX = '360 degree equirectangular panorama, seamless spherical projection, 2:1 aspect ratio, ';
+/** 固定的全景格式后缀 */
+const PROMPT_SUFFIX = '. The environment wraps fully 360 degrees with consistent lighting and no visible seams. Style: photorealistic, cinematic lighting, ultra detailed, 8K resolution';
+
+interface Props {
+  className?: string;
+}
+
+/**
+ * 全景提示词生成器：用户输入简单场景描述 → 自动拼接专业全景格式前后缀 → 一键复制。
+ * 在全景节点空状态时显示。
+ */
+export function PromptBuilder({ className }: Props) {
+  const { t } = useTranslation();
+  const [input, setInput] = useState('');
+  const [generatedPrompt, setGeneratedPrompt] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const handleGenerate = useCallback(() => {
+    const trimmed = input.trim();
+    trimmed && setGeneratedPrompt(`${PROMPT_PREFIX}${trimmed}${PROMPT_SUFFIX}`);
+  }, [input]);
+
+  const handleCopy = useCallback(async () => {
+    generatedPrompt && await navigator.clipboard.writeText(generatedPrompt);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [generatedPrompt]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    e.stopPropagation();
+    e.key === 'Enter' && !e.shiftKey && (e.preventDefault(), handleGenerate());
+  }, [handleGenerate]);
+
+  return (
+    <div className={cn('flex flex-col gap-2 w-full px-4 py-3 nodrag', className)} onClick={(e) => e.stopPropagation()}>
+      {/* 场景描述输入 */}
+      <textarea
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onPointerDown={(e) => e.stopPropagation()}
+        placeholder={t('canvas.node.panorama.promptBuilder.placeholder', '描述你想要的场景，例如：飞船内部驾驶舱、未来城市天台…')}
+        rows={2}
+        className="w-full resize-none rounded-md border border-border/60 bg-secondary/30 px-3 py-2 text-xs text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:ring-1 focus:ring-primary/40 transition-colors"
+      />
+
+      {/* 生成按钮 */}
+      <button
+        type="button"
+        onClick={handleGenerate}
+        disabled={!input.trim()}
+        className="flex items-center justify-center gap-1.5 py-1.5 px-3 rounded-md text-[11px] font-medium bg-primary/10 text-primary hover:bg-primary/20 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+      >
+        <Sparkles className="w-3 h-3" />
+        {t('canvas.node.panorama.promptBuilder.generate', '生成全景提示词')}
+      </button>
+
+      {/* 生成结果 */}
+      {generatedPrompt && (
+        <div className="flex flex-col gap-1.5 animate-in fade-in slide-in-from-top-1 duration-200">
+          <textarea
+            readOnly
+            value={generatedPrompt}
+            rows={4}
+            className="w-full resize-none rounded-md border border-primary/30 bg-primary/5 px-3 py-2 text-[10px] text-foreground/80 leading-relaxed focus:outline-none cursor-text select-all"
+            onFocus={(e) => e.currentTarget.select()}
+            onPointerDown={(e) => e.stopPropagation()}
+          />
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="flex items-center justify-center gap-1.5 py-1.5 px-3 rounded-md text-[11px] font-medium bg-secondary hover:bg-secondary/80 text-foreground/80 transition-all"
+          >
+            {copied ? <Check className="w-3 h-3 text-green-500" /> : <Copy className="w-3 h-3" />}
+            {copied
+              ? t('canvas.node.panorama.promptBuilder.copied', '已复制')
+              : t('canvas.node.panorama.promptBuilder.copyPrompt', '复制提示词')}
+          </button>
+          <span className="text-[10px] text-muted-foreground/60 text-center leading-snug">
+            {t('canvas.node.panorama.promptBuilder.hint', '将提示词粘贴到 Midjourney / DALL-E 等工具生成全景图，再上传到此节点')}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/canvas/PanoramaNode/constants.ts
+++ b/frontend/src/components/canvas/PanoramaNode/constants.ts
@@ -1,0 +1,21 @@
+/**
+ * Panorama 节点常量。与 ImageNode/VideoNode 的 constants 模块保持一致风格。
+ */
+export const MIN_WIDTH = 320;
+export const MIN_HEIGHT = 200;
+export const MAX_DIMENSION = 1600;
+
+/** 节点拖拽至画布时的默认尺寸（参考 Sidebar.NODE_TYPES.dimensions） */
+export const DEFAULT_DIMENSIONS = { width: 512, height: 320 } as const;
+
+/** 上传文件类型限制 —— 全景图通常较大，仅接受常见栅格图像 */
+export const PANORAMA_ACCEPT = '.jpg,.jpeg,.png,.webp';
+export const PANORAMA_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'] as const;
+
+/** 单文件大小上限（字节）—— 全景图分辨率高，放宽到 30 MB */
+export const PANORAMA_MAX_BYTES = 30 * 1024 * 1024;
+
+/** Photo Sphere Viewer 默认视角/FOV */
+export const DEFAULT_YAW = 0;
+export const DEFAULT_PITCH = 0;
+export const DEFAULT_FOV = 60;

--- a/frontend/src/components/canvas/PanoramaNode/utils.ts
+++ b/frontend/src/components/canvas/PanoramaNode/utils.ts
@@ -1,0 +1,38 @@
+/**
+ * Panorama 节点工具函数。
+ *
+ * 设计原则：遵循 style.md，尽可能用三元/早返回替代多重 if 分支。
+ */
+
+/**
+ * 规范化全景图 URL：把相对路径（如 /media/xxx.jpg）合并为绝对 URL。
+ * 与 ImageNode/utils 中 normalizeImageUrl 实现等价。
+ */
+export const normalizePanoramaUrl = (url: string | null | undefined): string => {
+  const safe = url ?? '';
+  const isAbsolute = /^https?:\/\//i.test(safe) || safe.startsWith('blob:') || safe.startsWith('data:');
+  return isAbsolute ? safe : safe;
+};
+
+/**
+ * 触发浏览器下载 dataURL 为本地文件。
+ * 用于全屏 viewer 截图后导出 PNG。
+ */
+export const downloadDataUrl = (dataUrl: string, filename: string): void => {
+  const link = document.createElement('a');
+  link.href = dataUrl;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+};
+
+/**
+ * 基于当前时间戳生成截图文件名。
+ * @param baseName 节点标题，作为前缀
+ */
+export const buildScreenshotFilename = (baseName: string): string => {
+  const safe = (baseName || 'panorama').replace(/[\\/:*?"<>|]/g, '_').trim() || 'panorama';
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  return `${safe}_${ts}.png`;
+};

--- a/frontend/src/components/canvas/Sidebar.tsx
+++ b/frontend/src/components/canvas/Sidebar.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { 
   VectorSquare, Plus, ScrollText, Image as ImageIcon, Video, 
-  Table2, GripVertical, Film, ImagePlus, Music, ExternalLink, Loader2, Headphones
+  Table2, GripVertical, Film, ImagePlus, Music, ExternalLink, Loader2, Headphones, Globe
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { resourceApi, AssetItem } from '@/lib/resourceApi';
@@ -64,6 +64,17 @@ const NODE_TYPES = [
     titleKey: 'canvas.node.storyboardCard',
     data: { shotNumber: '01', duration: 3, description: '', pivotConfig: { rows: [], cols: [], values: [] } },
     dimensions: { width: 768, height: 512 }
+  },
+  { 
+    type: 'panorama', 
+    nameKey: 'sidebar.panoramaCard', 
+    descKey: 'sidebar.panoramaDesc',
+    icon: Globe, 
+    color: 'text-cyan-500', 
+    bg: 'bg-cyan-500/10',
+    titleKey: 'canvas.node.newPanoramaCard',
+    data: { description: '' },
+    dimensions: { width: 512, height: 320 }
   },
 ];
 

--- a/frontend/src/hooks/useImageGenerationApply.ts
+++ b/frontend/src/hooks/useImageGenerationApply.ts
@@ -21,8 +21,16 @@ const MAX_IMAGES = 9;
  * AI 图像生成的提交 + 完成自动应用 + applyToNode / applyToNextNode：
  * - submit 前保存 prevImages 快照以支持"应用到下一节点"回滚
  * - 完成后累计到 generatedImages 历史（去重），并替换当前节点图像
+ * - options.onCustomApply: 返回 true 表示已自行处理结果（跳过默认 apply），
+ *   用于“生成全景图”等需要路由到其他节点类型的一键场景
  */
-export function useImageGenerationApply(id: string, data: CharacterNodeData) {
+export function useImageGenerationApply(
+  id: string,
+  data: CharacterNodeData,
+  options?: {
+    onCustomApply?: (urls: string[], params: ImageCreateParams | null) => boolean;
+  },
+) {
   const { t } = useTranslation();
   const { getNode, getEdges } = useReactFlow();
   const updateNodeData = useCanvasStore((s) => s.updateNodeData);
@@ -49,12 +57,14 @@ export function useImageGenerationApply(id: string, data: CharacterNodeData) {
   }, [imageTask.startedAt]);
 
   // 完成后自动合并入 generatedImages 历史并替换当前节点图像
+  // - 若 onCustomApply 返回 true 表示已自行处理（如“生成全景图”路由到全景节点），跳过默认应用
   useEffect(() => {
     const res = imageTask.result;
     (res && imageTask.isCompleted) && (() => {
       const sp = lastSubmitParamsRef.current;
       const urls = res.images || [];
-      urls.length === 0 || (() => {
+      const handled = options?.onCustomApply?.(urls, sp) ?? false;
+      handled || urls.length === 0 || (() => {
         const createdAt = new Date().toISOString();
         const newEntries: ImageGenHistoryEntry[] = urls.map((url) => ({
           url,

--- a/frontend/src/hooks/useQuickImageMode.ts
+++ b/frontend/src/hooks/useQuickImageMode.ts
@@ -8,6 +8,13 @@ import type {
   ImageRef,
 } from '@/components/canvas/ImageGeneratePanel';
 
+/** 全景图提示词模板（一键填充到生成面板） */
+const PANORAMA_PROMPT =
+  '360 degree equirectangular panorama, seamless spherical projection, 2:1 aspect ratio, ' +
+  'expand and extend this image into a full 360-degree panoramic environment. ' +
+  'The environment wraps fully 360 degrees with consistent lighting and no visible seams. ' +
+  'Style: photorealistic, cinematic lighting, ultra detailed, 8K resolution';
+
 /**
  * 工具条「快捷模式」：一键把当前节点的图作为参考/编辑目标，自动切换生成面板模式。
  * - reference_images：把所有图作为参考
@@ -27,7 +34,11 @@ export function useQuickImageMode(
   const [showEditPicker, setShowEditPicker] = useState(false);
   const editPickerRef = useRef<HTMLDivElement | null>(null);
 
-  const submitModeRequest = useCallback((mode: ImageMode, urls: string[]) => {
+  const submitModeRequest = useCallback((
+    mode: ImageMode,
+    urls: string[],
+    overrides?: { promptOverride?: string; aspectRatioOverride?: string },
+  ) => {
     const total = urls.length;
     const baseName = data.name || t('canvas.node.image.currentImage', '当前图像');
     const refs: ImageRef[] = urls.map((u, i) => ({
@@ -36,7 +47,13 @@ export function useQuickImageMode(
       sourceNodeId: id,
     }));
     modeTokenRef.current += 1;
-    setPanelModeRequest({ mode, token: modeTokenRef.current, preselectImages: refs });
+    setPanelModeRequest({
+      mode,
+      token: modeTokenRef.current,
+      preselectImages: refs,
+      promptOverride: overrides?.promptOverride,
+      aspectRatioOverride: overrides?.aspectRatioOverride,
+    });
     data.pinPanel || updateNodeData(id, { pinPanel: true } as Partial<CharacterNodeData>);
   }, [data.name, data.pinPanel, id, normalizeImageUrl, t, updateNodeData]);
 
@@ -55,6 +72,18 @@ export function useQuickImageMode(
     submitModeRequest('edit', [url]);
     setShowEditPicker(false);
   }, [submitModeRequest]);
+
+  /**
+   * 一键生成全景图：以当前图像为参考 + edit 模式 + 21:9 比例 + 预填全景提示词。
+   * 用户可手动调整后点击生成，生成后由 ImageNode 侧的 onCustomApply 路由到全景节点。
+   */
+  const handleGeneratePanorama = useCallback((e?: React.MouseEvent) => {
+    e?.stopPropagation();
+    imageList.length > 0 && submitModeRequest('edit', [imageList[0]], {
+      promptOverride: PANORAMA_PROMPT,
+      aspectRatioOverride: '21:9',
+    });
+  }, [imageList, submitModeRequest]);
 
   // 外部点击关闭选择器
   useEffect(() => {
@@ -80,6 +109,7 @@ export function useQuickImageMode(
     submitModeRequest,
     handleQuickMode,
     handlePickEditImage,
+    handleGeneratePanorama,
     setShowEditPicker,
   };
 }

--- a/frontend/src/i18n/locales/en-US.json
+++ b/frontend/src/i18n/locales/en-US.json
@@ -246,17 +246,44 @@
       "unnamedImageCard": "Untitled Image Card",
       "unnamedAudioCard": "Untitled Audio Card",
       "unnamedVideoCard": "Untitled Video Card",
+      "unnamedPanoramaCard": "Untitled Panorama Card",
       "newTextCard": "New Text Card",
       "newImageCard": "New Image Card",
       "newAudioCard": "New Audio Card",
       "newVideoCard": "New Video Card",
+      "newPanoramaCard": "New Panorama Card",
       "copySuffix": "{{name}} (Copy)",
       "deleteConfirm": {
         "text": "Are you sure you want to delete this text card?",
         "image": "Are you sure you want to delete this image card?",
         "audio": "Are you sure you want to delete this audio card?",
         "storyboard": "Are you sure you want to delete this pivot table card?",
-        "video": "Are you sure you want to delete this video card?"
+        "video": "Are you sure you want to delete this video card?",
+        "panorama": "Are you sure you want to delete this panorama card?"
+      },
+      "panorama": {
+        "enterFullscreen": "Enter 720° Fullscreen",
+        "screenshot": "Screenshot",
+        "resetView": "Reset View",
+        "exit": "Exit Fullscreen (ESC)",
+        "uploadPanorama": "Upload Panorama",
+        "changePanorama": "Change Panorama",
+        "emptyHint": "Upload or pick a 720° panorama",
+        "doubleClickToFullscreen": "Double-click for 720° fullscreen",
+        "sizeError": "Panorama too large (max 30 MB)",
+        "hint": "Drag to look around · Scroll to zoom · ESC to exit",
+        "noPanorama": "No panorama uploaded",
+        "loading": "Loading panorama…",
+        "loadError": "Failed to load panorama",
+        "loadErrorHint": "Make sure the image is accessible and is in equirectangular projection (2:1 ratio recommended, e.g. 4096×2048)",
+        "screenshotName": "Panorama Screenshot",
+        "promptBuilder": {
+          "placeholder": "Describe the scene you want, e.g.: spaceship cockpit, futuristic city rooftop…",
+          "generate": "Generate Panorama Prompt",
+          "copied": "Copied",
+          "copyPrompt": "Copy Prompt",
+          "hint": "Paste the prompt into Midjourney / DALL-E to generate a panorama, then upload here"
+        }
       },
       "toolbar": {
         "duplicate": "Duplicate",
@@ -468,7 +495,9 @@
         "pickEditImage": "Pick an image to edit",
         "removeRef": "Remove",
         "generatingHint": "Generating image…",
-        "lastDuration": "Last generation time"
+        "lastDuration": "Last generation time",
+        "generatePanorama": "Generate Panorama",
+        "panoramaGenName": "Generated Panorama"
       },
       "storyboard": {
         "noData": "No Data",
@@ -604,6 +633,8 @@
     "storyboardDesc": "Storyboards, scripts, data management",
     "audioCard": "Audio Card",
     "audioDesc": "Music, sound effects, voice",
+    "panoramaCard": "Panorama Card",
+    "panoramaDesc": "720° panoramic scene",
     "dropToAdd": "Drop to add node",
     "images": "Images",
     "videos": "Videos",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -246,17 +246,44 @@
       "unnamedImageCard": "未命名图片卡",
       "unnamedAudioCard": "未命名音频卡",
       "unnamedVideoCard": "未命名视频卡",
+      "unnamedPanoramaCard": "未命名全景卡",
       "newTextCard": "新文本卡",
       "newImageCard": "新图片卡",
       "newAudioCard": "新音频卡",
       "newVideoCard": "新视频卡",
+      "newPanoramaCard": "新全景卡",
       "copySuffix": "{{name}} (副本)",
       "deleteConfirm": {
         "text": "确定要删除这张文本卡吗？",
         "image": "确定要删除这张图片卡吗？",
         "audio": "确定要删除这张音频卡吗？",
         "storyboard": "确定要删除这张多维表格卡吗？",
-        "video": "确定要删除这张视频卡吗？"
+        "video": "确定要删除这张视频卡吗？",
+        "panorama": "确定要删除这张全景卡吗？"
+      },
+      "panorama": {
+        "enterFullscreen": "进入全屏 720° 浏览",
+        "screenshot": "截图保存",
+        "resetView": "复位视角",
+        "exit": "退出全屏 (ESC)",
+        "uploadPanorama": "上传全景图",
+        "changePanorama": "更换全景图",
+        "emptyHint": "上传或选择 720° 全景图",
+        "doubleClickToFullscreen": "双击进入 720° 全景浏览",
+        "sizeError": "全景图过大（上限 30 MB）",
+        "hint": "拖拽改视角 · 滚轮缩放 · ESC 退出",
+        "noPanorama": "未上传全景图",
+        "loading": "正在加载全景图…",
+        "loadError": "全景图加载失败",
+        "loadErrorHint": "请确认图像可访问且为等距柱状投影（推荐 2:1 长宽比，例如 4096×2048）",
+        "screenshotName": "全景截图",
+        "promptBuilder": {
+          "placeholder": "描述你想要的场景，例如：飞船内部驾驶舱、未来城市天台…",
+          "generate": "生成全景提示词",
+          "copied": "已复制",
+          "copyPrompt": "复制提示词",
+          "hint": "将提示词粘贴到 Midjourney / DALL-E 等工具生成全景图，再上传到此节点"
+        }
       },
       "toolbar": {
         "duplicate": "创建副本",
@@ -468,7 +495,9 @@
         "pickEditImage": "选择要编辑的图片",
         "removeRef": "移除",
         "generatingHint": "图像生成中…",
-        "lastDuration": "本次生成耗时"
+        "lastDuration": "本次生成耗时",
+        "generatePanorama": "生成全景图",
+        "panoramaGenName": "生成全景图"
       },
       "storyboard": {
         "noData": "暂无数据",
@@ -604,6 +633,8 @@
     "storyboardDesc": "分镜、脚本等数据管理",
     "audioCard": "音频卡",
     "audioDesc": "音乐、音效、语音等",
+    "panoramaCard": "全景卡",
+    "panoramaDesc": "720° 全景场景图",
     "dropToAdd": "放置以添加节点",
     "images": "图片",
     "videos": "视频",

--- a/frontend/src/lib/canvas/__tests__/edgeRules.test.ts
+++ b/frontend/src/lib/canvas/__tests__/edgeRules.test.ts
@@ -1,8 +1,9 @@
 /**
  * edgeRules.ts 矩阵与 validateEdge 的单元测试。
  * 测试覆盖：
- *  - 5x5 矩阵字面值与 edgeRules.md 第 4 节一致
+ *  - 6x6 矩阵字面值与后端 _canvas_edge_rules.py 对齐
  *  - validateEdge 早返回顺序（self_loop → same_polarity → duplicate_edge → cycle → matrix）
+ *  - panorama 节点作为 MVP 阶段占位：仅自环 allow，其余 deferred
  */
 import type { Edge } from '@xyflow/react';
 import {
@@ -23,33 +24,39 @@ const mkEdge = (source: string, target: string, sh = 'right-source', th = 'left-
 });
 
 describe('EDGE_LEGALITY_MATRIX 字面值锁定', () => {
-  it('text 行：全 allow', () => {
+  it('text 行：五个原始类型 allow，→panorama=deferred', () => {
     expect(EDGE_LEGALITY_MATRIX.text).toEqual({
-      text: 'allow', image: 'allow', video: 'allow', audio: 'allow', storyboard: 'allow',
+      text: 'allow', image: 'allow', video: 'allow', audio: 'allow', storyboard: 'allow', panorama: 'deferred',
     });
   });
 
-  it('image 行：→audio=forbid, →text=deferred，其余 allow', () => {
+  it('image 行：→text=deferred, →panorama=deferred，其余 allow', () => {
     expect(EDGE_LEGALITY_MATRIX.image).toEqual({
-      text: 'deferred', image: 'allow', video: 'allow', audio: 'forbid', storyboard: 'allow',
+      text: 'deferred', image: 'allow', video: 'allow', audio: 'allow', storyboard: 'allow', panorama: 'deferred',
     });
   });
 
-  it('video 行：→text=deferred, →audio=deferred，其余 allow', () => {
+  it('video 行：→text=deferred, →audio=deferred, →panorama=deferred，其余 allow', () => {
     expect(EDGE_LEGALITY_MATRIX.video).toEqual({
-      text: 'deferred', image: 'allow', video: 'allow', audio: 'deferred', storyboard: 'allow',
+      text: 'deferred', image: 'allow', video: 'allow', audio: 'deferred', storyboard: 'allow', panorama: 'deferred',
     });
   });
 
-  it('audio 行：→image=forbid, →text=deferred, →audio=deferred，其余 allow', () => {
+  it('audio 行：→image=forbid, →text=deferred, →audio=deferred, →panorama=deferred，其余 allow', () => {
     expect(EDGE_LEGALITY_MATRIX.audio).toEqual({
-      text: 'deferred', image: 'forbid', video: 'allow', audio: 'deferred', storyboard: 'allow',
+      text: 'deferred', image: 'forbid', video: 'allow', audio: 'deferred', storyboard: 'allow', panorama: 'deferred',
     });
   });
 
-  it('storyboard 行：全 allow', () => {
+  it('storyboard 行：五个原始类型 allow，→panorama=deferred', () => {
     expect(EDGE_LEGALITY_MATRIX.storyboard).toEqual({
-      text: 'allow', image: 'allow', video: 'allow', audio: 'allow', storyboard: 'allow',
+      text: 'allow', image: 'allow', video: 'allow', audio: 'allow', storyboard: 'allow', panorama: 'deferred',
+    });
+  });
+
+  it('panorama 行：仅自环 allow，其余全部 deferred（MVP 占位）', () => {
+    expect(EDGE_LEGALITY_MATRIX.panorama).toEqual({
+      text: 'deferred', image: 'deferred', video: 'deferred', audio: 'deferred', storyboard: 'deferred', panorama: 'allow',
     });
   });
 });
@@ -154,6 +161,26 @@ describe('validateEdge 矩阵', () => {
     expect(r.ok).toBe(true);
   });
 
+  it('text→panorama：deferred → not_supported_yet', () => {
+    const r = validateEdge({ ...base, sourceType: 'text', targetType: 'panorama' });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('not_supported_yet');
+  });
+
+  it('panorama→panorama：allow（仅自环被拒，同类型不同节点放行）', () => {
+    const r = validateEdge({
+      ...base, sourceType: 'panorama', targetType: 'panorama',
+      sourceId: 'p1', targetId: 'p2',
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it('panorama→image：deferred → not_supported_yet', () => {
+    const r = validateEdge({ ...base, sourceType: 'panorama', targetType: 'image' });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('not_supported_yet');
+  });
+
   it('未知类型：按 allow 处理', () => {
     const r = validateEdge({ ...base, sourceType: 'ghost' as unknown as NodeType, targetType: 'text' });
     expect(r.ok).toBe(true);
@@ -169,5 +196,11 @@ describe('getEdgeLegality', () => {
   });
   it('text→storyboard = allow', () => {
     expect(getEdgeLegality('text', 'storyboard')).toBe('allow');
+  });
+  it('text→panorama = deferred', () => {
+    expect(getEdgeLegality('text', 'panorama')).toBe('deferred');
+  });
+  it('panorama→panorama = allow', () => {
+    expect(getEdgeLegality('panorama', 'panorama')).toBe('allow');
   });
 });

--- a/frontend/src/lib/canvas/edgeRules.ts
+++ b/frontend/src/lib/canvas/edgeRules.ts
@@ -12,7 +12,7 @@
 import type { Edge } from '@xyflow/react';
 import { hasCycle } from '@/lib/graphUtils';
 
-export type NodeType = 'text' | 'image' | 'video' | 'audio' | 'storyboard';
+export type NodeType = 'text' | 'image' | 'video' | 'audio' | 'storyboard' | 'panorama';
 
 export type EdgeLegality = 'allow' | 'deferred' | 'forbid';
 
@@ -32,8 +32,11 @@ export interface EdgeValidationResult {
 }
 
 /**
- * 5x5 合法性矩阵（Source → Target）。
- * 必须与 edgeRules.md 第 4 节、SKILL.md Edge Compatibility Matrix 三方对齐。
+ * 6x6 合法性矩阵（Source → Target）。
+ * 必须与 SKILL.md Edge Compatibility Matrix 与后端 _canvas_edge_rules.py 三方对齐。
+ *
+ * panorama 行/列在 MVP 阶段全部以 'deferred' 占位（仅自环 allow），表示
+ * 与其他节点类型的连线注入语义尚未在 edgePayload.ts 中实现；后续迭代再按需放行。
  */
 export const EDGE_LEGALITY_MATRIX: Record<NodeType, Record<NodeType, EdgeLegality>> = {
   text: {
@@ -42,6 +45,7 @@ export const EDGE_LEGALITY_MATRIX: Record<NodeType, Record<NodeType, EdgeLegalit
     video: 'allow',
     audio: 'allow',
     storyboard: 'allow',
+    panorama: 'deferred',
   },
   image: {
     text: 'deferred',
@@ -49,6 +53,7 @@ export const EDGE_LEGALITY_MATRIX: Record<NodeType, Record<NodeType, EdgeLegalit
     video: 'allow',
     audio: 'allow',
     storyboard: 'allow',
+    panorama: 'deferred',
   },
   video: {
     text: 'deferred',
@@ -56,6 +61,7 @@ export const EDGE_LEGALITY_MATRIX: Record<NodeType, Record<NodeType, EdgeLegalit
     video: 'allow',
     audio: 'deferred',
     storyboard: 'allow',
+    panorama: 'deferred',
   },
   audio: {
     text: 'deferred',
@@ -63,6 +69,7 @@ export const EDGE_LEGALITY_MATRIX: Record<NodeType, Record<NodeType, EdgeLegalit
     video: 'allow',
     audio: 'deferred',
     storyboard: 'allow',
+    panorama: 'deferred',
   },
   storyboard: {
     text: 'allow',
@@ -70,6 +77,15 @@ export const EDGE_LEGALITY_MATRIX: Record<NodeType, Record<NodeType, EdgeLegalit
     video: 'allow',
     audio: 'allow',
     storyboard: 'allow',
+    panorama: 'deferred',
+  },
+  panorama: {
+    text: 'deferred',
+    image: 'deferred',
+    video: 'deferred',
+    audio: 'deferred',
+    storyboard: 'deferred',
+    panorama: 'allow',
   },
 };
 
@@ -84,7 +100,7 @@ export const REJECT_MESSAGES: Record<EdgeRejectReason, string> = {
 };
 
 const isNodeType = (x: unknown): x is NodeType =>
-  typeof x === 'string' && ['text', 'image', 'video', 'audio', 'storyboard'].includes(x);
+  typeof x === 'string' && ['text', 'image', 'video', 'audio', 'storyboard', 'panorama'].includes(x);
 
 /**
  * 读取 Handle 所在的几何侧边（基于 id 前缀）。

--- a/frontend/src/store/useCanvasStore.ts
+++ b/frontend/src/store/useCanvasStore.ts
@@ -146,14 +146,29 @@ export type AudioNodeData = {
   updatedAt?: string;
 };
 
+export type PanoramaNodeData = {
+  name: string;
+  description?: string;
+  /** 等距柱状投影的全景图 URL（推荐 2:1 长宽比，例如 4096x2048） */
+  panoramaUrl?: string | null;
+  uploading?: boolean;
+  /** 全屏浏览的默认视角参数（弧度），可选 */
+  defaultYaw?: number;
+  defaultPitch?: number;
+  /** 默认 FOV（度），范围通常 30~100 */
+  defaultFov?: number;
+  /** 最后修改时间（ISO 字符串），用于节点选择器排序 */
+  updatedAt?: string;
+};
+
 export type GhostNodeData = {
-  targetNodeType: string;  // The node type being created (text/image/video/audio/storyboard)
+  targetNodeType: string;  // The node type being created (text/image/video/audio/storyboard/panorama)
   label?: string;
 };
 
 export type NodeEffect = 'reading' | 'scanning' | 'updating' | 'deleting' | 'connecting';
 
-export type CanvasNode = Node<ScriptNodeData | CharacterNodeData | StoryboardNodeData | VideoNodeData | AudioNodeData | GhostNodeData>;
+export type CanvasNode = Node<ScriptNodeData | CharacterNodeData | StoryboardNodeData | VideoNodeData | AudioNodeData | PanoramaNodeData | GhostNodeData>;
 
 interface HistoryState {
   nodes: CanvasNode[];
@@ -200,7 +215,7 @@ interface CanvasState {
   deleteNode: (id: string) => void;
   deleteEdge: (id: string) => void;
   reset: () => void;
-  updateNodeData: (id: string, data: Partial<ScriptNodeData | CharacterNodeData | StoryboardNodeData | VideoNodeData | AudioNodeData>) => void;
+  updateNodeData: (id: string, data: Partial<ScriptNodeData | CharacterNodeData | StoryboardNodeData | VideoNodeData | AudioNodeData | PanoramaNodeData>) => void;
   updateNodeDimensions: (id: string, width: number, height: number) => void;
   /**
    * 静默恢复节点位置（不打 isDirty，不入历史快照）。
@@ -570,7 +585,7 @@ export const useCanvasStore = create<CanvasState>()(
         });
       },
 
-      updateNodeData: (id: string, data: Partial<ScriptNodeData | CharacterNodeData | StoryboardNodeData | VideoNodeData | AudioNodeData>) => {
+      updateNodeData: (id: string, data: Partial<ScriptNodeData | CharacterNodeData | StoryboardNodeData | VideoNodeData | AudioNodeData | PanoramaNodeData>) => {
         const now = new Date().toISOString();
         set({
           nodes: get().nodes.map((node) =>


### PR DESCRIPTION
- backend schemas 和 canvas provider 增加 panorama 节点类型及边规则
- 前端 package.json 添加 @photo-sphere-viewer/core 依赖
- ImageNode 增加一键生成全景图功能，支持快速创建 panorama 节点及连线
- 新增 PanoramaNode 组件，实现全景图的显示、上传、编辑、删除等功能
- 侧边栏新增 panorama 节点卡片，用于创建全景图节点
- 实现 PanoramaNode 资产库选择弹窗，支持从资产库快速选取全景图
- ImageGeneratePanel 支持模式请求中 prompt 和 aspectRatio 的覆盖，用于一键生成全景图
- 快捷模式切换器增加生成全景图按钮入口
- 边规则矩阵调整为 6x6，panorama 连线当前为 deferred，后续支持继续完善