### PR TITLE
feat(proxy): 实现跨平台系统代理自动检测与配置

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -18,17 +18,110 @@ from fastapi.responses import JSONResponse
 from errors import BizError, ErrorCode, STATUS_TO_CODE
 
 # ---------------------------------------------------------------------------
-# 代理旁路：开发机常常设了 HTTP_PROXY/HTTPS_PROXY（Clash / V2Ray / 公司代理），
-# httpx / ollama-py / openai-py 默认读环境变量，连本机 Ollama (localhost:11434)
-# 会被误转发到代理服务器上，触发 "Server disconnected without sending a response"。
-# 这里将环回地址追加到 NO_PROXY，让所有本机调用绕过代理。
+# 代理自动检测（跨平台）：
+#   1. 自动检测系统代理设置（Windows 注册表 / macOS scutil / Linux gsettings）
+#   2. 若检测到系统代理 → 设置 HTTP_PROXY/HTTPS_PROXY → 外网模型（Gemini/Claude）走代理
+#   3. 始终将 localhost/127.0.0.1 加入 NO_PROXY → Ollama 本地调用绕过代理
 # ---------------------------------------------------------------------------
+import subprocess as _sp
+
+
+def _detect_system_proxy() -> str | None:
+    """跨平台检测系统代理。返回 'http://host:port' 或 None。"""
+    _DETECTORS = {
+        "win32": _detect_proxy_windows,
+        "darwin": _detect_proxy_macos,
+        "linux": _detect_proxy_linux,
+    }
+    detector = _DETECTORS.get(sys.platform)
+    return detector() if detector else None
+
+
+def _detect_proxy_windows() -> str | None:
+    """Windows: 读取注册表 Internet Settings。"""
+    try:
+        import winreg
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER,
+                            r"Software\Microsoft\Windows\CurrentVersion\Internet Settings") as key:
+            enabled, _ = winreg.QueryValueEx(key, "ProxyEnable")
+            server, _ = winreg.QueryValueEx(key, "ProxyServer")
+            if enabled and server:
+                # 协议分组格式 "http=h:p;https=h:p;..." 或简单格式 "host:port"
+                parts = dict(item.split("=", 1) for item in server.split(";") if "=" in item)
+                addr = parts.get("https") or parts.get("http") or server
+                return f"http://{addr}" if not addr.startswith("http") else addr
+    except Exception:
+        pass
+    return None
+
+
+def _detect_proxy_macos() -> str | None:
+    """macOS: 通过 scutil --proxy 读取系统网络代理。"""
+    try:
+        out = _sp.check_output(["scutil", "--proxy"], text=True, timeout=3)
+        lines = {l.strip().split(" : ")[0]: l.strip().split(" : ")[1]
+                 for l in out.splitlines() if " : " in l}
+        # 优先 HTTPS，回退 HTTP
+        for enable_key, host_key, port_key in [
+            ("HTTPSEnable", "HTTPSProxy", "HTTPSPort"),
+            ("HTTPEnable", "HTTPProxy", "HTTPPort"),
+        ]:
+            enabled = lines.get(enable_key, "0") == "1"
+            host = lines.get(host_key, "")
+            port = lines.get(port_key, "")
+            if enabled and host:
+                return f"http://{host}:{port}" if port else f"http://{host}"
+        # SOCKS 代理（Clash 增强模式常用）
+        socks_on = lines.get("SOCKSEnable", "0") == "1"
+        socks_host = lines.get("SOCKSProxy", "")
+        socks_port = lines.get("SOCKSPort", "")
+        if socks_on and socks_host:
+            return f"socks5://{socks_host}:{socks_port}" if socks_port else f"socks5://{socks_host}"
+    except Exception:
+        pass
+    return None
+
+
+def _detect_proxy_linux() -> str | None:
+    """Linux: 通过 gsettings 读取 GNOME 代理，或检测常见代理端口。"""
+    # 尝试 gsettings（GNOME 桌面）
+    try:
+        mode = _sp.check_output(
+            ["gsettings", "get", "org.gnome.system.proxy", "mode"], text=True, timeout=3
+        ).strip().strip("'")
+        if mode == "manual":
+            host = _sp.check_output(
+                ["gsettings", "get", "org.gnome.system.proxy.http", "host"], text=True, timeout=3
+            ).strip().strip("'")
+            port = _sp.check_output(
+                ["gsettings", "get", "org.gnome.system.proxy.http", "port"], text=True, timeout=3
+            ).strip()
+            if host and port and port != "0":
+                return f"http://{host}:{port}"
+    except Exception:
+        pass
+    return None
+
+
+# 优先级：环境变量 > 系统代理自动检测
+_proxy_url = os.environ.get("HTTPS_PROXY") or os.environ.get("HTTP_PROXY") or os.environ.get("https_proxy") or os.environ.get("http_proxy")
+_proxy_url = _proxy_url or _detect_system_proxy()
+_proxy_url and os.environ.setdefault("HTTP_PROXY", _proxy_url)
+_proxy_url and os.environ.setdefault("HTTPS_PROXY", _proxy_url)
+_proxy_url and os.environ.setdefault("http_proxy", _proxy_url)
+_proxy_url and os.environ.setdefault("https_proxy", _proxy_url)
+
+# NO_PROXY: 本地地址始终绕过代理（Ollama / 本地服务）
 _no_proxy_existing = os.environ.get("NO_PROXY") or os.environ.get("no_proxy") or ""
 _no_proxy_set = {item.strip() for item in _no_proxy_existing.split(",") if item.strip()}
 _no_proxy_set.update({"localhost", "127.0.0.1", "::1"})
 _no_proxy_value = ",".join(sorted(_no_proxy_set))
 os.environ["NO_PROXY"] = _no_proxy_value
 os.environ["no_proxy"] = _no_proxy_value
+
+# 日志输出代理状态（启动时可见）
+_proxy_url and print(f"[PROXY] 检测到代理: {_proxy_url} | NO_PROXY: {_no_proxy_value}")
+(not _proxy_url) and print(f"[PROXY] 未检测到代理，外网模型可能无法连接 | NO_PROXY: {_no_proxy_value}")
 
 # ---------------------------------------------------------------------------
 # Windows 兼容：asyncpg + 控制台 UTF-8

--- a/backend/main.py
+++ b/backend/main.py
@@ -51,7 +51,7 @@ def _detect_proxy_windows() -> str | None:
                 addr = parts.get("https") or parts.get("http") or server
                 return f"http://{addr}" if not addr.startswith("http") else addr
     except Exception:
-        pass
+        logging.debug("Failed to detect Windows system proxy from registry.", exc_info=True)
     return None
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,6 +9,8 @@ import logging
 import os
 import sys
 
+logger = logging.getLogger(__name__)
+
 import uvicorn
 from fastapi import FastAPI, HTTPException, Request, WebSocket
 from fastapi.exceptions import RequestValidationError
@@ -77,8 +79,8 @@ def _detect_proxy_macos() -> str | None:
         socks_port = lines.get("SOCKSPort", "")
         if socks_on and socks_host:
             return f"socks5://{socks_host}:{socks_port}" if socks_port else f"socks5://{socks_host}"
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug("Failed to detect macOS system proxy: %s", e, exc_info=True)
     return None
 
 
@@ -98,8 +100,8 @@ def _detect_proxy_linux() -> str | None:
             ).strip()
             if host and port and port != "0":
                 return f"http://{host}:{port}"
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug("Failed to detect Linux system proxy: %s", e, exc_info=True)
     return None
 
 

--- a/backend/skills/active_skills/Photography_Scene_Design/SKILL.md
+++ b/backend/skills/active_skills/Photography_Scene_Design/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: Photography_Scene_Design
+description: "专业摄影器材与参数指南，用于角色、道具、场景的AI图像生成。涵盖主流相机机身、镜头品牌、焦距与光圈的详细说明，适用于GPT-image-2、nanobanana2.0、nanobanana pro等文生图/图生图模型。"
+metadata:
+  builtin_skill_version: "1.0"
+---
+
+# 摄影场景设计（角色·道具·场景）
+
+**目的**：为AI图像生成注入真实摄影器材参数，通过指定相机机身、镜头品牌、焦距与光圈，精确控制画面质感、景深、透视与氛围，提升角色/道具/场景设计的专业度与真实感。
+
+## 使用场景
+
+- 生成角色立绘、人像写真、时尚摄影
+- 道具细节特写、产品摄影
+- 场景氛围图、概念设计、环境渲染
+- 需要特定摄影器材质感的图像（胶片感、中画幅质感、电影镜头风格等）
+
+## 核心原则
+
+1. **器材服务画面**：选择器材参数是为了实现特定视觉效果，不是堆砌品牌名
+2. **参数协调**：焦距、光圈、机身三者搭配需合理，避免不可能的组合
+3. **一句一器材**：提示词中明确一套器材参数即可，不混用多套
+4. **适配模型特性**：针对不同图像模型（GPT-image-2、nanobanana系列），器材描述融入自然语言
+
+---
+
+## 一、相机机身品牌速查
+
+### 全画幅/中画幅（高画质优先）
+
+| 品牌 | 代表机型 | 画面特征 | 适用场景 |
+|------|----------|----------|----------|
+| Canon | EOS R5 / R6 Mark II | 肤色讨喜、色彩饱和、暗部纯净 | 人像、时尚、商业摄影 |
+| Nikon | Z8 / Z9 | 色彩真实、锐度极高、高动态范围 | 风光、产品、纪实 |
+| Sony | A7R V / A7 IV | 高解析力、对焦精准、宽容度大 | 全场景通用、人像、街拍 |
+| Fujifilm | GFX 100S / X-T5 | 独特胶片色彩模拟、中画幅质感 | 人文、肖像、胶片风格 |
+| Leica | M11 / Q3 | 德味色彩、过渡细腻、氛围独特 | 街拍、人文、艺术摄影 |
+| Hasselblad | X2D 100C | 中画幅超高细节、色彩科学顶级 | 时尚、商业广告、精细产品 |
+| Phase One | IQ4 150MP | 1.5亿像素、极致细节、色彩精准 | 高端商业、艺术品复制 |
+
+### 电影/视频机身（电影质感）
+
+| 品牌 | 代表机型 | 画面特征 | 适用场景 |
+|------|----------|----------|----------|
+| ARRI | ALEXA 35 / Mini LF | 自然肤色、电影级宽容度、柔和高光 | 电影感角色、叙事场景 |
+| RED | V-RAPTOR / KOMODO | 高分辨率、锐利细节、科技感 | 科幻、动作、高细节场景 |
+| Blackmagic | URSA Mini Pro 12K | 高动态范围、Raw色彩空间 | 独立电影、概念场景 |
+
+### 胶片相机（复古质感）
+
+| 品牌 | 代表机型 | 画面特征 | 适用场景 |
+|------|----------|----------|----------|
+| Contax | T2 / G2 | 蔡司镜头、温暖色调、柔和过渡 | 复古人像、日系写真 |
+| Mamiya | RZ67 / 7II | 中画幅胶片、奶油虚化、立体感强 | 肖像、时尚胶片感 |
+| Pentax 67 | 6x7 | 大底胶片、景深极浅、影调丰富 | 人像、风光、文艺 |
+| Rolleiflex | 2.8F | 双反结构、方画幅、古典韵味 | 古典肖像、街头人文 |
+
+---
+
+## 二、镜头品牌速查
+
+### 顶级光学品牌
+
+| 品牌 | 特征 | 代表镜头 | 适用搭配 |
+|------|------|----------|----------|
+| Zeiss | 极致锐度、色散控制、3D立体感 | Otus 55/1.4、Milvus 85/1.4 | 高端人像、产品 |
+| Leica | 德味渲染、焦外旋转、过渡细腻 | Summilux 50/1.4、Noctilux 75/1.25 | 人文、艺术、氛围 |
+| Canon L | 红圈标识、肤色优化、对焦快速 | RF 85/1.2L、RF 50/1.2L | 商业人像、婚礼 |
+| Nikon S | 纳米涂层、抗眩光、高解析 | Z 50/1.2S、Z 85/1.2S | 全场景、高锐度需求 |
+| Sony GM | 高MTF、极速对焦、轻量化 | FE 85/1.4GM II、FE 50/1.2GM | 人像、运动、街拍 |
+
+### 专业副厂/艺术镜头
+
+| 品牌 | 特征 | 代表镜头 | 适用搭配 |
+|------|------|----------|----------|
+| Sigma Art | 极高锐度、大光圈、性价比 | 35/1.4 Art、85/1.4 Art | 全场景锐利画质 |
+| Voigtlander | 手动对焦、复古焦外、紧凑 | Nokton 50/1.2、40/1.2 | 文艺、街拍、氛围 |
+| Helios | 旋转焦外（旋焦）、苏联镜头 | Helios 44-2 58/2 | 梦幻旋焦、复古人像 |
+| Petzval | 漩涡焦外、中心锐利边缘柔和 | Lomography Petzval 85/2.2 | 戏剧性肖像、奇幻 |
+| Cooke | 电影镜头、Cooke Look柔和渲染 | S7/i 75mm T2.0 | 电影质感、叙事场景 |
+| ARRI/Zeiss | Master Prime系列、电影级 | Master Prime 50/T1.3 | 电影布光、专业场景 |
+
+---
+
+## 三、焦距详解
+
+### 焦距与透视关系速查
+
+| 焦距范围 | 类型 | 透视效果 | 角色场景应用 |
+|----------|------|----------|--------------|
+| 14-20mm | 超广角 | 强烈透视畸变、空间极度夸张 | 建筑内景、环境全貌、压迫感场景 |
+| 24-28mm | 广角 | 适度透视、前景突出 | 环境人像、街拍全身、场景氛围 |
+| 35mm | 小广角 | 接近人眼、自然不变形 | 纪实、街拍、环境肖像 |
+| 50mm | 标准 | 最接近人眼视角、无畸变 | 通用人像、日常场景、产品 |
+| 85mm | 中长焦 | 轻微压缩、面部比例最佳 | 人像黄金焦段、半身特写 |
+| 105-135mm | 长焦 | 明显压缩、主体突出背景虚化 | 特写肖像、道具细节、情绪渲染 |
+| 200-400mm | 超长焦 | 极度压缩、前后景叠加 | 远景人物、空间压缩、梦幻氛围 |
+| 100mm Macro | 微距 | 1:1放大、极致细节 | 道具特写、珠宝、微观世界 |
+
+### 焦距选择指南
+
+| 设计目标 | 推荐焦距 | 原因 |
+|----------|----------|------|
+| 角色全身+环境交代 | 24-35mm | 能容纳环境信息，建立角色与空间关系 |
+| 角色半身/四分之三 | 50-85mm | 面部比例自然，景深适中突出主体 |
+| 角色面部特写 | 85-135mm | 面部压缩最佳，避免鼻子变形 |
+| 道具/饰品细节 | 90-105mm Macro | 放大细节，背景完全虚化 |
+| 宏大场景/建筑 | 14-24mm | 视角宽广，建立空间感 |
+| 多角色群像 | 35-50mm | 自然透视，多人同框不变形 |
+
+---
+
+## 四、光圈详解
+
+### 光圈与景深关系速查
+
+| 光圈值 | 景深效果 | 画面特征 | 适用场景 |
+|--------|----------|----------|----------|
+| f/1.0-f/1.2 | 极浅景深 | 仅眼睛锐利，其余全化为奶油焦外 | 极致氛围人像、梦幻特写 |
+| f/1.4-f/1.8 | 很浅景深 | 面部锐利，背景大面积虚化 | 标准人像、角色立绘、情绪渲染 |
+| f/2.0-f/2.8 | 浅景深 | 上半身锐利，背景柔和分离 | 半身人像、产品摄影、道具特写 |
+| f/4.0-f/5.6 | 适中景深 | 全身锐利，背景轻微虚化 | 全身人像、时尚、环境肖像 |
+| f/8.0-f/11 | 大景深 | 全画面清晰锐利 | 场景设计、建筑、群像、风光 |
+| f/16-f/22 | 极大景深 | 从前景到无穷远全部清晰 | 宏大场景、全景、产品目录 |
+
+### 焦外（Bokeh）风格
+
+| 类型 | 特征 | 来源 |
+|------|------|------|
+| 奶油焦外 | 过渡平滑无二线性，圆润光斑 | Canon RF 85/1.2L、Sony 85/1.4GM |
+| 旋转焦外 | 焦外呈漩涡状旋转 | Helios 44-2、Petzval 85 |
+| 硬焦外 | 光斑边缘锐利、有洋葱圈纹 | 反射镜头、部分老镜头 |
+| 柔化焦外 | 整体朦胧、梦幻 | 柔焦镜头、Leica Thambar |
+| 星芒 | 点光源呈放射状星芒 | 小光圈 f/11-f/16 |
+
+---
+
+## 五、提示词模板库
+
+### 角色设计——人像特写
+```
+Shot on Canon EOS R5 with RF 85mm f/1.2L USM at f/1.4, a young woman with silver hair gazes into the lens, soft window light illuminating her face, extremely shallow depth of field with creamy bokeh dissolving the background into warm golden tones, skin texture and iris details rendered with exceptional clarity.
+```
+
+### 角色设计——全身立绘
+```
+Captured with Sony A7R V and Sigma 35mm f/1.4 Art at f/2.8, a cyberpunk warrior stands in a rain-soaked neon alley, full body visible from head to boots, ambient neon reflections on wet surfaces, medium depth of field keeping the character sharp while the background glows with colorful bokeh.
+```
+
+### 角色设计——电影感肖像
+```
+Filmed on ARRI ALEXA 35 with Cooke S7/i 75mm T2.0, cinematic portrait of a detective in a dimly lit office, warm practical lighting from a desk lamp, the Cooke Look rendering skin with gentle halation and smooth tonal transitions, shallow depth of field isolating the subject from the noir background.
+```
+
+### 道具设计——细节特写
+```
+Shot on Hasselblad X2D 100C with Zeiss Otus 100mm Macro at f/4, extreme close-up of an ornate mechanical pocket watch, every gear tooth and engraving rendered in extraordinary detail, dark velvet background completely dissolved into pure black, studio rim lighting accentuating metallic textures.
+```
+
+### 场景设计——宏大环境
+```
+Captured with Nikon Z8 and Nikkor Z 14-24mm f/2.8S at 16mm f/8, a vast cyberpunk cityscape at twilight, towering megastructures receding into atmospheric haze, deep depth of field rendering every architectural detail from foreground market stalls to distant skyscrapers, dramatic perspective lines converging at the horizon.
+```
+
+### 场景设计——氛围内景
+```
+Shot on Fujifilm GFX 100S with GF 80mm f/1.7 at f/2.0, a quiet Japanese tea room in late afternoon, golden hour light streaming through shoji screens, medium format rendering delivering exceptional tonal gradation and three-dimensionality, gentle bokeh on background elements.
+```
+
+### 复古胶片——角色写真
+```
+Shot on Contax T2 with Zeiss Sonnar 38mm f/2.8, Kodak Portra 400 film, a woman in a summer dress walking through a sunlit garden, characteristic warm color palette with soft highlight rolloff, natural film grain adding organic texture, the timeless Contax rendering style.
+```
+
+### 产品/道具——商业级
+```
+Photographed with Phase One IQ4 150MP and Schneider 120mm LS f/4 Macro, a luxury perfume bottle on reflective black acrylic surface, 150 megapixel resolution capturing every crystal facet and light refraction, controlled studio lighting with precise specular highlights, absolute color accuracy.
+```
+
+---
+
+## 六、快速意图匹配指南
+
+| 设计意图 | 推荐器材组合 |
+|----------|--------------|
+| 梦幻人像/氛围感 | Canon R5 + RF 85/1.2L @ f/1.2 |
+| 锐利角色立绘 | Sony A7RV + 85GM II @ f/1.8 |
+| 电影叙事感 | ARRI ALEXA 35 + Cooke 75mm T2.0 |
+| 胶片复古风 | Contax T2 / Mamiya RZ67 + Portra 400 |
+| 道具微距细节 | Hasselblad X2D + Zeiss 100mm Macro |
+| 宏大场景 | Nikon Z8 + 14-24/2.8S @ f/8 |
+| 德味人文 | Leica M11 + Summilux 50/1.4 |
+| 日系清新 | Fujifilm X-T5 + 56/1.2 (Classic Chrome) |
+| 科幻/高科技 | RED V-RAPTOR + Sigma 35 Art |
+| 奇幻/戏剧性 | Petzval 85/2.2（旋涡焦外） |
+
+---
+
+## 七、与图像模型集成方式
+
+在生成提示词时融入器材参数：
+
+1. **GPT-image-2**：直接在提示词中以自然语言描述器材和参数
+   - 示例：`Photo taken with a Canon EOS R5, 85mm f/1.2 lens, shallow depth of field, creamy bokeh background`
+
+2. **nanobanana 2.0 / nanobanana pro**：将器材信息作为画面质感描述的一部分
+   - 示例：`shot on Hasselblad medium format, 80mm lens at f/2, cinematic lighting, ultra-detailed skin texture`
+
+3. **通用格式**：`[器材信息] + [主体描述] + [光线环境] + [景深/焦外描述]`
+
+### 注意事项
+
+- 器材参数为画质提示，模型不会真的模拟光学物理，但能引导风格方向
+- 可组合使用本技能与「电影镜头语言」技能，前者控制静态画质，后者控制动态运镜
+- 光圈值与焦距搭配需合理：超广角 f/1.2 镜头现实中极少存在
+
+---
+
+## 完整器材提示词参考
+
+上方速查表提供快速选型。每种器材组合的**详细参数说明**和**可直接使用的完整提示词模板**，请参阅：
+
+👉 [摄影器材完整参考手册](./references/full_photography_guide.md)
+
+使用方式：
+1. 从速查表中根据设计意图选定器材组合
+2. 打开完整参考手册查阅对应组合的详细提示词模板
+3. 根据具体角色/道具/场景需求微调后融入生成提示词

--- a/backend/skills/active_skills/Photography_Scene_Design/references/full_photography_guide.md
+++ b/backend/skills/active_skills/Photography_Scene_Design/references/full_photography_guide.md
@@ -1,0 +1,148 @@
+# 摄影器材完整参考手册
+
+按场景分类的完整提示词模板，每条包含：器材组合 + 参数设定 + 完整提示词。
+
+---
+
+## 一、角色人像类
+
+### 1. 梦幻大光圈人像
+**器材**：Canon EOS R5 + Canon RF 85mm f/1.2L USM
+**参数**：f/1.2 | ISO 100 | 自然光
+**提示词**：Shot on Canon EOS R5 with RF 85mm f/1.2L at f/1.2, dreamy close-up portrait of a young woman with flowing auburn hair, single eye in critical focus with eyelash detail visible, skin rendered with Canon's signature warm color science, background completely dissolved into large circular bokeh orbs of golden afternoon light, natural rim lighting on hair.
+
+### 2. 锐利商业人像
+**器材**：Sony A7R V + Sony FE 85mm f/1.4 GM II
+**参数**：f/1.8 | ISO 200 | 影棚闪光
+**提示词**：Captured with Sony A7R V and FE 85mm f/1.4 GM II at f/1.8, high-resolution studio portrait of a male model, tack-sharp from ear to ear, professional three-point lighting with soft key light and subtle fill, clean medium gray background with smooth GM bokeh transition, every pore and stubble rendered in 61MP detail.
+
+### 3. 电影风格肖像
+**器材**：ARRI ALEXA 35 + Cooke S7/i 50mm T2.0
+**参数**：T2.0 | 800 ASA | 实景光源
+**提示词**：Filmed on ARRI ALEXA 35 with Cooke S7/i 50mm T2.0, cinematic close-up of a weathered old man in a dimly lit bar, single warm practical light source creating dramatic chiaroscuro, the signature Cooke Look rendering skin with gentle halation around highlights, smooth color transitions in shadows, organic and painterly quality.
+
+### 4. 德味街拍人像
+**器材**：Leica M11 + Leica Summilux-M 50mm f/1.4 ASPH
+**参数**：f/1.4 | ISO 400 | 街头自然光
+**提示词**：Shot on Leica M11 with Summilux 50mm f/1.4, candid street portrait of a jazz musician, the distinctive Leica color rendering with rich mid-tones and smooth highlight rolloff, subject isolated from busy urban background by characteristic swirly Summilux bokeh, rangefinder shooting style with natural unposed expression.
+
+### 5. 中画幅质感肖像
+**器材**：Hasselblad X2D 100C + XCD 90mm f/2.5
+**参数**：f/2.5 | ISO 64 | 柔光箱
+**提示词**：Photographed with Hasselblad X2D 100C and XCD 90mm f/2.5, medium format portrait with extraordinary tonal depth, a woman's face rendered with the three-dimensionality only a large sensor delivers, subtle skin gradations from highlight to shadow, micro-contrast revealing texture without harshness, clean studio environment.
+
+### 6. 胶片人像（Portra色彩）
+**器材**：Mamiya RZ67 + Sekor Z 110mm f/2.8
+**参数**：f/2.8 | Kodak Portra 160
+**提示词**：Shot on Mamiya RZ67 with 110mm f/2.8 on Kodak Portra 160, medium format film portrait of a dancer in natural light studio, gorgeous creamy bokeh from the 6x7 negative, Portra's legendary skin tone rendering with peach highlights and cool shadows, visible but fine film grain adding organic texture, exceptional subject separation.
+
+### 7. 日系清新人像
+**器材**：Fujifilm X-T5 + XF 56mm f/1.2 R WR
+**参数**：f/1.6 | ISO 160 | Classic Chrome模拟
+**提示词**：Shot on Fujifilm X-T5 with XF 56mm f/1.2 in Classic Chrome film simulation, a young woman in white linen dress standing near a sunlit window, Fujifilm's characteristic desaturated warm tones with teal shadows, soft directional light creating gentle contrast, shallow depth of field with smooth background separation.
+
+### 8. 复古Contax人像
+**器材**：Contax T2 + Carl Zeiss Sonnar 38mm f/2.8
+**参数**：f/2.8 | Kodak Gold 200
+**提示词**：Shot on Contax T2 with Zeiss Sonnar 38mm f/2.8, loaded with Kodak Gold 200, casual portrait of a couple at a seaside café, the legendary T2 rendering with warm golden tones and gentle vignetting, point-and-shoot intimacy, natural ambient light, film grain and slight highlight bloom creating nostalgic summer atmosphere.
+
+---
+
+## 二、角色全身/立绘类
+
+### 9. 角色立绘——锐利现代
+**器材**：Sony A7 IV + Sigma 35mm f/1.4 DG DN Art
+**参数**：f/2.8 | ISO 200 | 混合光源
+**提示词**：Captured with Sony A7 IV and Sigma 35mm f/1.4 Art at f/2.8, full-body character design of a cyberpunk mercenary standing in a neon-lit alley, sharp from head to boots with controlled depth of field, the Sigma Art lens delivering razor-sharp detail across the frame, neon bokeh in background, wet pavement reflections.
+
+### 10. 角色立绘——时尚杂志
+**器材**：Canon EOS R5 + Canon RF 50mm f/1.2L
+**参数**：f/2.0 | ISO 100 | 影棚+彩色凝胶灯
+**提示词**：Shot on Canon EOS R5 with RF 50mm f/1.2L at f/2.0, high-fashion full-body shot of a model in avant-garde outfit, studio environment with colored gel lighting creating vibrant magenta and cyan accents, Canon's flattering color science rendering fabric textures and metallic accessories with precision, clean infinite backdrop.
+
+### 11. 角色立绘——奇幻战士
+**器材**：Nikon Z8 + Nikkor Z 50mm f/1.2 S
+**参数**：f/2.5 | ISO 400 | 实景+补光
+**提示词**：Shot on Nikon Z8 with Nikkor Z 50mm f/1.2S at f/2.5, full-body portrait of a fantasy knight in ornate plate armor standing on a misty battlefield, Nikon's accurate color reproduction capturing every scratch and patina on the metal, medium depth of field separating the warrior from the fog-shrouded background, dramatic side lighting.
+
+### 12. 群像/多角色
+**器材**：Sony A7R V + Sony FE 35mm f/1.4 GM
+**参数**：f/4.0 | ISO 200 | 自然光
+**提示词**：Captured with Sony A7R V and FE 35mm f/1.4 GM at f/4, group shot of four adventurers standing in formation before a ruined temple gate, sufficient depth of field keeping all characters sharp, 35mm focal length providing natural perspective without distortion, golden hour side light casting long dramatic shadows.
+
+---
+
+## 三、道具/产品类
+
+### 13. 机械道具特写
+**器材**：Hasselblad X2D 100C + Zeiss Otus 100mm f/1.4 (adapted)
+**参数**：f/4.0 | ISO 64 | 影棚微距灯
+**提示词**：Shot on Hasselblad X2D with Zeiss Otus 100mm at f/4, extreme close-up of a steampunk mechanical gauntlet, every rivet, gear, and leather strap rendered in 100MP medium format detail, dark moody studio lighting with precise rim light accentuating metallic edges, shallow enough depth of field to create layered dimensionality.
+
+### 14. 珠宝/精细道具
+**器材**：Phase One IQ4 150MP + Schneider 120mm LS f/4 Macro
+**参数**：f/8 | ISO 50 | 精密布光
+**提示词**：Photographed with Phase One IQ4 150MP and Schneider 120mm Macro at f/8, a dragon-head amulet encrusted with emeralds and rubies on black velvet, 150 megapixel resolution revealing every microscopic facet and inclusion in the gemstones, controlled specular highlights dancing across gold filigree, absolute color accuracy.
+
+### 15. 武器/大型道具
+**器材**：Nikon Z8 + Nikkor Z MC 105mm f/2.8 VR S
+**参数**：f/5.6 | ISO 100 | 侧光+反射板
+**提示词**：Shot on Nikon Z8 with Z MC 105mm Macro at f/5.6, a katana blade displayed on a wooden stand, macro detail revealing the hamon temper line and subtle steel grain, diffused side lighting creating soft gradients along the blade, background fading to deep charcoal, the micro-contrast and sharpness of Nikon's latest macro optics.
+
+### 16. 食物/药水道具
+**器材**：Canon EOS R5 + Canon RF 100mm f/2.8L Macro IS
+**参数**：f/3.5 | ISO 200 | 背光+补光
+**提示词**：Shot on Canon EOS R5 with RF 100mm f/2.8L Macro at f/3.5, a glowing magical potion in a crystal vial, backlit to reveal swirling luminescent liquid within, Canon's macro rendering capturing every bubble and light refraction, shallow depth of field isolating the vial from a blurred alchemist's workshop background.
+
+---
+
+## 四、场景环境类
+
+### 17. 赛博朋克城市
+**器材**：Nikon Z8 + Nikkor Z 14-24mm f/2.8 S
+**参数**：16mm f/8 | ISO 400 | 城市夜景
+**提示词**：Captured with Nikon Z8 and Nikkor Z 14-24mm f/2.8S at 16mm f/8, a sprawling cyberpunk megalopolis at night, deep depth of field rendering every holographic billboard and steam vent from foreground street level to distant mega-towers, ultra-wide perspective creating dramatic converging lines, Nikon's exceptional high-ISO performance maintaining clean shadows.
+
+### 18. 奇幻自然景观
+**器材**：Sony A7R V + Sony FE 16-35mm f/2.8 GM II
+**参数**：20mm f/11 | ISO 100 | 黄金时刻
+**提示词**：Shot on Sony A7R V with FE 16-35mm GM II at 20mm f/11, an enchanted forest valley with bioluminescent flora, deep depth of field from mushroom-covered foreground rocks to distant crystal waterfalls, ultra-wide field of view capturing the vast magical ecosystem, golden hour light filtering through the canopy above.
+
+### 19. 室内氛围场景
+**器材**：Fujifilm GFX 100S + GF 32-64mm f/4 R LM WR
+**参数**：45mm f/4 | ISO 800 | 实景光
+**提示词**：Shot on Fujifilm GFX 100S with GF 32-64mm at 45mm f/4, the interior of a Victorian-era library, warm gas lamp lighting, medium format rendering delivering exceptional shadow detail and tonal gradation in the dark wood paneling, deep enough depth of field to render both foreground leather armchairs and distant bookshelves with clarity.
+
+### 20. 荒野/废墟场景
+**器材**：Leica SL2 + Leica APO-Summicron-SL 28mm f/2
+**参数**：f/5.6 | ISO 200 | 阴天散射光
+**提示词**：Captured with Leica SL2 and APO-Summicron 28mm f/2 at f/5.6, a post-apocalyptic highway stretching into the distance, abandoned vehicles overgrown with vines, Leica's signature color rendering bringing melancholy beauty to decay, wide angle encompassing the desolate landscape, overcast diffused light creating even illumination across the scene.
+
+---
+
+## 五、特殊风格类
+
+### 21. 旋焦梦幻
+**器材**：Sony A7 III + Helios 44-2 58mm f/2 (adapted)
+**参数**：f/2 | ISO 200 | 逆光
+**提示词**：Shot on Sony A7 III with vintage Helios 44-2 58mm f/2, portrait of a ballerina in a sunlit meadow, the legendary swirly bokeh creating a vortex of blurred golden grasses surrounding the sharp central subject, strong backlight causing characteristic flare and halation, dreamlike and ethereal quality.
+
+### 22. 漩涡焦外肖像
+**器材**：Canon EOS R6 II + Lomography Petzval 85mm f/2.2
+**参数**：f/2.2 | ISO 400 | 舞台光
+**提示词**：Shot with Lomography Petzval 85mm f/2.2 on Canon EOS R6 II, theatrical portrait of a circus performer, sharp center with dramatic swirling bokeh vortex at the edges, stage spotlights becoming spinning light trails in the out-of-focus areas, vintage brass lens character adding warmth and artistic imperfection.
+
+### 23. 超长焦压缩
+**器材**：Sony A1 + Sony FE 200-600mm f/5.6-6.3 G
+**参数**：400mm f/6.3 | ISO 800
+**提示词**：Shot on Sony A1 with FE 200-600mm at 400mm f/6.3, a lone samurai silhouetted against an enormous setting sun, extreme telephoto compression making the sun appear massive behind the figure, atmospheric haze layering the foreground and background into distinct planes, color palette reduced to deep oranges and blacks.
+
+### 24. 移轴微缩效果
+**器材**：Canon EOS R5 + Canon TS-E 90mm f/2.8L Macro
+**参数**：f/2.8 tilted | ISO 100
+**提示词**：Shot on Canon EOS R5 with TS-E 90mm f/2.8L tilt-shift, overhead view of a medieval market square, the tilted focal plane creating an extremely narrow band of sharp focus across the center, everything above and below dissolved into creamy blur, making the real scene appear as a miniature diorama, warm afternoon light.
+
+### 25. 红外/特殊感光
+**器材**：Sony A7R (IR converted) + Voigtlander 21mm f/1.4
+**参数**：f/5.6 | 720nm IR filter
+**提示词**：Shot on infrared-converted Sony A7R with Voigtlander 21mm f/1.4 at f/5.6, a dark fantasy landscape where all foliage appears luminous white, dark ominous sky with defined clouds, a cloaked figure standing among the ghostly trees, the infrared rendering creating an otherworldly and haunting atmosphere impossible in visible light.

--- a/backend/skills/builtin_skills/Photography_Scene_Design/SKILL.md
+++ b/backend/skills/builtin_skills/Photography_Scene_Design/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: Photography_Scene_Design
+description: "专业摄影器材与参数指南，用于角色、道具、场景的AI图像生成。涵盖主流相机机身、镜头品牌、焦距与光圈的详细说明，适用于GPT-image-2、nanobanana2.0、nanobanana pro等文生图/图生图模型。"
+metadata:
+  builtin_skill_version: "1.0"
+---
+
+# 摄影场景设计（角色·道具·场景）
+
+**目的**：为AI图像生成注入真实摄影器材参数，通过指定相机机身、镜头品牌、焦距与光圈，精确控制画面质感、景深、透视与氛围，提升角色/道具/场景设计的专业度与真实感。
+
+## 使用场景
+
+- 生成角色立绘、人像写真、时尚摄影
+- 道具细节特写、产品摄影
+- 场景氛围图、概念设计、环境渲染
+- 需要特定摄影器材质感的图像（胶片感、中画幅质感、电影镜头风格等）
+
+## 核心原则
+
+1. **器材服务画面**：选择器材参数是为了实现特定视觉效果，不是堆砌品牌名
+2. **参数协调**：焦距、光圈、机身三者搭配需合理，避免不可能的组合
+3. **一句一器材**：提示词中明确一套器材参数即可，不混用多套
+4. **适配模型特性**：针对不同图像模型（GPT-image-2、nanobanana系列），器材描述融入自然语言
+
+---
+
+## 一、相机机身品牌速查
+
+### 全画幅/中画幅（高画质优先）
+
+| 品牌 | 代表机型 | 画面特征 | 适用场景 |
+|------|----------|----------|----------|
+| Canon | EOS R5 / R6 Mark II | 肤色讨喜、色彩饱和、暗部纯净 | 人像、时尚、商业摄影 |
+| Nikon | Z8 / Z9 | 色彩真实、锐度极高、高动态范围 | 风光、产品、纪实 |
+| Sony | A7R V / A7 IV | 高解析力、对焦精准、宽容度大 | 全场景通用、人像、街拍 |
+| Fujifilm | GFX 100S / X-T5 | 独特胶片色彩模拟、中画幅质感 | 人文、肖像、胶片风格 |
+| Leica | M11 / Q3 | 德味色彩、过渡细腻、氛围独特 | 街拍、人文、艺术摄影 |
+| Hasselblad | X2D 100C | 中画幅超高细节、色彩科学顶级 | 时尚、商业广告、精细产品 |
+| Phase One | IQ4 150MP | 1.5亿像素、极致细节、色彩精准 | 高端商业、艺术品复制 |
+
+### 电影/视频机身（电影质感）
+
+| 品牌 | 代表机型 | 画面特征 | 适用场景 |
+|------|----------|----------|----------|
+| ARRI | ALEXA 35 / Mini LF | 自然肤色、电影级宽容度、柔和高光 | 电影感角色、叙事场景 |
+| RED | V-RAPTOR / KOMODO | 高分辨率、锐利细节、科技感 | 科幻、动作、高细节场景 |
+| Blackmagic | URSA Mini Pro 12K | 高动态范围、Raw色彩空间 | 独立电影、概念场景 |
+
+### 胶片相机（复古质感）
+
+| 品牌 | 代表机型 | 画面特征 | 适用场景 |
+|------|----------|----------|----------|
+| Contax | T2 / G2 | 蔡司镜头、温暖色调、柔和过渡 | 复古人像、日系写真 |
+| Mamiya | RZ67 / 7II | 中画幅胶片、奶油虚化、立体感强 | 肖像、时尚胶片感 |
+| Pentax 67 | 6x7 | 大底胶片、景深极浅、影调丰富 | 人像、风光、文艺 |
+| Rolleiflex | 2.8F | 双反结构、方画幅、古典韵味 | 古典肖像、街头人文 |
+
+---
+
+## 二、镜头品牌速查
+
+### 顶级光学品牌
+
+| 品牌 | 特征 | 代表镜头 | 适用搭配 |
+|------|------|----------|----------|
+| Zeiss | 极致锐度、色散控制、3D立体感 | Otus 55/1.4、Milvus 85/1.4 | 高端人像、产品 |
+| Leica | 德味渲染、焦外旋转、过渡细腻 | Summilux 50/1.4、Noctilux 75/1.25 | 人文、艺术、氛围 |
+| Canon L | 红圈标识、肤色优化、对焦快速 | RF 85/1.2L、RF 50/1.2L | 商业人像、婚礼 |
+| Nikon S | 纳米涂层、抗眩光、高解析 | Z 50/1.2S、Z 85/1.2S | 全场景、高锐度需求 |
+| Sony GM | 高MTF、极速对焦、轻量化 | FE 85/1.4GM II、FE 50/1.2GM | 人像、运动、街拍 |
+
+### 专业副厂/艺术镜头
+
+| 品牌 | 特征 | 代表镜头 | 适用搭配 |
+|------|------|----------|----------|
+| Sigma Art | 极高锐度、大光圈、性价比 | 35/1.4 Art、85/1.4 Art | 全场景锐利画质 |
+| Voigtlander | 手动对焦、复古焦外、紧凑 | Nokton 50/1.2、40/1.2 | 文艺、街拍、氛围 |
+| Helios | 旋转焦外（旋焦）、苏联镜头 | Helios 44-2 58/2 | 梦幻旋焦、复古人像 |
+| Petzval | 漩涡焦外、中心锐利边缘柔和 | Lomography Petzval 85/2.2 | 戏剧性肖像、奇幻 |
+| Cooke | 电影镜头、Cooke Look柔和渲染 | S7/i 75mm T2.0 | 电影质感、叙事场景 |
+| ARRI/Zeiss | Master Prime系列、电影级 | Master Prime 50/T1.3 | 电影布光、专业场景 |
+
+---
+
+## 三、焦距详解
+
+### 焦距与透视关系速查
+
+| 焦距范围 | 类型 | 透视效果 | 角色场景应用 |
+|----------|------|----------|--------------|
+| 14-20mm | 超广角 | 强烈透视畸变、空间极度夸张 | 建筑内景、环境全貌、压迫感场景 |
+| 24-28mm | 广角 | 适度透视、前景突出 | 环境人像、街拍全身、场景氛围 |
+| 35mm | 小广角 | 接近人眼、自然不变形 | 纪实、街拍、环境肖像 |
+| 50mm | 标准 | 最接近人眼视角、无畸变 | 通用人像、日常场景、产品 |
+| 85mm | 中长焦 | 轻微压缩、面部比例最佳 | 人像黄金焦段、半身特写 |
+| 105-135mm | 长焦 | 明显压缩、主体突出背景虚化 | 特写肖像、道具细节、情绪渲染 |
+| 200-400mm | 超长焦 | 极度压缩、前后景叠加 | 远景人物、空间压缩、梦幻氛围 |
+| 100mm Macro | 微距 | 1:1放大、极致细节 | 道具特写、珠宝、微观世界 |
+
+### 焦距选择指南
+
+| 设计目标 | 推荐焦距 | 原因 |
+|----------|----------|------|
+| 角色全身+环境交代 | 24-35mm | 能容纳环境信息，建立角色与空间关系 |
+| 角色半身/四分之三 | 50-85mm | 面部比例自然，景深适中突出主体 |
+| 角色面部特写 | 85-135mm | 面部压缩最佳，避免鼻子变形 |
+| 道具/饰品细节 | 90-105mm Macro | 放大细节，背景完全虚化 |
+| 宏大场景/建筑 | 14-24mm | 视角宽广，建立空间感 |
+| 多角色群像 | 35-50mm | 自然透视，多人同框不变形 |
+
+---
+
+## 四、光圈详解
+
+### 光圈与景深关系速查
+
+| 光圈值 | 景深效果 | 画面特征 | 适用场景 |
+|--------|----------|----------|----------|
+| f/1.0-f/1.2 | 极浅景深 | 仅眼睛锐利，其余全化为奶油焦外 | 极致氛围人像、梦幻特写 |
+| f/1.4-f/1.8 | 很浅景深 | 面部锐利，背景大面积虚化 | 标准人像、角色立绘、情绪渲染 |
+| f/2.0-f/2.8 | 浅景深 | 上半身锐利，背景柔和分离 | 半身人像、产品摄影、道具特写 |
+| f/4.0-f/5.6 | 适中景深 | 全身锐利，背景轻微虚化 | 全身人像、时尚、环境肖像 |
+| f/8.0-f/11 | 大景深 | 全画面清晰锐利 | 场景设计、建筑、群像、风光 |
+| f/16-f/22 | 极大景深 | 从前景到无穷远全部清晰 | 宏大场景、全景、产品目录 |
+
+### 焦外（Bokeh）风格
+
+| 类型 | 特征 | 来源 |
+|------|------|------|
+| 奶油焦外 | 过渡平滑无二线性，圆润光斑 | Canon RF 85/1.2L、Sony 85/1.4GM |
+| 旋转焦外 | 焦外呈漩涡状旋转 | Helios 44-2、Petzval 85 |
+| 硬焦外 | 光斑边缘锐利、有洋葱圈纹 | 反射镜头、部分老镜头 |
+| 柔化焦外 | 整体朦胧、梦幻 | 柔焦镜头、Leica Thambar |
+| 星芒 | 点光源呈放射状星芒 | 小光圈 f/11-f/16 |
+
+---
+
+## 五、提示词模板库
+
+### 角色设计——人像特写
+```
+Shot on Canon EOS R5 with RF 85mm f/1.2L USM at f/1.4, a young woman with silver hair gazes into the lens, soft window light illuminating her face, extremely shallow depth of field with creamy bokeh dissolving the background into warm golden tones, skin texture and iris details rendered with exceptional clarity.
+```
+
+### 角色设计——全身立绘
+```
+Captured with Sony A7R V and Sigma 35mm f/1.4 Art at f/2.8, a cyberpunk warrior stands in a rain-soaked neon alley, full body visible from head to boots, ambient neon reflections on wet surfaces, medium depth of field keeping the character sharp while the background glows with colorful bokeh.
+```
+
+### 角色设计——电影感肖像
+```
+Filmed on ARRI ALEXA 35 with Cooke S7/i 75mm T2.0, cinematic portrait of a detective in a dimly lit office, warm practical lighting from a desk lamp, the Cooke Look rendering skin with gentle halation and smooth tonal transitions, shallow depth of field isolating the subject from the noir background.
+```
+
+### 道具设计——细节特写
+```
+Shot on Hasselblad X2D 100C with Zeiss Otus 100mm Macro at f/4, extreme close-up of an ornate mechanical pocket watch, every gear tooth and engraving rendered in extraordinary detail, dark velvet background completely dissolved into pure black, studio rim lighting accentuating metallic textures.
+```
+
+### 场景设计——宏大环境
+```
+Captured with Nikon Z8 and Nikkor Z 14-24mm f/2.8S at 16mm f/8, a vast cyberpunk cityscape at twilight, towering megastructures receding into atmospheric haze, deep depth of field rendering every architectural detail from foreground market stalls to distant skyscrapers, dramatic perspective lines converging at the horizon.
+```
+
+### 场景设计——氛围内景
+```
+Shot on Fujifilm GFX 100S with GF 80mm f/1.7 at f/2.0, a quiet Japanese tea room in late afternoon, golden hour light streaming through shoji screens, medium format rendering delivering exceptional tonal gradation and three-dimensionality, gentle bokeh on background elements.
+```
+
+### 复古胶片——角色写真
+```
+Shot on Contax T2 with Zeiss Sonnar 38mm f/2.8, Kodak Portra 400 film, a woman in a summer dress walking through a sunlit garden, characteristic warm color palette with soft highlight rolloff, natural film grain adding organic texture, the timeless Contax rendering style.
+```
+
+### 产品/道具——商业级
+```
+Photographed with Phase One IQ4 150MP and Schneider 120mm LS f/4 Macro, a luxury perfume bottle on reflective black acrylic surface, 150 megapixel resolution capturing every crystal facet and light refraction, controlled studio lighting with precise specular highlights, absolute color accuracy.
+```
+
+---
+
+## 六、快速意图匹配指南
+
+| 设计意图 | 推荐器材组合 |
+|----------|--------------|
+| 梦幻人像/氛围感 | Canon R5 + RF 85/1.2L @ f/1.2 |
+| 锐利角色立绘 | Sony A7RV + 85GM II @ f/1.8 |
+| 电影叙事感 | ARRI ALEXA 35 + Cooke 75mm T2.0 |
+| 胶片复古风 | Contax T2 / Mamiya RZ67 + Portra 400 |
+| 道具微距细节 | Hasselblad X2D + Zeiss 100mm Macro |
+| 宏大场景 | Nikon Z8 + 14-24/2.8S @ f/8 |
+| 德味人文 | Leica M11 + Summilux 50/1.4 |
+| 日系清新 | Fujifilm X-T5 + 56/1.2 (Classic Chrome) |
+| 科幻/高科技 | RED V-RAPTOR + Sigma 35 Art |
+| 奇幻/戏剧性 | Petzval 85/2.2（旋涡焦外） |
+
+---
+
+## 七、与图像模型集成方式
+
+在生成提示词时融入器材参数：
+
+1. **GPT-image-2**：直接在提示词中以自然语言描述器材和参数
+   - 示例：`Photo taken with a Canon EOS R5, 85mm f/1.2 lens, shallow depth of field, creamy bokeh background`
+
+2. **nanobanana 2.0 / nanobanana pro**：将器材信息作为画面质感描述的一部分
+   - 示例：`shot on Hasselblad medium format, 80mm lens at f/2, cinematic lighting, ultra-detailed skin texture`
+
+3. **通用格式**：`[器材信息] + [主体描述] + [光线环境] + [景深/焦外描述]`
+
+### 注意事项
+
+- 器材参数为画质提示，模型不会真的模拟光学物理，但能引导风格方向
+- 可组合使用本技能与「电影镜头语言」技能，前者控制静态画质，后者控制动态运镜
+- 光圈值与焦距搭配需合理：超广角 f/1.2 镜头现实中极少存在
+
+---
+
+## 完整器材提示词参考
+
+上方速查表提供快速选型。每种器材组合的**详细参数说明**和**可直接使用的完整提示词模板**，请参阅：
+
+👉 [摄影器材完整参考手册](./references/full_photography_guide.md)
+
+使用方式：
+1. 从速查表中根据设计意图选定器材组合
+2. 打开完整参考手册查阅对应组合的详细提示词模板
+3. 根据具体角色/道具/场景需求微调后融入生成提示词

--- a/backend/skills/builtin_skills/Photography_Scene_Design/references/full_photography_guide.md
+++ b/backend/skills/builtin_skills/Photography_Scene_Design/references/full_photography_guide.md
@@ -1,0 +1,148 @@
+# 摄影器材完整参考手册
+
+按场景分类的完整提示词模板，每条包含：器材组合 + 参数设定 + 完整提示词。
+
+---
+
+## 一、角色人像类
+
+### 1. 梦幻大光圈人像
+**器材**：Canon EOS R5 + Canon RF 85mm f/1.2L USM
+**参数**：f/1.2 | ISO 100 | 自然光
+**提示词**：Shot on Canon EOS R5 with RF 85mm f/1.2L at f/1.2, dreamy close-up portrait of a young woman with flowing auburn hair, single eye in critical focus with eyelash detail visible, skin rendered with Canon's signature warm color science, background completely dissolved into large circular bokeh orbs of golden afternoon light, natural rim lighting on hair.
+
+### 2. 锐利商业人像
+**器材**：Sony A7R V + Sony FE 85mm f/1.4 GM II
+**参数**：f/1.8 | ISO 200 | 影棚闪光
+**提示词**：Captured with Sony A7R V and FE 85mm f/1.4 GM II at f/1.8, high-resolution studio portrait of a male model, tack-sharp from ear to ear, professional three-point lighting with soft key light and subtle fill, clean medium gray background with smooth GM bokeh transition, every pore and stubble rendered in 61MP detail.
+
+### 3. 电影风格肖像
+**器材**：ARRI ALEXA 35 + Cooke S7/i 50mm T2.0
+**参数**：T2.0 | 800 ASA | 实景光源
+**提示词**：Filmed on ARRI ALEXA 35 with Cooke S7/i 50mm T2.0, cinematic close-up of a weathered old man in a dimly lit bar, single warm practical light source creating dramatic chiaroscuro, the signature Cooke Look rendering skin with gentle halation around highlights, smooth color transitions in shadows, organic and painterly quality.
+
+### 4. 德味街拍人像
+**器材**：Leica M11 + Leica Summilux-M 50mm f/1.4 ASPH
+**参数**：f/1.4 | ISO 400 | 街头自然光
+**提示词**：Shot on Leica M11 with Summilux 50mm f/1.4, candid street portrait of a jazz musician, the distinctive Leica color rendering with rich mid-tones and smooth highlight rolloff, subject isolated from busy urban background by characteristic swirly Summilux bokeh, rangefinder shooting style with natural unposed expression.
+
+### 5. 中画幅质感肖像
+**器材**：Hasselblad X2D 100C + XCD 90mm f/2.5
+**参数**：f/2.5 | ISO 64 | 柔光箱
+**提示词**：Photographed with Hasselblad X2D 100C and XCD 90mm f/2.5, medium format portrait with extraordinary tonal depth, a woman's face rendered with the three-dimensionality only a large sensor delivers, subtle skin gradations from highlight to shadow, micro-contrast revealing texture without harshness, clean studio environment.
+
+### 6. 胶片人像（Portra色彩）
+**器材**：Mamiya RZ67 + Sekor Z 110mm f/2.8
+**参数**：f/2.8 | Kodak Portra 160
+**提示词**：Shot on Mamiya RZ67 with 110mm f/2.8 on Kodak Portra 160, medium format film portrait of a dancer in natural light studio, gorgeous creamy bokeh from the 6x7 negative, Portra's legendary skin tone rendering with peach highlights and cool shadows, visible but fine film grain adding organic texture, exceptional subject separation.
+
+### 7. 日系清新人像
+**器材**：Fujifilm X-T5 + XF 56mm f/1.2 R WR
+**参数**：f/1.6 | ISO 160 | Classic Chrome模拟
+**提示词**：Shot on Fujifilm X-T5 with XF 56mm f/1.2 in Classic Chrome film simulation, a young woman in white linen dress standing near a sunlit window, Fujifilm's characteristic desaturated warm tones with teal shadows, soft directional light creating gentle contrast, shallow depth of field with smooth background separation.
+
+### 8. 复古Contax人像
+**器材**：Contax T2 + Carl Zeiss Sonnar 38mm f/2.8
+**参数**：f/2.8 | Kodak Gold 200
+**提示词**：Shot on Contax T2 with Zeiss Sonnar 38mm f/2.8, loaded with Kodak Gold 200, casual portrait of a couple at a seaside café, the legendary T2 rendering with warm golden tones and gentle vignetting, point-and-shoot intimacy, natural ambient light, film grain and slight highlight bloom creating nostalgic summer atmosphere.
+
+---
+
+## 二、角色全身/立绘类
+
+### 9. 角色立绘——锐利现代
+**器材**：Sony A7 IV + Sigma 35mm f/1.4 DG DN Art
+**参数**：f/2.8 | ISO 200 | 混合光源
+**提示词**：Captured with Sony A7 IV and Sigma 35mm f/1.4 Art at f/2.8, full-body character design of a cyberpunk mercenary standing in a neon-lit alley, sharp from head to boots with controlled depth of field, the Sigma Art lens delivering razor-sharp detail across the frame, neon bokeh in background, wet pavement reflections.
+
+### 10. 角色立绘——时尚杂志
+**器材**：Canon EOS R5 + Canon RF 50mm f/1.2L
+**参数**：f/2.0 | ISO 100 | 影棚+彩色凝胶灯
+**提示词**：Shot on Canon EOS R5 with RF 50mm f/1.2L at f/2.0, high-fashion full-body shot of a model in avant-garde outfit, studio environment with colored gel lighting creating vibrant magenta and cyan accents, Canon's flattering color science rendering fabric textures and metallic accessories with precision, clean infinite backdrop.
+
+### 11. 角色立绘——奇幻战士
+**器材**：Nikon Z8 + Nikkor Z 50mm f/1.2 S
+**参数**：f/2.5 | ISO 400 | 实景+补光
+**提示词**：Shot on Nikon Z8 with Nikkor Z 50mm f/1.2S at f/2.5, full-body portrait of a fantasy knight in ornate plate armor standing on a misty battlefield, Nikon's accurate color reproduction capturing every scratch and patina on the metal, medium depth of field separating the warrior from the fog-shrouded background, dramatic side lighting.
+
+### 12. 群像/多角色
+**器材**：Sony A7R V + Sony FE 35mm f/1.4 GM
+**参数**：f/4.0 | ISO 200 | 自然光
+**提示词**：Captured with Sony A7R V and FE 35mm f/1.4 GM at f/4, group shot of four adventurers standing in formation before a ruined temple gate, sufficient depth of field keeping all characters sharp, 35mm focal length providing natural perspective without distortion, golden hour side light casting long dramatic shadows.
+
+---
+
+## 三、道具/产品类
+
+### 13. 机械道具特写
+**器材**：Hasselblad X2D 100C + Zeiss Otus 100mm f/1.4 (adapted)
+**参数**：f/4.0 | ISO 64 | 影棚微距灯
+**提示词**：Shot on Hasselblad X2D with Zeiss Otus 100mm at f/4, extreme close-up of a steampunk mechanical gauntlet, every rivet, gear, and leather strap rendered in 100MP medium format detail, dark moody studio lighting with precise rim light accentuating metallic edges, shallow enough depth of field to create layered dimensionality.
+
+### 14. 珠宝/精细道具
+**器材**：Phase One IQ4 150MP + Schneider 120mm LS f/4 Macro
+**参数**：f/8 | ISO 50 | 精密布光
+**提示词**：Photographed with Phase One IQ4 150MP and Schneider 120mm Macro at f/8, a dragon-head amulet encrusted with emeralds and rubies on black velvet, 150 megapixel resolution revealing every microscopic facet and inclusion in the gemstones, controlled specular highlights dancing across gold filigree, absolute color accuracy.
+
+### 15. 武器/大型道具
+**器材**：Nikon Z8 + Nikkor Z MC 105mm f/2.8 VR S
+**参数**：f/5.6 | ISO 100 | 侧光+反射板
+**提示词**：Shot on Nikon Z8 with Z MC 105mm Macro at f/5.6, a katana blade displayed on a wooden stand, macro detail revealing the hamon temper line and subtle steel grain, diffused side lighting creating soft gradients along the blade, background fading to deep charcoal, the micro-contrast and sharpness of Nikon's latest macro optics.
+
+### 16. 食物/药水道具
+**器材**：Canon EOS R5 + Canon RF 100mm f/2.8L Macro IS
+**参数**：f/3.5 | ISO 200 | 背光+补光
+**提示词**：Shot on Canon EOS R5 with RF 100mm f/2.8L Macro at f/3.5, a glowing magical potion in a crystal vial, backlit to reveal swirling luminescent liquid within, Canon's macro rendering capturing every bubble and light refraction, shallow depth of field isolating the vial from a blurred alchemist's workshop background.
+
+---
+
+## 四、场景环境类
+
+### 17. 赛博朋克城市
+**器材**：Nikon Z8 + Nikkor Z 14-24mm f/2.8 S
+**参数**：16mm f/8 | ISO 400 | 城市夜景
+**提示词**：Captured with Nikon Z8 and Nikkor Z 14-24mm f/2.8S at 16mm f/8, a sprawling cyberpunk megalopolis at night, deep depth of field rendering every holographic billboard and steam vent from foreground street level to distant mega-towers, ultra-wide perspective creating dramatic converging lines, Nikon's exceptional high-ISO performance maintaining clean shadows.
+
+### 18. 奇幻自然景观
+**器材**：Sony A7R V + Sony FE 16-35mm f/2.8 GM II
+**参数**：20mm f/11 | ISO 100 | 黄金时刻
+**提示词**：Shot on Sony A7R V with FE 16-35mm GM II at 20mm f/11, an enchanted forest valley with bioluminescent flora, deep depth of field from mushroom-covered foreground rocks to distant crystal waterfalls, ultra-wide field of view capturing the vast magical ecosystem, golden hour light filtering through the canopy above.
+
+### 19. 室内氛围场景
+**器材**：Fujifilm GFX 100S + GF 32-64mm f/4 R LM WR
+**参数**：45mm f/4 | ISO 800 | 实景光
+**提示词**：Shot on Fujifilm GFX 100S with GF 32-64mm at 45mm f/4, the interior of a Victorian-era library, warm gas lamp lighting, medium format rendering delivering exceptional shadow detail and tonal gradation in the dark wood paneling, deep enough depth of field to render both foreground leather armchairs and distant bookshelves with clarity.
+
+### 20. 荒野/废墟场景
+**器材**：Leica SL2 + Leica APO-Summicron-SL 28mm f/2
+**参数**：f/5.6 | ISO 200 | 阴天散射光
+**提示词**：Captured with Leica SL2 and APO-Summicron 28mm f/2 at f/5.6, a post-apocalyptic highway stretching into the distance, abandoned vehicles overgrown with vines, Leica's signature color rendering bringing melancholy beauty to decay, wide angle encompassing the desolate landscape, overcast diffused light creating even illumination across the scene.
+
+---
+
+## 五、特殊风格类
+
+### 21. 旋焦梦幻
+**器材**：Sony A7 III + Helios 44-2 58mm f/2 (adapted)
+**参数**：f/2 | ISO 200 | 逆光
+**提示词**：Shot on Sony A7 III with vintage Helios 44-2 58mm f/2, portrait of a ballerina in a sunlit meadow, the legendary swirly bokeh creating a vortex of blurred golden grasses surrounding the sharp central subject, strong backlight causing characteristic flare and halation, dreamlike and ethereal quality.
+
+### 22. 漩涡焦外肖像
+**器材**：Canon EOS R6 II + Lomography Petzval 85mm f/2.2
+**参数**：f/2.2 | ISO 400 | 舞台光
+**提示词**：Shot with Lomography Petzval 85mm f/2.2 on Canon EOS R6 II, theatrical portrait of a circus performer, sharp center with dramatic swirling bokeh vortex at the edges, stage spotlights becoming spinning light trails in the out-of-focus areas, vintage brass lens character adding warmth and artistic imperfection.
+
+### 23. 超长焦压缩
+**器材**：Sony A1 + Sony FE 200-600mm f/5.6-6.3 G
+**参数**：400mm f/6.3 | ISO 800
+**提示词**：Shot on Sony A1 with FE 200-600mm at 400mm f/6.3, a lone samurai silhouetted against an enormous setting sun, extreme telephoto compression making the sun appear massive behind the figure, atmospheric haze layering the foreground and background into distinct planes, color palette reduced to deep oranges and blacks.
+
+### 24. 移轴微缩效果
+**器材**：Canon EOS R5 + Canon TS-E 90mm f/2.8L Macro
+**参数**：f/2.8 tilted | ISO 100
+**提示词**：Shot on Canon EOS R5 with TS-E 90mm f/2.8L tilt-shift, overhead view of a medieval market square, the tilted focal plane creating an extremely narrow band of sharp focus across the center, everything above and below dissolved into creamy blur, making the real scene appear as a miniature diorama, warm afternoon light.
+
+### 25. 红外/特殊感光
+**器材**：Sony A7R (IR converted) + Voigtlander 21mm f/1.4
+**参数**：f/5.6 | 720nm IR filter
+**提示词**：Shot on infrared-converted Sony A7R with Voigtlander 21mm f/1.4 at f/5.6, a dark fantasy landscape where all foliage appears luminous white, dark ominous sky with defined clouds, a cloaked figure standing among the ghostly trees, the infrared rendering creating an otherworldly and haunting atmosphere impossible in visible light.


### PR DESCRIPTION
- 实现Windows、macOS和Linux环境下的系统代理检测函数
- 检测到系统代理时自动设置HTTP_PROXY/HTTPS_PROXY环境变量
- 始终将localhost和环回地址加入NO_PROXY列表，确保本地服务绕过代理
- 优先使用环境变量代理配置，其次自动检测系统代理
- 启动时打印代理状态日志，方便调试和监控代理设置
- 彻底重构代理旁路逻辑，支持多平台和多代理类型
- 添加全面摄影场景设计技能文档，提供专业摄影器材参数指南
- 新增详细摄影器材参考手册，涵盖相机品牌、镜头、焦距及光圈参数
- 提供丰富提示词模板，支持多种图像生成模型的场景需求
- 全面支持角色、道具、场景设计中的摄影参数注入和风格控制