### PR TITLE
chore(frontend): 升级 TipTap 依赖版本

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -44,7 +44,7 @@
         "@tiptap/extensions": "^3.20.4",
         "@tiptap/pm": "^3.20.4",
         "@tiptap/react": "^3.20.4",
-        "@tiptap/starter-kit": "^3.20.4",
+        "@tiptap/starter-kit": "^3.23.6",
         "@types/dagre": "^0.7.54",
         "@types/lodash.debounce": "^4.0.9",
         "@types/react-window": "^1.8.8",
@@ -5188,29 +5188,29 @@
       }
     },
     "node_modules/@tiptap/extension-blockquote": {
-      "version": "3.20.4",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-blockquote/-/extension-blockquote-3.20.4.tgz",
-      "integrity": "sha512-9sskyyhYj2oKat//lyZVXCp9YrPt4oJAZnGHYWXS0xlskjsLElrfKKlM4vpbhGss3VrhQRoEGqWLnIaJYPF1zw==",
+      "version": "3.23.6",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-blockquote/-/extension-blockquote-3.23.6.tgz",
+      "integrity": "sha512-2RmnqNqTltZ2k1F7IfjoDNs935Uq4rRDR7d98mqkg3OlDktcQIyBpv0t9dTay6H5bkQeZUuS8ogK2S1E8Edjug==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.20.4"
+        "@tiptap/core": "3.23.6"
       }
     },
     "node_modules/@tiptap/extension-bold": {
-      "version": "3.20.4",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-bold/-/extension-bold-3.20.4.tgz",
-      "integrity": "sha512-Md7/mNAeJCY+VLJc8JRGI+8XkVPKiOGB1NgqQPdh3aYtxXQDChQOZoJEQl6TuudDxZ85bLZB67NjZlx3jo8/0g==",
+      "version": "3.23.6",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-bold/-/extension-bold-3.23.6.tgz",
+      "integrity": "sha512-1LMhjnytdbbhWHSoOwnLxZAOQZWPkKyXVCNmaIk0Mhi4tLPUXptG4qKS5sVYTCveE5H6IBPFrbgBFi5dMI6krA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.20.4"
+        "@tiptap/core": "3.23.6"
       }
     },
     "node_modules/@tiptap/extension-bubble-menu": {
@@ -5230,6 +5230,19 @@
         "@tiptap/pm": "3.23.4"
       }
     },
+    "node_modules/@tiptap/extension-bullet-list": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-bullet-list/-/extension-bullet-list-3.23.6.tgz",
+      "integrity": "sha512-RMRgfXZykr/13X8UBOwvpgysVOo9KchwqMoEbvqQSj4YFfU56iIn59C8sbxiQ1sKfeltUf0wH4fPc0I4iwKqAA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.23.6"
+      }
+    },
     "node_modules/@tiptap/extension-character-count": {
       "version": "3.23.1",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-character-count/-/extension-character-count-3.23.1.tgz",
@@ -5244,30 +5257,30 @@
       }
     },
     "node_modules/@tiptap/extension-code": {
-      "version": "3.20.4",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-code/-/extension-code-3.20.4.tgz",
-      "integrity": "sha512-7j8Hi964bH1SZ9oLdZC1fkqWz27mliSDV7M8lmL/M14+Qw42D/VOAKS4Aw9OCFtHMlTsjLR6qsoVxL8Lpkt6NA==",
+      "version": "3.23.6",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-code/-/extension-code-3.23.6.tgz",
+      "integrity": "sha512-KG8KXFYyLrtYvT7AZ1WGV61ofx8pDe5g9pH658MERxqQGii+Pyfc6xkz04l7XeBts/7+571UQp/0O7i/z560TA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.20.4"
+        "@tiptap/core": "3.23.6"
       }
     },
     "node_modules/@tiptap/extension-code-block": {
-      "version": "3.20.4",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-code-block/-/extension-code-block-3.20.4.tgz",
-      "integrity": "sha512-Zlw3FrXTy01+o1yISeX/LC+iJeHA+ym602bMXGmtA6lyl7QSOSO7WExweJ6xeJGhbCjldwT5al6fkRAs8iGJZg==",
+      "version": "3.23.6",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-code-block/-/extension-code-block-3.23.6.tgz",
+      "integrity": "sha512-4kccgcn5yHThxrzsIhJny3EwfEZYIk+BjUCL4uIuzOyWvExtGhZ6JMHVCZeMhI8D1/bX1LNkkAKN5DXPzH4lXQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.20.4",
-        "@tiptap/pm": "^3.20.4"
+        "@tiptap/core": "3.23.6",
+        "@tiptap/pm": "3.23.6"
       }
     },
     "node_modules/@tiptap/extension-color": {
@@ -5284,16 +5297,29 @@
       }
     },
     "node_modules/@tiptap/extension-document": {
-      "version": "3.20.4",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-document/-/extension-document-3.20.4.tgz",
-      "integrity": "sha512-zF1CIFVLt8MfSpWWnPwtGyxPOsT0xYM2qJKcXf2yZcTG37wDKmUi6heG53vGigIavbQlLaAFvs+1mNdOu2x/0A==",
+      "version": "3.23.6",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-document/-/extension-document-3.23.6.tgz",
+      "integrity": "sha512-XDAIgG9KcKumFM9KJWUEUhXPbFIhhl47bfy5GknareWTRKke85rcoj/oxKKO9ihLZr8JfpbXjqnS4SCm5yhYPw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.20.4"
+        "@tiptap/core": "3.23.6"
+      }
+    },
+    "node_modules/@tiptap/extension-dropcursor": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-dropcursor/-/extension-dropcursor-3.23.6.tgz",
+      "integrity": "sha512-+XWEoRKf3lXxi7Le1aOM2xU1XHwxICGpXjT3m4QaYqUgIpsq8gQEuso6kVg8DnTD7biKQs6+oIQ0o2b/gTW9WA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.23.6"
       }
     },
     "node_modules/@tiptap/extension-floating-menu": {
@@ -5311,30 +5337,43 @@
         "@tiptap/pm": "3.23.4"
       }
     },
-    "node_modules/@tiptap/extension-hard-break": {
-      "version": "3.20.4",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-hard-break/-/extension-hard-break-3.20.4.tgz",
-      "integrity": "sha512-gJbq58d8zB1gzyqVEopowej5CpW4/Fpg6oGJvlZxaCukqd0gJRWGC89K+jE62YA1Td4sfcKrekKvN7jm2y/ZUg==",
+    "node_modules/@tiptap/extension-gapcursor": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-gapcursor/-/extension-gapcursor-3.23.6.tgz",
+      "integrity": "sha512-wbKmxXsszxWacEkrHucRpSQbiKjz4fmOebD6OVyL9AcrmlbxNk8vcM3iyh/8cVeRy09XY+morM165t/u7/z4IQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.20.4"
+        "@tiptap/extensions": "3.23.6"
+      }
+    },
+    "node_modules/@tiptap/extension-hard-break": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-hard-break/-/extension-hard-break-3.23.6.tgz",
+      "integrity": "sha512-KeUm+tkUfIVSX9QM9XOIhaay0Fn36sLKUo5NVYjN3uJaxFvaZXZmTlxdO85OTdgF2P5sqh9LomrIgliaFRGk4w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.6"
       }
     },
     "node_modules/@tiptap/extension-heading": {
-      "version": "3.20.4",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-heading/-/extension-heading-3.20.4.tgz",
-      "integrity": "sha512-xsnkmTGggJc5P2iCwS1lv8KFG31xC/GNPJKoi/3UH67j/lKDhA3AdtshsLeyv2FKtTtYDb8oV0IqzHB1MM6a7w==",
+      "version": "3.23.6",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-heading/-/extension-heading-3.23.6.tgz",
+      "integrity": "sha512-A/0jPhxnUh9THSZymlu0OGPZe1wdFdwHAXnRCmqvYUCwJjrG7LCC/ahzmcj1tcNzI9hgHyuYPSfev8RXYrNu/w==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.20.4"
+        "@tiptap/core": "3.23.6"
       }
     },
     "node_modules/@tiptap/extension-highlight": {
@@ -5351,17 +5390,17 @@
       }
     },
     "node_modules/@tiptap/extension-horizontal-rule": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.23.4.tgz",
-      "integrity": "sha512-EA4kK8ywZ4dQNOdxeZbplmDDs5T5LjMgHpqxRwukj9wwKiILOK5E3fcKm1fCKh9Q02w96jax6YVccHwmgJP3sQ==",
+      "version": "3.23.6",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.23.6.tgz",
+      "integrity": "sha512-hEUlz4H+I64r+TH6LCuNCRgO7JTHncXGmx9+WbU69EOfY8O0ZurcgeJc8HeiAKL+r9YuC1e5YHfFxgCaaC0jlg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.23.4",
-        "@tiptap/pm": "3.23.4"
+        "@tiptap/core": "3.23.6",
+        "@tiptap/pm": "3.23.6"
       }
     },
     "node_modules/@tiptap/extension-image": {
@@ -5378,22 +5417,22 @@
       }
     },
     "node_modules/@tiptap/extension-italic": {
-      "version": "3.20.4",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-italic/-/extension-italic-3.20.4.tgz",
-      "integrity": "sha512-4ZqiWr7cmqPFux8tj1ZLiYytyWf343IvQemNX6AvVWvscrJcrfj3YX4Le2BA0RW3A3M6RpLQXXozuF8vxYFDeQ==",
+      "version": "3.23.6",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-italic/-/extension-italic-3.23.6.tgz",
+      "integrity": "sha512-wol5KdwCPAvpiYhH9PLlvO8ZnJHwZtIboVevrfOGgBcKlXRA3dedR4OAMXHnUtkkzu9KtliLg1+TYzEx4JZG9Q==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.20.4"
+        "@tiptap/core": "3.23.6"
       }
     },
     "node_modules/@tiptap/extension-link": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.23.4.tgz",
-      "integrity": "sha512-XjxltY7MomwfTs6jmN6Bw5bb/upb34lpyqv2RiXppFTK25Br7ipksRjUpWpB4/csZeg30qwrLGVKxCol38ffrw==",
+      "version": "3.23.6",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-link/-/extension-link-3.23.6.tgz",
+      "integrity": "sha512-KNZz7z7P2/qbQsx5bPAbSPjrKDg1VHsedGlLHJCr8U2VRD5VgmDLkMpkouP1CsDg15qgyUKv/nDib5KgPpLNWA==",
       "license": "MIT",
       "dependencies": {
         "linkifyjs": "^4.3.3"
@@ -5403,35 +5442,74 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.23.4",
-        "@tiptap/pm": "3.23.4"
+        "@tiptap/core": "3.23.6",
+        "@tiptap/pm": "3.23.6"
       }
     },
     "node_modules/@tiptap/extension-list": {
-      "version": "3.23.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.23.1.tgz",
-      "integrity": "sha512-v1AeXPpagslgRZdOp7WdjCoO4TjjNP8RM2R6Gqx0/inGaNXnM8zCMshOxZlAb03Ad7kq/4RGJmkpM/Jjsi6dEQ==",
+      "version": "3.23.6",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-list/-/extension-list-3.23.6.tgz",
+      "integrity": "sha512-z6vj9+Qht2sjdQkyyHcUpsC/yCIZqTrQiyHDhs/HGKrfvoANyAZGpqdNeKf1wSyjIso+27tQuIH5NDfk8ygyNw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.23.1",
-        "@tiptap/pm": "3.23.1"
+        "@tiptap/core": "3.23.6",
+        "@tiptap/pm": "3.23.6"
+      }
+    },
+    "node_modules/@tiptap/extension-list-item": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-list-item/-/extension-list-item-3.23.6.tgz",
+      "integrity": "sha512-3zzyhdkUWcHVpXuvy6KiIwjh29rbH6gEDEqPQqHLrl1XGnO9pnShC7pSHctlCDjmcx3O4n9cd4QMtVBlUerbiA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.23.6"
+      }
+    },
+    "node_modules/@tiptap/extension-list-keymap": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-list-keymap/-/extension-list-keymap-3.23.6.tgz",
+      "integrity": "sha512-x8bPcLViGzg/RAmQM/XtmfqIwQ/Pv9Q8mkd+OgfUiTqjeJqKwVQmiqbLFNa7zw81+H61M+HDU+qGAaQ3vRIMjw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.23.6"
+      }
+    },
+    "node_modules/@tiptap/extension-ordered-list": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-ordered-list/-/extension-ordered-list-3.23.6.tgz",
+      "integrity": "sha512-1m/wWB/ZtXcmG2vNdiUkCqsOgqv5vBjCv/mVaHhF9OvV+zQS8YDjoWE7zEuT/GgELdT77Xq8lHrn4nCDudB3/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.23.6"
       }
     },
     "node_modules/@tiptap/extension-paragraph": {
-      "version": "3.20.4",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-paragraph/-/extension-paragraph-3.20.4.tgz",
-      "integrity": "sha512-lm6fOScWuZAF/Sfp97igUwFd3L1QHIVLAWP5NVdh0DTLrEIt4rMBmsww+yOpMQRhvz2uTgMbMXynrimhzi/QVw==",
+      "version": "3.23.6",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-paragraph/-/extension-paragraph-3.23.6.tgz",
+      "integrity": "sha512-+7m58LUSncodjrIyXks4RZ3tLNYrvgT77wRR4l3HnM5OABY3GDsDTqi7c1t1yI29NVOSk/DUacqy6UwYAj1DGg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.20.4"
+        "@tiptap/core": "3.23.6"
       }
     },
     "node_modules/@tiptap/extension-placeholder": {
@@ -5448,16 +5526,16 @@
       }
     },
     "node_modules/@tiptap/extension-strike": {
-      "version": "3.20.4",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-strike/-/extension-strike-3.20.4.tgz",
-      "integrity": "sha512-It1Px9uDGTsVqyyg6cy7DigLoenljpQwqdI0jssM7QclZrHnsrye9fZxBBiiuCzzV1305MxKgHvratkHwqmVNA==",
+      "version": "3.23.6",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-strike/-/extension-strike-3.23.6.tgz",
+      "integrity": "sha512-oF7FEZ37f15aCe5kPgzGDYf/m+hr7VdQ/Ko/Hds/UM9pX7AG1fdtmRrl6wqkRqDM/incZaC/AQR2/Dpo2VCNGQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.20.4"
+        "@tiptap/core": "3.23.6"
       }
     },
     "node_modules/@tiptap/extension-subscript": {
@@ -5568,16 +5646,16 @@
       }
     },
     "node_modules/@tiptap/extension-text": {
-      "version": "3.20.4",
-      "resolved": "https://registry.npmmirror.com/@tiptap/extension-text/-/extension-text-3.20.4.tgz",
-      "integrity": "sha512-jchJcBZixDEO2J66Zx5dchsI2mA6IYsROqF8P1poxL4ienH7RVQRCTsBNnSfIeOtREKKWeOU/tEs5fcpvvGwIQ==",
+      "version": "3.23.6",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-text/-/extension-text-3.23.6.tgz",
+      "integrity": "sha512-ipoC2TkIAIOTiF5ByiGgvQB1DqDyfP90wrUB3mohBcgvp7lQnwHszCDGv8dNnmcUek8uXV/uoLu2VXeVQlxjPA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.20.4"
+        "@tiptap/core": "3.23.6"
       }
     },
     "node_modules/@tiptap/extension-text-align": {
@@ -5620,36 +5698,36 @@
       }
     },
     "node_modules/@tiptap/extension-underline": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.23.4.tgz",
-      "integrity": "sha512-F1ocPT10LV+seky25R1TMCRdc/Iof99jLcDSYDGr6mNEDY4ct2RvOeSM8aDdYq6CkH+vXt3i3JDeRwV23KzswQ==",
+      "version": "3.23.6",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extension-underline/-/extension-underline-3.23.6.tgz",
+      "integrity": "sha512-P55wGIZGYTVH92Fq0cgI4/O9AhLCaJC3hhxg15RSERP5/YegM9eJHDK/GQ1EE/DvYA+xpYGOV6agKwAUqfA/Iw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.23.4"
+        "@tiptap/core": "3.23.6"
       }
     },
     "node_modules/@tiptap/extensions": {
-      "version": "3.23.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.23.1.tgz",
-      "integrity": "sha512-7UIn+idaVTVhdlP0KmgzBh8Csmwck357Dq4te5DuAxhSkN1gsXHlq39mpx907UYKJdSOgd+GMFeyOziPwSmbOQ==",
+      "version": "3.23.6",
+      "resolved": "https://registry.npmmirror.com/@tiptap/extensions/-/extensions-3.23.6.tgz",
+      "integrity": "sha512-X09/Db1teB+ifXzDGVVFmOeQRx7wTAayE9/280spxpsHkHZvJ5bHRvWIzUzviMIjbBz+NPDIKYPK7gMfh9iaig==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.23.1",
-        "@tiptap/pm": "3.23.1"
+        "@tiptap/core": "3.23.6",
+        "@tiptap/pm": "3.23.6"
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "3.23.1",
-      "resolved": "https://registry.npmmirror.com/@tiptap/pm/-/pm-3.23.1.tgz",
-      "integrity": "sha512-8G+TkNsUHHAAJYREpA6fw+Dw/m2Y3Go4/QMQM8RYepid+wTeE1wSv7sBA/CBrphhYmJSWeTyCPtgQIxnTJXMCA==",
+      "version": "3.23.6",
+      "resolved": "https://registry.npmmirror.com/@tiptap/pm/-/pm-3.23.6.tgz",
+      "integrity": "sha512-in5CaMaWlJcH2A1q6GJKFtrodE8WLS3M9tIi/f89jPmIVHJShpodC0KZDNyJkrVBQomYk0DEh86Utm6ASXzQww==",
       "license": "MIT",
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
@@ -5698,165 +5776,35 @@
       }
     },
     "node_modules/@tiptap/starter-kit": {
-      "version": "3.20.4",
-      "resolved": "https://registry.npmmirror.com/@tiptap/starter-kit/-/starter-kit-3.20.4.tgz",
-      "integrity": "sha512-WcyK6hsTl8eBsQhQ+d9Sq8fYZKOYdL+D45MyH3hz583elXqJlW3h3JPFYb0o87gddGxn8Mm57OA/gA1zEdeDMw==",
+      "version": "3.23.6",
+      "resolved": "https://registry.npmmirror.com/@tiptap/starter-kit/-/starter-kit-3.23.6.tgz",
+      "integrity": "sha512-gykwtGWrnWCmtql1hid3opac/KV8zQvOAnu3bTqIqcHrn1FusbUwKmNzavSbfGvcktHM3hFjb35W48JyVLyu/A==",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/core": "^3.20.4",
-        "@tiptap/extension-blockquote": "^3.20.4",
-        "@tiptap/extension-bold": "^3.20.4",
-        "@tiptap/extension-bullet-list": "^3.20.4",
-        "@tiptap/extension-code": "^3.20.4",
-        "@tiptap/extension-code-block": "^3.20.4",
-        "@tiptap/extension-document": "^3.20.4",
-        "@tiptap/extension-dropcursor": "^3.20.4",
-        "@tiptap/extension-gapcursor": "^3.20.4",
-        "@tiptap/extension-hard-break": "^3.20.4",
-        "@tiptap/extension-heading": "^3.20.4",
-        "@tiptap/extension-horizontal-rule": "^3.20.4",
-        "@tiptap/extension-italic": "^3.20.4",
-        "@tiptap/extension-link": "^3.20.4",
-        "@tiptap/extension-list": "^3.20.4",
-        "@tiptap/extension-list-item": "^3.20.4",
-        "@tiptap/extension-list-keymap": "^3.20.4",
-        "@tiptap/extension-ordered-list": "^3.20.4",
-        "@tiptap/extension-paragraph": "^3.20.4",
-        "@tiptap/extension-strike": "^3.20.4",
-        "@tiptap/extension-text": "^3.20.4",
-        "@tiptap/extension-underline": "^3.20.4",
-        "@tiptap/extensions": "^3.20.4",
-        "@tiptap/pm": "^3.20.4"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-bullet-list": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.23.4.tgz",
-      "integrity": "sha512-mXB2KZOz1R+E6VNTZ3vzdAk7ZDGKjPmsJEZIQg1B5qRycTKg49/rCCkLA2QnqAwX6BzS3mLLH1RWE2W0oXD7vg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/extension-list": "3.23.4"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-dropcursor": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.23.4.tgz",
-      "integrity": "sha512-ujJQUIENk0RwVFCh5g/TOSEv1a7Pnam/cjHmSUqHWUNZkYS9aOqjm+JfURJPCinRS2oHvo3AARul5mkKgDJYcA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/extensions": "3.23.4"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-gapcursor": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.23.4.tgz",
-      "integrity": "sha512-RuyvOlIGP6UpVOc0Lw0L63jKLtYM49CNhPV2OMSfwwwbBZ3pJGos2/SqpYg71d3sn+qpsAopS4Pfr8iPZog73A==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/extensions": "3.23.4"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-list": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.23.4.tgz",
-      "integrity": "sha512-yuauDm6qW/7q+ZO0YJBKQEGdnUm6DDTJM8AMp9bMZrT4jRf/zyUtNcZ91QEfFvBcyVuI+10PIOXtNPevhQ741Q==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.23.4",
-        "@tiptap/pm": "3.23.4"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-list-item": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.23.4.tgz",
-      "integrity": "sha512-Q/JXosShD5oyDwukE6igdrZD2lb0ZgyoQTHYchk0pzU4frClFbn3RI1wKP+XeqKLhdO6KH2WZ9rERGH7PtDi7Q==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/extension-list": "3.23.4"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-list-keymap": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.23.4.tgz",
-      "integrity": "sha512-9FezifCfuoc0o+5K6l4QNOOfelqxnDGg/f9oL1D/LFZPC54bPxpWWft9QCWOqyqZgyLCLjbCjciAlbgkrFUmmw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/extension-list": "3.23.4"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-ordered-list": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.23.4.tgz",
-      "integrity": "sha512-+3ofyssYnOTa1+nFWEmCAY1ngn8nAV1xo25JnNNC87NMU9WkSgr93jB7/uUJP0uui1C2dBLlaup3XXm108yarw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/extension-list": "3.23.4"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extensions": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.23.4.tgz",
-      "integrity": "sha512-SlGPXauW8iKWG7wwuwC/0y/smLImp0h6GBIGgNnTBgIP/ThXQnjLMSZH0mW/REO87dQxkku01V3ARRywi+juhg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.23.4",
-        "@tiptap/pm": "3.23.4"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/pm": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.23.4.tgz",
-      "integrity": "sha512-+C5ngcoza47n3MjtjVBqBEBICPC0McdbwzJ+X6SSCviCLoqnSYanv5mIX9HWG0Q4fJ4BkdNM3VibZUxQaTbKyQ==",
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-changeset": "^2.3.0",
-        "prosemirror-commands": "^1.6.2",
-        "prosemirror-dropcursor": "^1.8.1",
-        "prosemirror-gapcursor": "^1.3.2",
-        "prosemirror-history": "^1.4.1",
-        "prosemirror-keymap": "^1.2.2",
-        "prosemirror-model": "^1.24.1",
-        "prosemirror-schema-list": "^1.5.0",
-        "prosemirror-state": "^1.4.3",
-        "prosemirror-tables": "^1.6.4",
-        "prosemirror-transform": "^1.10.2",
-        "prosemirror-view": "^1.38.1"
+        "@tiptap/core": "^3.23.6",
+        "@tiptap/extension-blockquote": "^3.23.6",
+        "@tiptap/extension-bold": "^3.23.6",
+        "@tiptap/extension-bullet-list": "^3.23.6",
+        "@tiptap/extension-code": "^3.23.6",
+        "@tiptap/extension-code-block": "^3.23.6",
+        "@tiptap/extension-document": "^3.23.6",
+        "@tiptap/extension-dropcursor": "^3.23.6",
+        "@tiptap/extension-gapcursor": "^3.23.6",
+        "@tiptap/extension-hard-break": "^3.23.6",
+        "@tiptap/extension-heading": "^3.23.6",
+        "@tiptap/extension-horizontal-rule": "^3.23.6",
+        "@tiptap/extension-italic": "^3.23.6",
+        "@tiptap/extension-link": "^3.23.6",
+        "@tiptap/extension-list": "^3.23.6",
+        "@tiptap/extension-list-item": "^3.23.6",
+        "@tiptap/extension-list-keymap": "^3.23.6",
+        "@tiptap/extension-ordered-list": "^3.23.6",
+        "@tiptap/extension-paragraph": "^3.23.6",
+        "@tiptap/extension-strike": "^3.23.6",
+        "@tiptap/extension-text": "^3.23.6",
+        "@tiptap/extension-underline": "^3.23.6",
+        "@tiptap/extensions": "^3.23.6",
+        "@tiptap/pm": "^3.23.6"
       },
       "funding": {
         "type": "github",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,7 @@
     "@tiptap/extensions": "^3.20.4",
     "@tiptap/pm": "^3.20.4",
     "@tiptap/react": "^3.20.4",
-    "@tiptap/starter-kit": "^3.20.4",
+    "@tiptap/starter-kit": "^3.23.6",
     "@types/dagre": "^0.7.54",
     "@types/lodash.debounce": "^4.0.9",
     "@types/react-window": "^1.8.8",
@@ -120,7 +120,8 @@
     "lodash": "^4.18.1",
     "prismjs": "^1.30.0",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "@tiptap/core": "^3.23.4"
   },
   "optionalDependencies": {
     "lightningcss-linux-arm64-gnu": "^1.30.1",


### PR DESCRIPTION
- 将 @tiptap/starter-kit 升级到 3.23.6 版本
- 新增 @tiptap/core 依赖，版本为 3.23.4
- 更新 package-lock.json 以反映依赖变更