### PR TITLE
feat(multimodal): 多模态模型支持视频音频多模态输入及前端播放预览

### DIFF
--- a/backend/services/chat_generation.py
+++ b/backend/services/chat_generation.py
@@ -14,7 +14,7 @@ from models import Agent, ChatSession, ChatMessage, LLMProvider, User, Admin, To
 from services.chat_utils import (
     sse, deserialize_content, extract_media_filename,
     get_last_image_path, image_file_to_data_url, inject_image_to_message,
-    inject_attachment_images,
+    inject_attachment_media,
 )
 from services.chat_tool_dispatch import append_tool_round, append_tool_round_with_errors
 from services.agent_executor import _extract_tool_results
@@ -136,7 +136,7 @@ async def generate_single_agent(
     # 路径 1：从消息文本的 __ATTACHMENTS__ 解析所有图片附件
     last_msg = messages[-1] if messages else None
     if last_msg and last_msg.get("role") == "user":
-        _injected_images = await inject_attachment_images(last_msg)
+        _injected_images = await inject_attachment_media(last_msg)
 
     # 路径 2/3：__ATTACHMENTS__ 未注入任何图片时，回退到单图注入
     _edit_image_data_url = None

--- a/backend/services/chat_utils.py
+++ b/backend/services/chat_utils.py
@@ -1,5 +1,5 @@
 """
-Chat shared utilities: SSE formatting, content serialization, image helpers.
+Chat shared utilities: SSE formatting, content serialization, multimodal media helpers.
 
 Shared by routers/chats.py, routers/admin_debug.py, and chat generation modules.
 """
@@ -38,12 +38,45 @@ ATTACHMENTS_PATTERN = re.compile(r"<!-- __ATTACHMENTS__(\[.*?\]) -->", re.DOTALL
 
 # 单次消息最多注入的图片附件数量（避免 base64 撑爆上下文窗口）
 MAX_ATTACHMENT_IMAGES = 5
+# 单次消息最多注入的视频/音频附件数量（体积更大，限制更严）
+MAX_ATTACHMENT_MEDIA = 2
+# 单个媒体文件 inline_data 大小上限（20MB，Gemini inline_data 限制）
+MAX_MEDIA_SIZE_BYTES = 20 * 1024 * 1024
+
+
+# 需要剥离的多模态 content part 类型集合
+_MULTIMODAL_PART_TYPES = frozenset({"image_url", "inline_data", "input_audio"})
+
+
+def strip_multimodal_parts(messages: list[dict]) -> list[dict]:
+    """Strip all multimodal content parts (image/video/audio) from messages.
+
+    Converts multimodal messages back to text-only format for models that
+    do not support vision/audio/video input.
+    """
+    stripped = []
+    for msg in messages:
+        content = msg.get("content")
+        # 纯文本或非 list 内容：保持原样
+        if not isinstance(content, list):
+            stripped.append(msg)
+            continue
+        # 多模态 list：过滤掉所有媒体 parts，只保留 text
+        text_parts = [p for p in content if isinstance(p, dict) and p.get("type") not in _MULTIMODAL_PART_TYPES]
+        # 合并所有 text 为单一字符串（剥离多模态格式）
+        merged_text = "\n".join(p.get("text", "") for p in text_parts if p.get("type") == "text").strip()
+        stripped.append({**msg, "content": merged_text or "(media attachment - model does not support multimodal input)"})
+    return stripped
+
+
+# 向后兼容别名
+strip_image_parts = strip_multimodal_parts
 
 
 _URL_EXTRACTORS = [
     (lambda u: "/api/media/" in u, lambda u: u.split("/api/media/")[-1].split("?")[0]),
     (lambda u: "/media/" in u,     lambda u: u.split("/media/")[-1].split("?")[0]),
-    (lambda u: u.endswith((".png", ".jpg", ".jpeg", ".webp", ".gif")), lambda u: u.split("/")[-1]),
+    (lambda u: u.endswith((".png", ".jpg", ".jpeg", ".webp", ".gif", ".mp4", ".mp3", ".wav", ".webm", ".ogg", ".aac")), lambda u: u.split("/")[-1]),
 ]
 
 
@@ -104,8 +137,36 @@ def inject_image_to_message(msg: dict, data_url: str):
     msg["content"] = builder(user_content)
 
 
-async def inject_attachment_images(msg: dict) -> list[str]:
-    """Parse __ATTACHMENTS__ metadata from message text, inject ALL image attachments as multimodal parts.
+def _media_file_to_inline_data_sync(path: str) -> dict | None:
+    """Read a local media file and build inline_data part (synchronous, for thread offload).
+
+    Returns {"type": "inline_data", "inline_data": {"mime_type": ..., "data": base64_str}}
+    or None if file missing/too large.
+    """
+    file_path = Path(path)
+    if not file_path.exists():
+        return None
+    # 大小检查
+    file_size = file_path.stat().st_size
+    if file_size > MAX_MEDIA_SIZE_BYTES:
+        return None
+    mime, _ = mimetypes.guess_type(str(file_path))
+    mime = mime or "application/octet-stream"
+    data = file_path.read_bytes()
+    b64 = base64.b64encode(data).decode("ascii")
+    return {"type": "inline_data", "inline_data": {"mime_type": mime, "data": b64}}
+
+
+async def media_file_to_inline_data(path: str) -> dict | None:
+    """Read a local media file and build inline_data part for multimodal input (async)."""
+    return await asyncio.to_thread(_media_file_to_inline_data_sync, path)
+
+
+async def inject_attachment_media(msg: dict) -> list[str]:
+    """Parse __ATTACHMENTS__ metadata from message text, inject image/video/audio attachments.
+
+    - image nodes → image_url (data URL) format (unchanged)
+    - video/audio nodes → inline_data format (new)
 
     Returns list of injected filenames for logging.
     """
@@ -123,38 +184,59 @@ async def inject_attachment_images(msg: dict) -> list[str]:
     except (json.JSONDecodeError, TypeError):
         return []
 
-    # Collect image attachment URLs (only image nodeType), capped at MAX_ATTACHMENT_IMAGES
+    # ── 图片附件注入（保持原有 image_url 格式） ──
     image_urls = [
         (a.get("thumbnailUrl", ""), a.get("label", ""))
         for a in attachments
         if isinstance(a, dict) and a.get("nodeType") == "image" and a.get("thumbnailUrl")
     ][:MAX_ATTACHMENT_IMAGES]
-    if not image_urls:
-        return []
 
-    # Convert each to data URL and build multimodal parts (parallel I/O)
-    filenames = [extract_media_filename(url) for url, _ in image_urls]
-    valid_fns = [fn for fn in filenames if fn]
-    resolved_pairs = [(fn, resolve_media_filepath(fn)) for fn in valid_fns]
-    convert_tasks = [(fn, p) for fn, p in resolved_pairs if p]
-    data_urls = await asyncio.gather(*[
-        image_file_to_data_url(str(p)) for _, p in convert_tasks
-    ])
+    image_filenames = [extract_media_filename(url) for url, _ in image_urls]
+    image_resolved = [(fn, resolve_media_filepath(fn)) for fn in image_filenames if fn]
+    image_tasks = [(fn, p) for fn, p in image_resolved if p]
+    image_data_urls = await asyncio.gather(*[
+        image_file_to_data_url(str(p)) for _, p in image_tasks
+    ]) if image_tasks else []
 
-    image_parts = []
-    injected = []
-    for (fn, _), data_url in zip(convert_tasks, data_urls):
+    media_parts: list[dict] = []
+    injected: list[str] = []
+
+    for (fn, _), data_url in zip(image_tasks, image_data_urls):
         if not data_url:
             continue
-        image_parts.append({"type": "image_url", "image_url": {"url": data_url}})
-        image_parts.append({"type": "text", "text": f"[Image source path: /api/media/{fn} \u2014 use this path when passing to tools, do NOT pass base64 data]"})
+        media_parts.append({"type": "image_url", "image_url": {"url": data_url}})
+        media_parts.append({"type": "text", "text": f"[Image source path: /api/media/{fn} \u2014 use this path when passing to tools, do NOT pass base64 data]"})
         injected.append(fn)
 
-    if not image_parts:
+    # ── 视频/音频附件注入（新增 inline_data 格式） ──
+    av_attachments = [
+        (a.get("thumbnailUrl", ""), a.get("label", ""), a.get("nodeType", ""))
+        for a in attachments
+        if isinstance(a, dict) and a.get("nodeType") in ("video", "audio") and a.get("thumbnailUrl")
+    ][:MAX_ATTACHMENT_MEDIA]
+
+    av_filenames = [extract_media_filename(url) for url, _, _ in av_attachments]
+    av_resolved = [(fn, resolve_media_filepath(fn), ntype) for fn, (_, _, ntype) in zip(av_filenames, av_attachments) if fn and resolve_media_filepath(fn)]
+    av_inline_results = await asyncio.gather(*[
+        media_file_to_inline_data(str(p)) for _, p, _ in av_resolved
+    ]) if av_resolved else []
+
+    for (fn, _, ntype), inline_part in zip(av_resolved, av_inline_results):
+        if not inline_part:
+            continue
+        media_parts.append(inline_part)
+        media_parts.append({"type": "text", "text": f"[{ntype.capitalize()} source path: /api/media/{fn} \u2014 use this path when passing to tools]"})
+        injected.append(fn)
+
+    if not media_parts:
         return []
 
-    # Prepend image parts to message content
+    # Prepend media parts to message content
     existing = msg.get("content")
     text_parts = [{"type": "text", "text": existing}] if isinstance(existing, str) else (list(existing) if isinstance(existing, list) else [])
-    msg["content"] = image_parts + text_parts
+    msg["content"] = media_parts + text_parts
     return injected
+
+
+# 向后兼容别名
+inject_attachment_images = inject_attachment_media

--- a/backend/services/llm_stream.py
+++ b/backend/services/llm_stream.py
@@ -1239,7 +1239,9 @@ def _has_multimodal_content(messages: List[Dict[str, Any]]) -> bool:
 
 
 # 向后兼容别名
-_has_image_content = _has_multimodal_content
+def _has_image_content(messages: List[Dict[str, Any]]) -> bool:
+    """向后兼容：旧名称映射到多模态检测实现。"""
+    return _has_multimodal_content(messages)
 
 
 async def stream_completion(

--- a/backend/services/llm_stream.py
+++ b/backend/services/llm_stream.py
@@ -123,6 +123,42 @@ def get_effective_base_url(ctx: StreamContext) -> str | None:
 # ============================================================
 # OpenAI 兼容供应商 (openai, azure, deepseek)
 # ============================================================
+
+
+def _convert_inline_data_for_openai(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """将 inline_data parts 转换为 OpenAI 兼容格式。
+
+    - audio/* → {"type": "input_audio", "input_audio": {"data": b64, "format": ext}}
+    - video/* → {"type": "image_url", "image_url": {"url": "data:{mime};base64,{data}"}}
+    """
+    converted = []
+    for msg in messages:
+        content = msg.get("content")
+        if not isinstance(content, list):
+            converted.append(msg)
+            continue
+        new_parts = []
+        for part in content:
+            if not isinstance(part, dict) or part.get("type") != "inline_data":
+                new_parts.append(part)
+                continue
+            inline = part.get("inline_data", {})
+            mime = inline.get("mime_type", "")
+            data = inline.get("data", "")
+            # 音频 → input_audio 格式
+            if mime.startswith("audio/"):
+                fmt = mime.split("/")[-1].split(";")[0]  # audio/mp3 → mp3
+                new_parts.append({"type": "input_audio", "input_audio": {"data": data, "format": fmt}})
+            # 视频 → data URL (OpenAI 通过 image_url 格式接收 data URL)
+            elif mime.startswith("video/"):
+                new_parts.append({"type": "image_url", "image_url": {"url": f"data:{mime};base64,{data}"}})
+            else:
+                # 未知类型：跳过（避免发送无法识别的格式）
+                new_parts.append({"type": "text", "text": f"[Unsupported media: {mime}]"})
+        converted.append({**msg, "content": new_parts})
+    return converted
+
+
 @register_provider("openai", "deepseek", "openrouter")
 async def stream_openai(ctx: StreamContext, result: StreamResult) -> AsyncGenerator[str, None]:
     """OpenAI/DeepSeek/OpenRouter 流式调用（支持 tool calling）"""
@@ -130,9 +166,12 @@ async def stream_openai(ctx: StreamContext, result: StreamResult) -> AsyncGenera
 
     client = _get_openai_client(ctx.api_key, get_effective_base_url(ctx))
     
+    # 将 inline_data parts 转为 OpenAI 兼容格式（audio → input_audio, video → data URL）
+    effective_messages = _convert_inline_data_for_openai(ctx.messages)
+    
     create_params = {
         "model": ctx.model,
-        "messages": ctx.messages,
+        "messages": effective_messages,
         "temperature": ctx.temperature,
         "stream": True,
         "stream_options": {"include_usage": True},
@@ -584,6 +623,53 @@ async def stream_azure(ctx: StreamContext, result: StreamResult) -> AsyncGenerat
 # ============================================================
 # Anthropic 兼容供应商 (anthropic, minimax)
 # ============================================================
+
+
+def _convert_messages_for_anthropic(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """将 OpenAI 格式的多模态消息转换为 Anthropic 原生格式。
+
+    - image_url (data URL) → {"type": "image", "source": {"type": "base64", ...}}
+    - inline_data (audio/video) → {"type": "document", "source": {"type": "base64", ...}}
+    - text → 保持不变
+    """
+    converted = []
+    for msg in messages:
+        content = msg.get("content")
+        if not isinstance(content, list):
+            converted.append(msg)
+            continue
+        new_parts = []
+        for part in content:
+            if not isinstance(part, dict):
+                new_parts.append(part)
+                continue
+            ptype = part.get("type", "")
+            # 文本：保持原样
+            if ptype == "text":
+                new_parts.append(part)
+            # 图片：data URL → Anthropic image 格式
+            elif ptype == "image_url":
+                url = part.get("image_url", {}).get("url", "")
+                if url.startswith("data:"):
+                    parsed = url.split(",", 1)
+                    mime = parsed[0].replace("data:", "").split(";")[0] if len(parsed) == 2 else "image/png"
+                    b64_data = parsed[1] if len(parsed) == 2 else ""
+                    new_parts.append({"type": "image", "source": {"type": "base64", "media_type": mime, "data": b64_data}})
+                else:
+                    # URL 引用：保持原样（Anthropic 可能支持）
+                    new_parts.append(part)
+            # 视频/音频：inline_data → Anthropic document 格式
+            elif ptype == "inline_data":
+                inline = part.get("inline_data", {})
+                mime = inline.get("mime_type", "")
+                data = inline.get("data", "")
+                new_parts.append({"type": "document", "source": {"type": "base64", "media_type": mime, "data": data}})
+            else:
+                new_parts.append(part)
+        converted.append({**msg, "content": new_parts})
+    return converted
+
+
 @register_provider("anthropic", "minimax")
 async def stream_anthropic(ctx: StreamContext, result: StreamResult) -> AsyncGenerator[str, None]:
     """Anthropic/MiniMax 流式调用（支持 tool calling）"""
@@ -591,10 +677,13 @@ async def stream_anthropic(ctx: StreamContext, result: StreamResult) -> AsyncGen
 
     client = _get_anthropic_client(ctx.api_key, get_effective_base_url(ctx))
     
+    # 转换多模态消息为 Anthropic 原生格式
+    anthropic_messages = _convert_messages_for_anthropic(ctx.messages)
+    
     # 提取 system message
     system_content = ""
     chat_messages = []
-    for msg in ctx.messages:
+    for msg in anthropic_messages:
         if msg["role"] == "system":
             system_content = msg["content"]
         else:
@@ -765,22 +854,34 @@ def _content_part_to_gemini(part: dict):
     输入格式：
     - {"type": "text", "text": "..."} 
     - {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}}
+    - {"type": "inline_data", "inline_data": {"mime_type": "video/mp4", "data": "base64..."}}
     """
     from google.genai import types
+    import base64 as b64mod
     
     part_type = part.get("type", "")
     
     # 文本
     text = part.get("text")
-    return {"text": text} if part_type == "text" and text else (
-        # 图片 (data URL)
-        types.Part.from_bytes(data=img_data[1], mime_type=img_data[0])
-        if part_type == "image_url" 
-           and (img_url := part.get("image_url", {}).get("url", ""))
-           and img_url.startswith("data:")
-           and (img_data := _parse_data_url(img_url))[1]
-        else None
-    )
+    if part_type == "text" and text:
+        return {"text": text}
+    
+    # 图片 (data URL)
+    if (part_type == "image_url"
+        and (img_url := part.get("image_url", {}).get("url", ""))
+        and img_url.startswith("data:")
+        and (img_data := _parse_data_url(img_url))[1]):
+        return types.Part.from_bytes(data=img_data[1], mime_type=img_data[0])
+    
+    # 视频/音频/任意媒体 (inline_data)
+    if part_type == "inline_data":
+        inline = part.get("inline_data", {})
+        mime = inline.get("mime_type", "")
+        data_b64 = inline.get("data", "")
+        data_bytes = b64mod.b64decode(data_b64) if data_b64 else b""
+        return types.Part.from_bytes(data=data_bytes, mime_type=mime) if data_bytes else None
+    
+    return None
 
 
 def _format_gemini_messages(messages: list[dict]) -> tuple[list, str]:
@@ -1100,6 +1201,47 @@ async def stream_gemini(ctx: StreamContext, result: StreamResult) -> AsyncGenera
 # ============================================================
 # 统一入口
 # ============================================================
+# ---------------------------------------------------------------------------
+# 多模态降级：响应式检测 + 内存缓存
+# 当模型首次拒绝多模态内容（400 错误）时自动降级重试并缓存结果，
+# 后续请求直接跳过媒体注入，无需重复尝试。
+# ---------------------------------------------------------------------------
+_NON_VISION_MODELS: set[str] = set()  # 缓存: "provider_type:model" → 已知不支持多模态
+
+# 用于匹配 400 错误中多模态拒绝的关键词（任一匹配即视为模型不支持多模态）
+_MULTIMODAL_REJECT_KEYWORDS = (
+    "image_url", "image url", "unknown variant",
+    "unsupported content", "invalid content type",
+    "does not support image", "multimodal",
+    "expected text", "invalid_request_error",
+    "inline_data", "input_audio", "audio", "video",
+    "does not support", "media_type",
+)
+
+
+def _is_multimodal_rejection(error: Exception) -> bool:
+    """判断异常是否为模型拒绝多模态输入的 400 错误。"""
+    status = getattr(error, 'status_code', 0) or 0
+    error_msg = str(error).lower()
+    # 通过 status_code 属性或错误文本中的 "400" 判断 HTTP 状态
+    is_400 = (status == 400) or ("error code: 400" in error_msg)
+    return is_400 and any(kw in error_msg for kw in _MULTIMODAL_REJECT_KEYWORDS)
+
+
+def _has_multimodal_content(messages: List[Dict[str, Any]]) -> bool:
+    """快速检测消息列表中是否包含多模态 content parts（图像/视频/音频）。"""
+    _media_types = frozenset({"image_url", "inline_data", "input_audio"})
+    return any(
+        isinstance(msg.get("content"), list)
+        and any(p.get("type") in _media_types for p in msg["content"] if isinstance(p, dict))
+        for msg in messages
+    )
+
+
+# 向后兼容别名
+_has_image_content = _has_multimodal_content
+
+
 async def stream_completion(
     provider_type: str,
     api_key: str,
@@ -1120,12 +1262,21 @@ async def stream_completion(
     Yields:
         tuple[str, StreamResult]: (chunk, result) - 每次 yield chunk 文本，最后一次包含完整 result
     """
+    # 多模态降级（缓存命中）：已知不支持多模态的模型直接跳过媒体注入
+    cache_key = f"{provider_type.lower()}:{model}"
+    effective_messages = messages
+    contains_media = _has_multimodal_content(messages)
+    if contains_media and cache_key in _NON_VISION_MODELS:
+        from services.chat_utils import strip_multimodal_parts
+        effective_messages = strip_multimodal_parts(messages)
+        logger.info(f"[Multimodal cache hit] Pre-stripped media for: {cache_key}")
+
     ctx = StreamContext(
         provider_type=provider_type.lower(),
         api_key=api_key,
         base_url=base_url,
         model=model,
-        messages=messages,
+        messages=effective_messages,
         temperature=temperature,
         context_window=context_window,
         thinking_mode=thinking_mode,
@@ -1162,6 +1313,40 @@ async def stream_completion(
         # When handler produced tool_calls but no text, yield sentinel so caller sees result
         (not yielded and result.tool_calls) and (yield ("", result))  # type: ignore[func-returns-value]
     except Exception as e:
+        # ----------------------------------------------------------------
+        # 多模态自动降级重试：检测到多模态拒绝 400 → 剥离媒体 → 重新请求
+        # ----------------------------------------------------------------
+        if _is_multimodal_rejection(e) and contains_media and cache_key not in _NON_VISION_MODELS:
+            _NON_VISION_MODELS.add(cache_key)
+            logger.info(f"[Multimodal fallback] Model rejected multimodal, retrying without media: {cache_key}")
+            from services.chat_utils import strip_multimodal_parts
+            stripped_msgs = strip_multimodal_parts(messages)
+            ctx_retry = StreamContext(
+                provider_type=ctx.provider_type,
+                api_key=ctx.api_key,
+                base_url=ctx.base_url,
+                model=ctx.model,
+                messages=stripped_msgs,
+                temperature=ctx.temperature,
+                context_window=ctx.context_window,
+                thinking_mode=ctx.thinking_mode,
+                gemini_config=ctx.gemini_config,
+                xai_image_config=ctx.xai_image_config,
+                tools=ctx.tools,
+                user_id=ctx.user_id,
+            )
+            result_retry = StreamResult()
+            try:
+                async with guarded(f"llm:{ctx.provider_type}"):
+                    async for chunk in handler(ctx_retry, result_retry):
+                        yield chunk, result_retry
+            except Exception as retry_err:
+                logger.error(f"Multimodal fallback retry also failed: {retry_err}")
+                result_retry.full_response = f"Error: {retry_err}"
+                yield result_retry.full_response, result_retry
+            return
+
+        # 原始错误处理
         error_str = str(e)
         logger.error(f"LLM stream error: {error_str}")
         

--- a/frontend/src/components/ai-assistant/ChatMessage.tsx
+++ b/frontend/src/components/ai-assistant/ChatMessage.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { motion } from 'framer-motion';
+import { Music, Film, Image as ImageIcon, ScrollText, Play, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { TypewriterText } from './TypewriterText';
 import { CallTimelinePanel } from './CallTimelinePanel';
@@ -17,6 +18,8 @@ import { VideoTaskCard } from './VideoTaskCard';
 import { MusicTaskCard } from './MusicTaskCard';
 import { WelcomeMessage } from './WelcomeMessage';
 import { CompactionNotice } from './CompactionNotice';
+import { AudioDisplay } from '@/components/canvas/AudioNode/AudioDisplay';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import type { Message, NodeAttachment, HarnessEvent } from '@/store/useAIAssistantStore';
 
 // ---------------------------------------------------------------------------
@@ -346,40 +349,163 @@ function StreamingIndicator() {
 }
 
 function UserAttachmentPreview({ attachments }: { attachments: NodeAttachment[] }) {
+  const [previewAttachment, setPreviewAttachment] = useState<NodeAttachment | null>(null);
+
   if (!attachments?.length) return null;
 
+  // 类型图标映射表
+  const TYPE_ICONS: Record<string, React.ElementType> = {
+    image: ImageIcon,
+    video: Film,
+    audio: Music,
+    text: ScrollText,
+    storyboard: ScrollText,
+  };
+
   return (
-    <div className="flex flex-wrap gap-2 mb-2">
-      {attachments.map(a => {
-        const isMedia = a.nodeType === 'image' || a.nodeType === 'video';
-        
-        if (isMedia && a.thumbnailUrl) {
+    <>
+      <div className="flex flex-wrap gap-2 mb-2">
+        {attachments.map(a => {
+          const Icon = TYPE_ICONS[a.nodeType] ?? ScrollText;
+
+          // 图片附件：缩略图 + 左上图标 + 底部名称
+          if (a.nodeType === 'image' && a.thumbnailUrl) {
+            return (
+              <div
+                key={a.nodeId}
+                className="relative size-[88px] rounded-lg overflow-hidden flex-shrink-0 cursor-pointer hover:ring-2 hover:ring-primary/50 transition-all border border-border shadow-sm"
+                title={a.label}
+                onClick={() => setPreviewAttachment(a)}
+              >
+                <img src={a.thumbnailUrl} alt={a.label} className="w-full h-full object-cover" />
+                <div className="absolute top-1.5 left-1.5 p-1 rounded-md bg-black/40 backdrop-blur-sm">
+                  <Icon className="w-3 h-3 text-white" />
+                </div>
+                <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent p-1.5">
+                  <p className="text-[10px] text-white truncate">{a.label}</p>
+                </div>
+              </div>
+            );
+          }
+
+          // 视频附件：视频帧 + 居中播放按钮 + 左上图标 + 底部名称
+          if (a.nodeType === 'video' && a.thumbnailUrl) {
+            return (
+              <div
+                key={a.nodeId}
+                className="relative size-[88px] rounded-lg overflow-hidden flex-shrink-0 cursor-pointer hover:ring-2 hover:ring-primary/50 transition-all bg-black/80"
+                title={a.label}
+                onClick={() => setPreviewAttachment(a)}
+              >
+                <video
+                  src={`${a.thumbnailUrl}#t=0.5`}
+                  preload="metadata"
+                  muted
+                  playsInline
+                  className="w-full h-full object-cover opacity-60"
+                />
+                <div className="absolute inset-0 flex items-center justify-center">
+                  <div className="w-6 h-6 rounded-full bg-black/50 backdrop-blur flex items-center justify-center">
+                    <Play className="w-3 h-3 text-white ml-0.5" fill="white" />
+                  </div>
+                </div>
+                <div className="absolute top-1.5 left-1.5 p-1 rounded-md bg-black/40 backdrop-blur-sm">
+                  <Icon className="w-3 h-3 text-white" />
+                </div>
+                <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent p-1.5">
+                  <p className="text-[10px] text-white truncate">{a.label}</p>
+                </div>
+              </div>
+            );
+          }
+
+          // 音频附件：居中播放图标 + 左上图标 + 底部名称
+          if (a.nodeType === 'audio' && a.thumbnailUrl) {
+            return (
+              <div
+                key={a.nodeId}
+                className="relative size-[88px] rounded-lg overflow-hidden flex-shrink-0 cursor-pointer hover:ring-2 hover:ring-primary/50 transition-all bg-secondary/50 flex items-center justify-center"
+                title={a.label}
+                onClick={() => setPreviewAttachment(a)}
+              >
+                <div className="w-8 h-8 rounded-full bg-foreground/10 flex items-center justify-center">
+                  <Play className="w-4 h-4 text-foreground ml-0.5" fill="currentColor" />
+                </div>
+                <div className="absolute top-1.5 left-1.5 p-1 rounded-md bg-black/40 backdrop-blur-sm">
+                  <Icon className="w-3 h-3 text-white" />
+                </div>
+                <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-background/80 to-transparent p-1.5">
+                  <p className="text-[10px] text-foreground truncate">{a.label}</p>
+                </div>
+              </div>
+            );
+          }
+
+          // 其他类型（文本/分镜）：摘要 + 左上图标 + 底部名称
           return (
-            <div 
-              key={a.nodeId} 
-              className="relative w-24 h-24 rounded-md overflow-hidden flex-shrink-0"
+            <div
+              key={a.nodeId}
+              className="relative size-[88px] rounded-lg overflow-hidden flex-shrink-0 bg-muted p-2 pt-7"
               title={a.label}
             >
-              {a.nodeType === 'video' ? (
-                <video src={a.thumbnailUrl} className="w-full h-full object-cover" muted playsInline preload="metadata" />
-              ) : (
-                <img src={a.thumbnailUrl} alt={a.label} className="w-full h-full object-cover" />
+              {a.excerpt && (
+                <p className="text-[7px] text-muted-foreground whitespace-pre-wrap break-words leading-tight line-clamp-4">
+                  {a.excerpt}
+                </p>
               )}
+              <div className="absolute top-1.5 left-1.5 p-1 rounded-md bg-black/40 backdrop-blur-sm">
+                <Icon className="w-3 h-3 text-white" />
+              </div>
+              <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-background/80 to-transparent p-1.5">
+                <p className="text-[10px] text-foreground truncate">{a.label}</p>
+              </div>
             </div>
           );
-        }
-        
-        return (
-          <div 
-            key={a.nodeId} 
-            className="flex items-center gap-1.5 px-2.5 py-1.5 bg-[var(--color-bg-primary)]/20 rounded-md text-xs border border-[var(--color-bg-primary)]/30 max-w-full overflow-hidden"
-            title={a.label}
+        })}
+      </div>
+
+      {/* 音视频全屏预览弹窗 */}
+      <Dialog open={!!previewAttachment} onOpenChange={(open) => { open || setPreviewAttachment(null); }}>
+        <DialogContent
+          className="max-w-[90vw] w-auto p-0 bg-black/95 border-none shadow-2xl [&>button]:hidden flex items-center justify-center"
+          onClick={() => setPreviewAttachment(null)}
+        >
+          <DialogTitle className="sr-only">{previewAttachment?.label || 'Preview'}</DialogTitle>
+          <button
+            className="absolute top-3 right-3 z-50 p-1.5 rounded-full bg-white/10 hover:bg-white/20 text-white transition-colors"
+            onClick={() => setPreviewAttachment(null)}
           >
-            <span className="truncate opacity-90 font-medium">{a.label}</span>
+            <X className="w-4 h-4" />
+          </button>
+          <div className="p-6" onClick={(e) => e.stopPropagation()}>
+            {previewAttachment?.nodeType === 'video' && previewAttachment.thumbnailUrl && (
+              <video
+                src={previewAttachment.thumbnailUrl}
+                controls
+                autoPlay
+                className="max-w-[80vw] max-h-[75vh] rounded-lg"
+              />
+            )}
+            {previewAttachment?.nodeType === 'audio' && previewAttachment.thumbnailUrl && (
+              <div className="w-[400px] h-[320px] rounded-xl overflow-hidden bg-black">
+                <AudioDisplay
+                  audioUrl={previewAttachment.thumbnailUrl}
+                  lyrics={(previewAttachment.meta as { lyrics?: string })?.lyrics}
+                  selected={true}
+                />
+              </div>
+            )}
+            {previewAttachment?.nodeType === 'image' && previewAttachment.thumbnailUrl && (
+              <img
+                src={previewAttachment.thumbnailUrl}
+                alt={previewAttachment.label}
+                className="max-w-[80vw] max-h-[75vh] object-contain rounded-lg"
+              />
+            )}
           </div>
-        );
-      })}
-    </div>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }
 

--- a/frontend/src/components/ai-assistant/NodePreviewCard.tsx
+++ b/frontend/src/components/ai-assistant/NodePreviewCard.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { ScrollText, Image as ImageIcon, Film, Clapperboard, X, Loader2 } from 'lucide-react';
+import { ScrollText, Image as ImageIcon, Film, Music, Clapperboard, X, Loader2, Play, Pause } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import type { NodeAttachment } from '@/store/useAIAssistantStore';
@@ -17,10 +17,11 @@ const NODE_PREVIEW_CONFIG: Record<string, {
   text:       { icon: ScrollText,   color: 'text-node-blue',   bg: 'bg-node-blue/10' },
   image:      { icon: ImageIcon,    color: 'text-node-green',  bg: 'bg-node-green/10' },
   video:      { icon: Film,         color: 'text-node-yellow', bg: 'bg-node-yellow/10' },
+  audio:      { icon: Music,        color: 'text-node-blue',   bg: 'bg-node-blue/10' },
   storyboard: { icon: Clapperboard, color: 'text-node-purple', bg: 'bg-node-purple/10' },
 };
 
-// 默认配置（兜底）
+// 默认配置（兆底）
 const DEFAULT_CONFIG = { icon: ScrollText, color: 'text-muted-foreground', bg: 'bg-muted/10' };
 
 interface NodePreviewCardProps {
@@ -30,11 +31,13 @@ interface NodePreviewCardProps {
 
 /**
  * 媒体节点预览卡（图片/视频）- 100x100 统一卡片
+ * 左上角显示类型图标，底部显示节点名称
  */
 function MediaNodeCard({ attachment, onClear }: NodePreviewCardProps) {
   const isUploading = !!attachment.meta?.uploading;
   const isVideo = attachment.nodeType === 'video';
   const config = NODE_PREVIEW_CONFIG[attachment.nodeType] ?? DEFAULT_CONFIG;
+  const Icon = config.icon;
 
   return (
     <motion.div
@@ -54,8 +57,8 @@ function MediaNodeCard({ attachment, onClear }: NodePreviewCardProps) {
               muted
             />
             <div className="absolute inset-0 flex items-center justify-center bg-black/20">
-              <div className="w-5 h-5 rounded-full bg-black/50 backdrop-blur flex items-center justify-center">
-                <div className="w-0 h-0 border-t-[4px] border-t-transparent border-l-[6px] border-l-white border-b-[4px] border-b-transparent ml-0.5" />
+              <div className="w-6 h-6 rounded-full bg-black/50 backdrop-blur flex items-center justify-center">
+                <Play className="w-3 h-3 text-white ml-0.5" fill="white" />
               </div>
             </div>
           </div>
@@ -66,12 +69,13 @@ function MediaNodeCard({ attachment, onClear }: NodePreviewCardProps) {
             className="w-full h-full object-cover"
           />
         )}
-        {/* 底部标签 */}
-        <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-background/80 to-transparent p-1.5 flex items-center gap-1">
-          <span className={cn('text-[9px]', config.color)}>
-            {config.icon === ImageIcon ? '图片' : '视频'}
-          </span>
-          <p className="text-[10px] text-foreground truncate flex-1">{attachment.label}</p>
+        {/* 左上角类型图标 */}
+        <div className={cn('absolute top-1.5 left-1.5 p-1 rounded-md bg-black/40 backdrop-blur-sm')}>
+          <Icon className="w-3 h-3 text-white" />
+        </div>
+        {/* 底部节点名称 */}
+        <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent p-1.5">
+          <p className="text-[10px] text-white truncate">{attachment.label}</p>
         </div>
       </div>
 
@@ -96,7 +100,77 @@ function MediaNodeCard({ attachment, onClear }: NodePreviewCardProps) {
 }
 
 /**
+ * 音频节点预览卡 - 100x100，点击播放/暂停，无进度条
+ * 左上角显示 Music 图标，中间大播放按钮，底部节点名称
+ */
+function AudioNodeCard({ attachment, onClear }: NodePreviewCardProps) {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  const togglePlay = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    const audio = audioRef.current;
+    if (!audio) return;
+    audio.paused ? audio.play() : audio.pause();
+  }, []);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, scale: 0.9 }}
+      animate={{ opacity: 1, scale: 1 }}
+      exit={{ opacity: 0, scale: 0.9 }}
+      transition={{ duration: 0.15 }}
+      className="relative group shrink-0"
+    >
+      <div className="size-[100px] rounded-lg overflow-hidden bg-secondary/50 border border-border shadow-sm flex flex-col items-center justify-center">
+        {attachment.thumbnailUrl && (
+          <audio
+            ref={audioRef}
+            src={attachment.thumbnailUrl}
+            preload="metadata"
+            onPlay={() => setIsPlaying(true)}
+            onPause={() => setIsPlaying(false)}
+            onEnded={() => setIsPlaying(false)}
+          />
+        )}
+        {/* 中间播放/暂停按钮 */}
+        <button
+          onClick={togglePlay}
+          className="w-10 h-10 rounded-full bg-foreground/10 hover:bg-foreground/20 flex items-center justify-center transition-colors"
+        >
+          {isPlaying ? (
+            <Pause className="w-5 h-5 text-foreground" fill="currentColor" />
+          ) : (
+            <Play className="w-5 h-5 text-foreground ml-0.5" fill="currentColor" />
+          )}
+        </button>
+        {/* 左上角类型图标 */}
+        <div className="absolute top-1.5 left-1.5 p-1 rounded-md bg-black/40 backdrop-blur-sm">
+          <Music className="w-3 h-3 text-white" />
+        </div>
+        {/* 底部节点名称 */}
+        <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-background/80 to-transparent p-1.5">
+          <p className="text-[10px] text-foreground truncate">{attachment.label}</p>
+        </div>
+      </div>
+
+      {/* 关闭按钮 */}
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="absolute -top-1 -right-1 h-5 w-5 rounded-full bg-background border border-border/50 shadow-sm opacity-0 group-hover:opacity-100 transition-opacity hover:bg-destructive hover:text-destructive-foreground z-10"
+        onClick={onClear}
+      >
+        <X className="h-3 w-3" />
+      </Button>
+    </motion.div>
+  );
+}
+
+/**
  * 文本/分镜等无缩略图节点预览卡 - 100x100 统一卡片
+ * 左上角类型图标，中间摘要文本，底部节点名称
  */
 function InfoNodeCard({ attachment, onClear }: NodePreviewCardProps) {
   const config = NODE_PREVIEW_CONFIG[attachment.nodeType] ?? DEFAULT_CONFIG;
@@ -111,26 +185,23 @@ function InfoNodeCard({ attachment, onClear }: NodePreviewCardProps) {
       transition={{ duration: 0.15 }}
       className="relative group shrink-0"
     >
-      <div className="size-[100px] rounded-lg overflow-hidden bg-muted border border-border shadow-sm p-2.5 flex flex-col">
-        {/* 顶部：图标 */}
-        <div className={cn('p-1.5 rounded-md shrink-0 w-fit', config.bg)}>
-          <Icon className={cn('w-3.5 h-3.5', config.color)} />
-        </div>
-
+      <div className="size-[100px] rounded-lg overflow-hidden bg-muted border border-border shadow-sm p-2.5 pt-8 flex flex-col">
         {/* 中间：摘要文本 */}
-        <div className="flex-1 min-w-0 overflow-hidden mt-1.5">
+        <div className="flex-1 min-w-0 overflow-hidden">
           {attachment.excerpt && (
-            <p className="text-[7px] text-muted-foreground whitespace-pre-wrap break-words leading-tight line-clamp-3">
+            <p className="text-[7px] text-muted-foreground whitespace-pre-wrap break-words leading-tight line-clamp-4">
               {attachment.excerpt}
             </p>
           )}
         </div>
-
-        {/* 底部渐变 + 标签 */}
-        <div className="absolute inset-0 bg-gradient-to-t from-background/90 via-transparent to-transparent pointer-events-none" />
-        <span className="absolute bottom-1.5 left-1.5 text-[9px] text-foreground bg-muted/90 border border-border/50 px-1.5 py-0.5 rounded truncate max-w-[85px]">
-          {attachment.label}
-        </span>
+        {/* 左上角类型图标 */}
+        <div className="absolute top-1.5 left-1.5 p-1 rounded-md bg-black/40 backdrop-blur-sm">
+          <Icon className="w-3 h-3 text-white" />
+        </div>
+        {/* 底部节点名称 */}
+        <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-background/80 to-transparent p-1.5">
+          <p className="text-[10px] text-foreground truncate">{attachment.label}</p>
+        </div>
       </div>
 
       {/* 关闭按钮 */}
@@ -187,9 +258,12 @@ export function NodePreviewList({ attachments, onRemove, onClearAll }: NodePrevi
  * 统一节点预览卡片 - 根据类型自动选择渲染方式
  */
 export function NodePreviewCard({ attachment, onClear }: NodePreviewCardProps) {
-  const isMedia = attachment.nodeType === 'image' || attachment.nodeType === 'video';
+  const isVisualMedia = attachment.nodeType === 'image' || attachment.nodeType === 'video';
+  const isAudio = attachment.nodeType === 'audio';
 
-  return isMedia
+  return isVisualMedia
     ? <MediaNodeCard attachment={attachment} onClear={onClear} />
-    : <InfoNodeCard attachment={attachment} onClear={onClear} />;
+    : isAudio
+      ? <AudioNodeCard attachment={attachment} onClear={onClear} />
+      : <InfoNodeCard attachment={attachment} onClear={onClear} />;
 }

--- a/frontend/src/components/canvas/AIAssistantPanel.tsx
+++ b/frontend/src/components/canvas/AIAssistantPanel.tsx
@@ -63,6 +63,7 @@ const ATTACHMENT_CONTEXT_BUILDERS: Record<string, (a: NodeAttachment) => string>
   },
   image: (a) => `[引用图像卡「${a.label}」]\n图像描述：${a.excerpt || '无描述'}`,
   video: (a) => `[引用视频卡「${a.label}」]\n视频描述：${a.excerpt || '无描述'}`,
+  audio: (a) => `[引用音频卡「${a.label}」]\n音频描述：${a.excerpt || '无描述'}`,
   storyboard: (a) => {
     const meta = a.meta as { tableColumns?: { key: string; label?: string }[]; tableData?: Record<string, unknown>[] } | undefined;
     const columns = meta?.tableColumns;

--- a/frontend/src/components/canvas/AudioNode/AudioDisplay.tsx
+++ b/frontend/src/components/canvas/AudioNode/AudioDisplay.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Play, Pause, Volume2, VolumeX, Music2 } from 'lucide-react';
+import { Play, Pause, Volume2, VolumeX, Music2, Download } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 interface Props {
@@ -499,6 +499,22 @@ export function AudioDisplay({ audioUrl, lyrics, selected = false }: Props) {
         <span className="text-[9px] text-muted-foreground tabular-nums w-7">
           {formatTime(duration)}
         </span>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            const url = audioRef.current?.src || audioUrl;
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = url.split('/').pop() || 'audio.mp3';
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+          }}
+          className="p-1 rounded text-muted-foreground hover:text-foreground hover:bg-white/10 transition-colors"
+          title={t('canvas.node.audio.download', '下载')}
+        >
+          <Download className="w-3 h-3" />
+        </button>
         <button
           onClick={(e) => { e.stopPropagation(); setShowLyrics((v) => !v); }}
           className={`p-1 rounded hover:bg-white/10 transition-colors ${

--- a/frontend/src/lib/nodeAttachmentUtils.ts
+++ b/frontend/src/lib/nodeAttachmentUtils.ts
@@ -1,4 +1,4 @@
-import type { CanvasNode, ScriptNodeData, CharacterNodeData, VideoNodeData, StoryboardNodeData } from '@/store/useCanvasStore';
+import type { CanvasNode, ScriptNodeData, CharacterNodeData, VideoNodeData, StoryboardNodeData, AudioNodeData } from '@/store/useCanvasStore';
 import type { NodeAttachment } from '@/store/useAIAssistantStore';
 
 /** 文本节点发送给 AI 的最大纯文本字符数 */
@@ -75,6 +75,23 @@ const NODE_ATTACHMENT_EXTRACTORS: Record<string, (node: CanvasNode) => NodeAttac
       excerpt: data.description || '',
       thumbnailUrl,
       meta: { fitMode: data.fitMode, uploading: data.uploading },
+      updatedAt: readUpdatedAt(node),
+    };
+  },
+  audio: (node) => {
+    const data = node.data as AudioNodeData;
+    // 将 audioUrl 转换为完整的 /api/media/ 路径
+    let thumbnailUrl: string | null = data.audioUrl || null;
+    if (thumbnailUrl && !thumbnailUrl.startsWith('http') && !thumbnailUrl.startsWith('/api/media/') && !thumbnailUrl.startsWith('data:')) {
+      thumbnailUrl = `/api/media/${thumbnailUrl}`;
+    }
+    return {
+      nodeId: node.id,
+      nodeType: 'audio',
+      label: data.name || '未命名音频',
+      excerpt: data.description || '',
+      thumbnailUrl,
+      meta: { lyrics: data.lyrics },
       updatedAt: readUpdatedAt(node),
     };
   },


### PR DESCRIPTION
- 后端新增媒体附件注入函数支持视频/音频inline_data格式
- 增加多模态内容剥离函数供模型不支持多模态时降级使用
- llm_stream模块转换多模态消息格式兼容OpenAI和Anthropic供应商
- 异常处理时自动检测多模态拒绝，触发剥离多模态内容重试
- 前端聊天消息组件新增音视频附件缩略图展示及弹窗预览功能
- NodePreviewCard新增音频节点预览卡支持播放暂停控制
- AIAssistantPanel扩展音频节点的文本引用格式
- 新增AudioDisplay组件用以音频播放控制与交互界面展示