### PR TITLE
feat(tool_manager): 支持工具组动态激活和技能卸载以优化上下文管理

### DIFF
--- a/backend/services/chat_generation.py
+++ b/backend/services/chat_generation.py
@@ -20,7 +20,8 @@ from services.chat_tool_dispatch import append_tool_round, append_tool_round_wit
 from services.agent_executor import _extract_tool_results
 from services.llm_stream import stream_completion
 from services.tool_manager import ToolManager, ToolContext, CANVAS_TOOL_NAMES, IMAGE_GEN_TOOL_NAME
-from services.tool_manager.context import TOOL_SKILL_GATE_MAP
+from services.tool_manager.context import TOOL_SKILL_GATE_MAP, TOOL_GROUPS, PROVIDER_GROUP_MAP
+from services.tool_manager.reset_tools import build_reset_tools_def
 from services.skill_tools import build_skill_prompt, build_load_skill_tool_def, load_skill_content
 from services.billing import calculate_credit_cost, deduct_credits_atomic, InsufficientCreditsError, BalanceFrozenError, require_positive_balance, is_paid_model, load_pricing
 from services.media_utils import MEDIA_DIR
@@ -54,6 +55,23 @@ def _extract_reasoning_to_msg(msg: dict) -> bool:
         content=_THINK_EXTRACT_RE.sub("", content).strip() or None,
     )
     return bool(match)
+
+
+def _is_group_potentially_available(group: str, agent: Any, theater_id: str | None) -> bool:
+    """Rough check whether a tool group is potentially relevant for the current agent.
+
+    Used to decide whether to expose the group in reset_tools schema.
+    Does NOT check global ToolConfig or skill-gate — just coarse eligibility.
+    """
+    _checks = {
+        "canvas": bool(theater_id and (agent.target_node_types or [])),
+        "image_gen": True,
+        "image_edit": True,
+        "video_gen": True,
+        "video_edit": True,
+        "music_gen": True,
+    }
+    return _checks.get(group, False)
 
 
 async def generate_single_agent(
@@ -168,23 +186,46 @@ async def generate_single_agent(
     agent_skills = agent.tools or []
 
     # 从聊天历史恢复已加载的技能（渐进式披露：跨轮次持久化）
-    # assistant 消息中的 skill_calls 字段记录了之前加载过的技能
+    # 取最后一条含 skill_calls 的助理消息作为权威状态（支持 unload 后的正确恢复）
     loaded_skills: set[str] = set()
-    for msg in history[skip_count:]:
+    for msg in reversed(history[skip_count:]):
         deserialized = (msg.role == "assistant") and deserialize_content(msg.content)
-        (isinstance(deserialized, dict) and deserialized.get("skill_calls")) and loaded_skills.update(
-            sc.get("skill_name", "") for sc in deserialized["skill_calls"]
-            if sc.get("status") == "loaded" and sc.get("skill_name")
-        )
+        if isinstance(deserialized, dict) and deserialized.get("skill_calls"):
+            loaded_skills.update(
+                sc.get("skill_name", "") for sc in deserialized["skill_calls"]
+                if sc.get("status") == "loaded" and sc.get("skill_name")
+            )
+            break
     # 同步到 ToolContext，使 is_skill_gated() 对已加载技能返回 False
     ctx.loaded_tool_skills.update(s for s in loaded_skills if s in TOOL_SKILL_GATE_MAP)
     loaded_skills and logger.info(f"Restored skills from history: {loaded_skills}")
+
+    # 从聊天历史恢复工具组覆盖状态（reset_tools 的最后一次调用）
+    for msg in reversed(history[skip_count:]):
+        deserialized = (msg.role == "assistant") and deserialize_content(msg.content)
+        if isinstance(deserialized, dict) and deserialized.get("tool_calls"):
+            for tc_hist in deserialized["tool_calls"]:
+                if tc_hist.get("name") == "reset_tools":
+                    _restored_args = tc_hist.get("arguments", {})
+                    isinstance(_restored_args, str) and (_restored_args := {})
+                    ctx.set_group_overrides(_restored_args)
+                    logger.info(f"Restored tool group overrides: {ctx._group_overrides}")
+                    break
+            if ctx._group_overrides:
+                break
 
     tool_defs = await tool_manager.build_tool_defs(ctx)
 
     # 技能系统（与工具同级，独立编排）
     remaining_skills = [s for s in agent_skills if s not in loaded_skills]
     agent_skills and (tool_defs := (tool_defs or []) + [build_load_skill_tool_def(agent_skills)])
+
+    # reset_tools 元工具注册（当有可用工具组时）
+    _available_groups = [
+        g for g in TOOL_GROUPS
+        if _is_group_potentially_available(g, agent, theater_id)
+    ]
+    _available_groups and (tool_defs := (tool_defs or []) + [build_reset_tools_def(_available_groups)])
 
     # 注入技能信息到 system prompt
     # 已恢复的技能：注入完整内容（补偿工具调用轮次未持久化导致的上下文丢失）
@@ -264,7 +305,6 @@ async def generate_single_agent(
     result = None
     generation_failed = False
     _SSE_START = {True: "skill_call", False: "tool_call"}
-    _SSE_END = {True: "skill_loaded", False: "tool_result"}
     _consecutive_tool_failures = 0   # Harness: 连续工具失败计数器
     _thinking_only_retried = False     # thinking-only 重试标记（防止无限循环）
     try:
@@ -434,49 +474,68 @@ async def generate_single_agent(
                 if tc.name == IMAGE_GEN_TOOL_NAME
             )
 
-            # 追踪已加载的技能 - 只从有效调用中追踪
-            tool_skill_loaded = False
+            # 追踪已加载/卸载的技能 - 只从有效调用中追踪
+            tool_skill_changed = False
             for tc, args in tool_calls_valid:
-                (tc.name == "load_skill") and loaded_skills.add(args.get("skill_name", ""))
-            # 检测本轮是否有工具Skill被加载（ctx.loaded_tool_skills 已在 _execute_skill 中更新）
-            tool_skill_loaded = any(
-                tc.name == "load_skill" and args.get("skill_name", "") in TOOL_SKILL_GATE_MAP
-                for tc, args in tool_calls_valid
-            )
+                if tc.name != "load_skill":
+                    continue
+                skill_name = args.get("skill_name", "")
+                action = args.get("action", "load")
+                # Unload: 从 loaded_skills 移除（ctx.loaded_tool_skills 已在 _execute_skill 中更新）
+                (action == "unload") and loaded_skills.discard(skill_name)
+                # Load: 添加到 loaded_skills
+                (action != "unload") and loaded_skills.add(skill_name)
+                # 检测是否是工具Skill变更（需触发完整重建）
+                (skill_name in TOOL_SKILL_GATE_MAP) and (tool_skill_changed := True)
+
+            # 检测 reset_tools 调用 → 需完整重建工具定义
+            _reset_tools_called = any(tc.name == "reset_tools" for tc, _ in tool_calls_valid)
 
             # 重建工具定义（技能 enum 自动缩减）
-            # 如果有工具Skill被加载，需完整异步重建以注入新解锁的工具定义
+            # 如果有工具Skill被加载/卸载或工具组重置，需完整异步重建
             remaining_skills = [s for s in agent_skills if s not in loaded_skills]
             managed_defs = (
                 await tool_manager.build_tool_defs(ctx)
-                if tool_skill_loaded
+                if (tool_skill_changed or _reset_tools_called)
                 else tool_manager.rebuild_after_round(ctx)
             )
-            tool_defs = (managed_defs or []) + ([build_load_skill_tool_def(agent_skills)] if agent_skills else [])
+            tool_defs = (managed_defs or [])
+            agent_skills and (tool_defs := tool_defs + [build_load_skill_tool_def(agent_skills)])
+            _available_groups and (tool_defs := tool_defs + [build_reset_tools_def(_available_groups)])
             tool_defs = tool_defs or None
 
             # 输出重建后的工具列表（仅在发生变化时）
-            tool_skill_loaded and logger.info(
-                f"  [Skill-gate] Rebuilt tools: {[d.get('function', {}).get('name', '?') for d in (tool_defs or [])]}"
+            (tool_skill_changed or _reset_tools_called) and logger.info(
+                f"  [ToolGroup] Rebuilt tools: {[d.get('function', {}).get('name', '?') for d in (tool_defs or [])]}"
             )
 
-            # 发送 tool 完成事件 (skill_loaded 或 tool_result)
+            # 发送 tool 完成事件 (skill_loaded / skill_unloaded / tool_result)
             for tc, args in tool_calls_valid:
                 is_skill = tc.name == "load_skill"
                 is_canvas = tc.name in CANVAS_TOOL_NAMES
                 tool_result_str = _tool_results_map.get(tc.id, "")
+                skill_action = args.get("action", "load") if is_skill else None
                 event_data = (
-                    {"skill_name": args.get("skill_name", "")}
+                    {"skill_name": args.get("skill_name", ""), "action": skill_action}
                     if is_skill else
                     {"tool_name": tc.name, "success": True, "result": tool_result_str}
                 )
-                yield sse(_SSE_END[is_skill], event_data)
+                skill_event = "skill_unloaded" if skill_action == "unload" else "skill_loaded"
+                yield sse(skill_event if is_skill else "tool_result", event_data)
                 
                 # Canvas / edit_image 工具执行后发送画布更新事件，通知前端刷新
                 (is_canvas or tc.name == "edit_image") and theater_id and (
                     yield sse("canvas_updated", {"theater_id": theater_id, "action": tc.name})
                 )
             
+            # 发送 reset_tools 事件通知前端
+            _reset_tools_called and (
+                yield sse("tools_reset", {
+                    "active_groups": [g for g, v in ctx._group_overrides.items() if v],
+                    "deactivated_groups": [g for g, v in ctx._group_overrides.items() if not v],
+                })
+            )
+
             # 发送错误调用的完成事件
             for tc, _ in tool_calls_with_error:
                 yield sse("tool_result", {"tool_name": tc.name, "success": False, "error": "JSON parse failed"})

--- a/backend/services/chat_generation.py
+++ b/backend/services/chat_generation.py
@@ -20,7 +20,7 @@ from services.chat_tool_dispatch import append_tool_round, append_tool_round_wit
 from services.agent_executor import _extract_tool_results
 from services.llm_stream import stream_completion
 from services.tool_manager import ToolManager, ToolContext, CANVAS_TOOL_NAMES, IMAGE_GEN_TOOL_NAME
-from services.tool_manager.context import TOOL_SKILL_GATE_MAP, TOOL_GROUPS, PROVIDER_GROUP_MAP
+from services.tool_manager.context import TOOL_SKILL_GATE_MAP, TOOL_GROUPS
 from services.tool_manager.reset_tools import build_reset_tools_def
 from services.skill_tools import build_skill_prompt, build_load_skill_tool_def, load_skill_content
 from services.billing import calculate_credit_cost, deduct_credits_atomic, InsufficientCreditsError, BalanceFrozenError, require_positive_balance, is_paid_model, load_pricing

--- a/backend/services/chat_tool_dispatch.py
+++ b/backend/services/chat_tool_dispatch.py
@@ -35,11 +35,14 @@ async def get_tool_result(
     status = "success"
     try:
         # Skill dispatch (peer-level, NOT a managed provider)
-        result = (
-            _execute_skill(tc_args, ctx)
-            if tc_name == "load_skill"
-            else await tool_manager.execute_tool(tc_name, tc_args, ctx)
-        )
+        # reset_tools dispatch (peer-level meta-tool, AgentScope-style group management)
+        if tc_name == "load_skill":
+            result = _execute_skill(tc_args, ctx)
+        elif tc_name == "reset_tools":
+            from services.tool_manager.reset_tools import execute_reset_tools
+            result = execute_reset_tools(tc_args, ctx)
+        else:
+            result = await tool_manager.execute_tool(tc_name, tc_args, ctx)
     except Exception as exc:
         result = f"Error: {exc}"
         status = "error"
@@ -53,7 +56,22 @@ def _execute_skill(tc_args: dict, ctx: "ToolContext") -> str:
     from services.tool_manager.context import TOOL_SKILL_GATE_MAP
     # 清理 skill_name：去除空白字符和引号
     skill_name = tc_args.get("skill_name", "").strip().strip("'\"'")
+    action = tc_args.get("action", "load").strip().lower()
     file_path = tc_args.get("file_path") or None
+
+    # --- Unload path: remove skill from loaded set, gated tools will be hidden on rebuild ---
+    is_unload = action == "unload"
+    if is_unload:
+        ctx.loaded_tool_skills.discard(skill_name)
+        gated_tools = TOOL_SKILL_GATE_MAP.get(skill_name, frozenset())
+        tool_list = ", ".join(sorted(gated_tools)) or "none"
+        return (
+            f"Skill '{skill_name}' unloaded. "
+            f"The following tools have been deactivated: [{tool_list}]. "
+            f"Call load_skill again if you need them later."
+        )
+
+    # --- Load path (default) ---
     # 追踪工具Skill加载（用于 skill-gated 工具动态注入，仅在加载主文档时触发）
     (not file_path and skill_name in TOOL_SKILL_GATE_MAP) and ctx.loaded_tool_skills.add(skill_name)
     return load_skill_content(skill_name, ctx.active_skills_dir, file_path)

--- a/backend/services/skill_tools.py
+++ b/backend/services/skill_tools.py
@@ -28,6 +28,8 @@ _SKILL_INDEX_HEADER = (
     "Each skill is a tutorial that teaches you how to perform specific tasks.\n"
     "You MUST call `load_skill` BEFORE attempting any skill-related task — "
     "do NOT tell the user you cannot do it; load the skill first and follow its instructions.\n"
+    "When a skill is no longer needed for the current task, call `load_skill` with "
+    "`action: \"unload\"` to release it and reduce context noise.\n"
 )
 
 _SKILL_INDEX_ITEM = "- **{name}**: {description}"
@@ -178,6 +180,8 @@ def build_load_skill_tool_def(skill_names: list[str]) -> dict:
     """Build the OpenAI-format tool definition for the load_skill meta-tool.
 
     Unified tool: loads SKILL.md by default, or any file when file_path is given.
+    Supports action="unload" to release a previously loaded skill and remove its
+    gated tools from the active schema — reducing context noise in long sessions.
     The enum covers ALL configured skills (not just remaining ones).
     """
     clean_skill_names = [name.strip() for name in skill_names]
@@ -186,10 +190,12 @@ def build_load_skill_tool_def(skill_names: list[str]) -> dict:
         "function": {
             "name": "load_skill",
             "description": (
-                "Load a skill or read any file within a skill directory. "
-                "Without file_path: loads the skill tutorial (SKILL.md) and lists available files. "
-                "With file_path: loads the specified file's full content. "
-                "You MUST call this (without file_path) before performing any skill-related task."
+                "Load or unload a skill. "
+                "action=\"load\" (default): loads the skill tutorial (SKILL.md) and lists available files. "
+                "action=\"unload\": releases a previously loaded skill and removes its associated tools. "
+                "With file_path (load only): loads the specified file's full content. "
+                "You MUST call this (action=\"load\") before performing any skill-related task. "
+                "Call with action=\"unload\" when the skill is no longer needed to keep context focused."
             ),
             "parameters": {
                 "type": "object",
@@ -199,10 +205,20 @@ def build_load_skill_tool_def(skill_names: list[str]) -> dict:
                         "description": "The name of the skill.",
                         "enum": clean_skill_names,
                     },
+                    "action": {
+                        "type": "string",
+                        "description": (
+                            "Whether to load or unload the skill. "
+                            "Use \"unload\" to release a skill that is no longer needed."
+                        ),
+                        "enum": ["load", "unload"],
+                        "default": "load",
+                    },
                     "file_path": {
                         "type": "string",
                         "description": (
-                            "Optional. Relative path to a file within the skill directory. "
+                            "Optional. Only used with action=\"load\". "
+                            "Relative path to a file within the skill directory. "
                             "When omitted, loads the skill's main tutorial (SKILL.md). "
                             "When provided, loads that specific file. "
                             "Example: 'references/guide.md'"

--- a/backend/services/tool_manager/context.py
+++ b/backend/services/tool_manager/context.py
@@ -33,6 +33,56 @@ TOOL_SKILL_GATE_MAP: dict[str, frozenset[str]] = {
 }
 
 
+# ---------------------------------------------------------------------------
+# Tool groups: AgentScope-style dynamic tool group management
+# ---------------------------------------------------------------------------
+@dataclass
+class ToolGroupDef:
+    """Definition of a tool group that can be activated/deactivated at runtime."""
+    name: str
+    description: str
+    instructions: str = ""  # Returned to agent when group is activated
+
+
+TOOL_GROUPS: dict[str, ToolGroupDef] = {
+    "canvas": ToolGroupDef(
+        name="canvas",
+        description="Canvas node CRUD tools for creating and managing theater nodes.",
+        instructions="Always use list_canvas_nodes first to understand current state.",
+    ),
+    "image_gen": ToolGroupDef(
+        name="image_gen",
+        description="Generate images from text prompts.",
+    ),
+    "image_edit": ToolGroupDef(
+        name="image_edit",
+        description="Edit existing images (inpainting, style transfer).",
+    ),
+    "video_gen": ToolGroupDef(
+        name="video_gen",
+        description="Generate videos from text/image prompts.",
+    ),
+    "video_edit": ToolGroupDef(
+        name="video_edit",
+        description="Edit existing videos (extension, effects).",
+    ),
+    "music_gen": ToolGroupDef(
+        name="music_gen",
+        description="Generate music/audio from text prompts.",
+    ),
+}
+
+# Provider class name -> group name (for build_defs group-state lookup)
+PROVIDER_GROUP_MAP: dict[str, str] = {
+    "CanvasProvider": "canvas",
+    "ImageGenProvider": "image_gen",
+    "ImageEditProvider": "image_edit",
+    "VideoGenProvider": "video_gen",
+    "VideoEditProvider": "video_edit",
+    "MusicGenProvider": "music_gen",
+}
+
+
 @dataclass
 class ToolContext:
     """Immutable-ish context that travels with a single chat generation request."""
@@ -63,9 +113,27 @@ class ToolContext:
     # --- skill-gated tool tracking ---
     loaded_tool_skills: set = field(default_factory=set, repr=False)
 
+    # --- tool group overrides (AgentScope-style reset_tools) ---
+    _group_overrides: dict = field(default_factory=dict, repr=False)
+
     # --- transient event collectors ---
     video_tasks: list = field(default_factory=list, repr=False)
     music_tasks: list = field(default_factory=list, repr=False)
+
+    # ------------------------------------------------------------------
+    # Tool group helpers (AgentScope-style reset_tools)
+    # ------------------------------------------------------------------
+
+    def is_group_active(self, group_name: str | None) -> bool | None:
+        """Check group override state.
+
+        Returns None = use default logic, True = force active, False = force inactive.
+        """
+        return self._group_overrides.get(group_name) if group_name else None
+
+    def set_group_overrides(self, overrides: dict[str, bool]) -> None:
+        """Called by reset_tools execution. Replaces all overrides (final-state semantics)."""
+        self._group_overrides = {k: v for k, v in overrides.items() if k in TOOL_GROUPS}
 
     # ------------------------------------------------------------------
     # Skill-gate helpers

--- a/backend/services/tool_manager/manager.py
+++ b/backend/services/tool_manager/manager.py
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
     from services.tool_manager.context import ToolContext
     from services.tool_manager.protocol import ToolProvider
 
+from services.tool_manager.context import PROVIDER_GROUP_MAP
+
 logger = logging.getLogger(__name__)
 
 
@@ -42,10 +44,16 @@ class ToolManager:
     async def build_tool_defs(self, ctx: ToolContext) -> list[dict] | None:
         """Build all applicable tool definitions for the current context.
 
-        Returns ``None`` when no tools should be enabled.
+        Respects tool group overrides: providers whose group is force-inactive
+        are skipped entirely. Returns ``None`` when no tools should be enabled.
         """
         all_defs: list[dict] = []
         for provider in self._providers:
+            group_name = PROVIDER_GROUP_MAP.get(type(provider).__name__)
+            # Group force-inactive → skip this provider entirely
+            override = ctx.is_group_active(group_name)
+            if override is False:
+                continue
             all_defs.extend(await provider.build_defs(ctx))
 
         self._cached_defs = all_defs or None

--- a/backend/services/tool_manager/reset_tools.py
+++ b/backend/services/tool_manager/reset_tools.py
@@ -1,0 +1,74 @@
+"""
+reset_tools — AgentScope-style meta-tool for dynamic tool group management.
+
+Allows the agent to activate/deactivate tool groups at runtime, keeping only
+relevant tools in the LLM context window and reducing token waste.
+
+Design principles (aligned with AgentScope 2.0 ToolGroup):
+- Final-state semantics: each call declares the COMPLETE desired state
+- Groups not mentioned are DEACTIVATED (not incremental)
+- The "basic" group (load_skill + reset_tools) is always active
+- Coexists with skill-gate: reset_tools controls group visibility,
+  load_skill controls skill content loading
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from services.tool_manager.context import TOOL_GROUPS
+
+if TYPE_CHECKING:
+    from services.tool_manager.context import ToolContext
+
+
+def build_reset_tools_def(available_groups: list[str]) -> dict:
+    """Build OpenAI-format tool definition for the reset_tools meta-tool.
+
+    Only includes groups that are potentially available for the current agent/context.
+    """
+    properties = {
+        group: {
+            "type": "boolean",
+            "description": TOOL_GROUPS[group].description,
+        }
+        for group in available_groups
+        if group in TOOL_GROUPS
+    }
+    return {
+        "type": "function",
+        "function": {
+            "name": "reset_tools",
+            "description": (
+                "Activate or deactivate tool groups to manage context window usage. "
+                "Each parameter represents a tool group — set to true to activate, false to deactivate. "
+                "Groups NOT mentioned will be DEACTIVATED (final-state semantics). "
+                "Use this to keep only relevant tools active and reduce context noise. "
+                "The load_skill and reset_tools meta-tools are always available regardless of group state."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": properties,
+            },
+        },
+    }
+
+
+def execute_reset_tools(args: dict, ctx: "ToolContext") -> str:
+    """Execute reset_tools: set group overrides and return activation instructions.
+
+    Final-state semantics: groups not mentioned in args are deactivated.
+    """
+    overrides = {k: bool(v) for k, v in args.items() if k in TOOL_GROUPS}
+    # Final-state: unmentioned groups → False
+    full_overrides = {g: overrides.get(g, False) for g in TOOL_GROUPS}
+    ctx.set_group_overrides(full_overrides)
+
+    activated = [g for g, v in full_overrides.items() if v]
+    deactivated = [g for g, v in full_overrides.items() if not v]
+
+    parts = [f"Tool groups updated. Active: [{', '.join(activated or ['none'])}], Deactivated: [{', '.join(deactivated or ['none'])}]"]
+    # Append instructions for newly activated groups
+    for g in activated:
+        instr = TOOL_GROUPS[g].instructions
+        instr and parts.append(f"[{g}] {instr}")
+    return "\n".join(parts)


### PR DESCRIPTION
- 新增reset_tools元工具，实现工具组的激活与停用管理，减少上下文词汇浪费
- 支持load_skill工具通过action参数卸载技能，释放对应的门控工具
- 聊天历史恢复中增加工具组覆盖状态的还原，确保状态正确同步
- 动态构建工具定义时考虑工具组激活状态，跳过被停用的Provider
- 更新工具调用处理逻辑，支持reset_tools调用及技能卸载的状态同步
- load_skill工具描述及参数中新增action字段，明确加载或卸载行为
- 发送前端事件支持reset_tools状态变更，便于UI刷新工具组状态
- 维护和追踪已加载技能及工具组重置，触发工具定义的完整异步重建