### PR TITLE
fix(image-gen): 修复图像生成错误处理并调整ark尺寸配置

### DIFF
--- a/backend/services/ark_image_gen.py
+++ b/backend/services/ark_image_gen.py
@@ -133,17 +133,13 @@ async def generate_ark_sequential_images(
         f"size={config.size}, web_search={config.web_search}"
     )
 
-    try:
-        response = await client.images.generate(**generate_params)
-        urls: list[str] = []
-        for item in response.data:
-            url = await _save_result_item(item, config.response_format, user_id=user_id)
-            url and urls.append(url)
-        logger.info(f"Ark Seedream sequential: generated {len(urls)} images")
-        return urls
-    except Exception as e:
-        logger.error(f"Ark Seedream sequential error: {e}")
-        return []
+    response = await client.images.generate(**generate_params)
+    urls: list[str] = []
+    for item in response.data:
+        url = await _save_result_item(item, config.response_format, user_id=user_id)
+        url and urls.append(url)
+    logger.info(f"Ark Seedream sequential: generated {len(urls)} images")
+    return urls
 
 
 # ---------------------------------------------------------------------------

--- a/backend/services/image_config_adapter.py
+++ b/backend/services/image_config_adapter.py
@@ -13,7 +13,7 @@ _QUALITY_MAP: dict[str, dict[str, str]] = {
     # Gemini 官方 API 标准字面量为 1K/2K/4K，与 batch_image_gen.IMAGE_SIZE_MAP 一致
     "gemini": {"standard": "1K",   "hd": "2K", "ultra": "4K"},
     "xai":    {"standard": "1k",   "hd": "2k", "ultra": "2k"},
-    "ark":    {"standard": "1K",   "hd": "2K", "ultra": "4K"},
+    "ark":    {"standard": "2K",   "hd": "3K", "ultra": "4K"},
 }
 
 # ---------------------------------------------------------------------------
@@ -136,7 +136,7 @@ _GEMINI25_ASPECT_RATIOS:    list[str] = sorted(
 # ---------------------------------------------------------------------------
 _SEEDREAM_50_SIZES:  list[str] = ["2K", "3K", "4K"]
 _SEEDREAM_45_SIZES:  list[str] = ["2K", "4K"]
-_SEEDREAM_40_SIZES:  list[str] = ["1K", "2K", "4K"]
+_SEEDREAM_40_SIZES:  list[str] = ["2K", "4K"]
 
 # ---------------------------------------------------------------------------
 # Seedream aspect_ratio + 分辨率等级 → 精确像素尺寸映射表（来自官方文档）
@@ -308,7 +308,7 @@ def _adapt_to_ark(unified: dict) -> dict:
 
     # quality → size
     q = cfg.get("quality")
-    q and img.update(size=_QUALITY_MAP["ark"].get(q, "1K"))
+    q and img.update(size=_QUALITY_MAP["ark"].get(q, "2K"))
 
     # batch_count → n
     bc = cfg.get("batch_count")

--- a/backend/services/tool_manager/providers/image_gen.py
+++ b/backend/services/tool_manager/providers/image_gen.py
@@ -135,7 +135,7 @@ async def _generate_via_xai(
         n=1,
         response_format=img_cfg.get("response_format") or "b64_json",
     )
-    result = await batch_generate_xai_images(
+    batch_result = await batch_generate_xai_images(
         api_key=api_key,
         model=model,
         prompts=[prompt] * max(1, n),
@@ -143,7 +143,13 @@ async def _generate_via_xai(
         base_url=base_url,
         user_id=user_id,
     )
-    urls = [url for r in result.results for url in r.image_urls]
+    urls = [url for r in batch_result.results for url in r.image_urls]
+    # 全部失败：提取第一个非空错误信息抛出，让 Agent 看到真实原因
+    (not urls and batch_result.failed > 0) and (_ for _ in ()).throw(
+        RuntimeError(
+            next((r.error for r in batch_result.results if r.error), "Unknown xAI image generation error")
+        )
+    )
     # xai 不返回 token usage，统一结构返回零值
     return urls, {"input_tokens": 0, "output_tokens": 0}
 
@@ -159,18 +165,24 @@ async def _generate_via_gemini(
         output_format=img_cfg.get("output_format") or "png",
     )
     # Gemini generates 1 image per prompt call; duplicate prompt for n images
-    result = await batch_generate_images(
+    batch_result = await batch_generate_images(
         api_key=api_key,
         model=model,
         prompts=[prompt] * n,
         config=gemini_config,
         user_id=user_id,
     )
-    urls = [r.image_url for r in result.results if r.image_url]
+    urls = [r.image_url for r in batch_result.results if r.image_url]
+    # 全部失败：提取第一个非空错误信息抛出，让 Agent 看到真实原因
+    (not urls and batch_result.failed > 0) and (_ for _ in ()).throw(
+        RuntimeError(
+            next((r.error for r in batch_result.results if r.error), "Unknown Gemini image generation error")
+        )
+    )
     # 汇总所有 prompt 的 token 使用量（image_output 计在 output_tokens 中）
     usage = {
-        "input_tokens":  sum((r.input_tokens or 0) for r in result.results),
-        "output_tokens": sum((r.output_tokens or 0) for r in result.results),
+        "input_tokens":  sum((r.input_tokens or 0) for r in batch_result.results),
+        "output_tokens": sum((r.output_tokens or 0) for r in batch_result.results),
     }
     return urls, usage
 
@@ -201,6 +213,8 @@ async def _generate_via_ark(
     # n > 1 时使用组图模式（单次调用生成多张关联图），n=1 时走单张生成
     ref_urls = img_cfg.get("reference_images") or []  # 组图模式下的参考图
     urls: list[str] = []
+
+    # 组图模式：异常直接上抛，由 _run_generator 统一处理
     ark_config.sequential and (
         urls := await generate_ark_sequential_images(
             api_key=api_key,
@@ -212,16 +226,25 @@ async def _generate_via_ark(
             image_urls=ref_urls or None,
         )
     )
-    (not ark_config.sequential) and (
-        urls := [u for r in (await batch_generate_ark_images(
+
+    # 单张生成模式：检查 batch 结果，全部失败时抛出真实错误信息
+    if not ark_config.sequential:
+        batch_result = await batch_generate_ark_images(
             api_key=api_key,
             model=model,
             prompts=[prompt],
             config=ark_config,
             base_url=base_url,
             user_id=user_id,
-        )).results for u in r.image_urls]
-    )
+        )
+        urls = [u for r in batch_result.results for u in r.image_urls]
+        # 全部失败：提取第一个非空错误信息抛出，让 Agent 看到真实原因
+        (not urls and batch_result.failed > 0) and (_ for _ in ()).throw(
+            RuntimeError(
+                next((r.error for r in batch_result.results if r.error), "Unknown ark image generation error")
+            )
+        )
+
     # ark 不返回 token usage，统一结构返回零值
     return urls, {"input_tokens": 0, "output_tokens": 0}
 


### PR DESCRIPTION
- 移除Ark顺序生成图像的try-except，改为允许异常抛出以便统一处理
- 修改image_config_adapter中ark尺寸映射，调整standard由1K改为2K，hd由2K改为3K
- 在image_gen中统一使用batch_result变量名以避免混淆
- 为XAI、Gemini和Ark单张生成增加全部失败时抛出第一个非空错误的逻辑，提升错误透明度
- Ark顺序生成与非顺序生成分别采用不同异常处理策略，保证Agent能正确捕获错误
- 修正_QUALITY_MAP中ark对应质量映射由默认1K调整为2K，保证图像质量匹配配置